### PR TITLE
Wipe Block Update Changes

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -18,15 +18,11 @@ services:
     restart: always
     expose:
       - 27017
-    volumes:
-      - mongo_data:/data/db
 
   mongo-express:
     image: mongo-express:1.0.2-20
     expose:
       - 8081
-    ports:
-      - "8081:8081"
     environment:
       ME_CONFIG_MONGODB_SERVER: mongo
       ME_CONFIG_MONGODB_PORT: 27017
@@ -40,8 +36,6 @@ services:
     restart: always
     expose:
       - 6379
-    volumes:
-      - redis_data:/data
 
 #  seq:
 #    image: datalust/seq
@@ -334,8 +328,6 @@ volumes:
   grafana_data:
   ipfs_data:
   ipfs_export:
-  mongo_data:
-  redis_data:
 #  seq_data:
 
 networks:

--- a/docs/guardian/standard-registry/policies/policy-creation/introduction/token-wipe-workflow-block.md
+++ b/docs/guardian/standard-registry/policies/policy-creation/introduction/token-wipe-workflow-block.md
@@ -3,7 +3,7 @@
 ### Description
 This block allows to wipe tokens. 
 * **Fungible (FT):** Wipes the amount computed by **Rule**.
-* **Non-Fungible (NFT):** Wipes the serials in the **inclusive range** from **Start Serial Number** to **End Serial Number**. If the block is configured with **fixed serial numbers** , the wipe operation will always target that same serial range. This effectively makes the run **single-use for those serials**. To keep the policy reusable across documents, configure **Start/End Serial Number** to be derived from the selected document.
+* **Non-Fungible (NFT):** Wipes one or more serial numbers defined by a flexible Serial Numbers Expression. If the block is configured with **fixed serial numbers** (e.g., 1,2-5,10), the wipe operation will always target that same serial range. This effectively makes the run **single-use for those serials**. To keep the policy **reusable across documents**, configure serial numbers to be derived from the selected document.
 
 
 ### Properties
@@ -21,9 +21,8 @@ This block allows to wipe tokens.
 | UI Property         | Definition                                                                                      | Examples                                              |
 | ------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | Token       | Select which token to wipe. The token must exist in the Guardian instance. | specific token                        |
-| Rule        | **FT required.** Enter any wiping calculations.                                             | `field0`, `10` |
-| Start Serial Number        | **NFT required.** Enter start serial number for wiping calculations.                                             | `field1`, `5`        |
-| End Serial Number	        | **NFT required.** Enter end serial number for wiping calculations.                                             | `field2`, `12`         |
+| Rule        | **FT required.** Enter any FT wiping calculations.                                             | `field0`, `10` |
+| Serial Numbers        | **NFT required.** Enter serials and ranges for NFT wiping. Supports comma-separated and range formats.                                             | `field0,field1-field2,field3`, `1,2-5,10`        |
 
 ### Events
 

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.html
@@ -95,18 +95,10 @@
     </tr>
     <tr class="propRow" [attr.collapse]="propHidden.main">
         <td class="propRowCol"></td>
-        <td class="propRowCell cellName">Start Serial Number</td>
+        <td class="propRowCell cellName">Serial Numbers</td>
         <td class="propRowCell">
-            <input class="prop-input" [(ngModel)]="properties.startSerialNumber" [readonly]="readonly"
-                   (blur)="onSave()">
-        </td>
-    </tr>
-    <tr class="propRow" [attr.collapse]="propHidden.main">
-        <td class="propRowCol"></td>
-        <td class="propRowCell cellName">End Serial Number</td>
-        <td class="propRowCell">
-            <input class="prop-input" [(ngModel)]="properties.endSerialNumber" [readonly]="readonly"
-                   (blur)="onSave()">
+            <input class="prop-input" [(ngModel)]="properties.serialNumbersExpression" [readonly]="readonly"
+                   (blur)="onSave()"  placeholder="Examples: 1,2-5,10  |  field0,field1-field5,field10">
         </td>
     </tr>
 </table>

--- a/guardian-service/src/policy-engine/block-validators/blocks/retirement-block.ts
+++ b/guardian-service/src/policy-engine/block-validators/blocks/retirement-block.ts
@@ -39,12 +39,8 @@ export class RetirementBlock {
                 validator.addError('Option "rule" must be a string');
             }
 
-            if (ref.options.startSerialNumber && typeof ref.options.startSerialNumber !== 'string') {
-                validator.addError('Option "start serial number" must be a string');
-            }
-
-            if (ref.options.endSerialNumber && typeof ref.options.endSerialNumber !== 'string') {
-                validator.addError('Option "end serial number" must be a string');
+            if (ref.options.serialNumbersExpression && typeof ref.options.serialNumbersExpression !== 'string') {
+                validator.addError('Option "serial numbers" must be a string');
             }
 
             const accountType = ['default', 'custom'];


### PR DESCRIPTION
### Issue Label
[https://github.com/hashgraph/guardian/issues/4988](https://github.com/hashgraph/guardian/issues/4988)

### Problem Description
The current implementation of Hedera Guardian does not support retiring NFTs by a specific set of serial numbers, even though the Hedera SDK natively supports this operation. 

In applications such as carbon credit management, it is often necessary to retire selected tokens (e.g., specific serial numbers) rather than the entire supply or a fixed count.

### Requirements
Enhance Guardian to support NFT retirement by specifying a list of serial numbers. The implementation should:
* Allow users or policy workflows to pass a custom array of serial numbers.
* Call the appropriate Hedera SDK function to retire those specific serial-numbered NFTs.

### Summary of Changes
By applying this enhancement:

* Users can select specific NFT serial numbers to retire.
* For NFT operations:

  * **Serial Numbers** field is required.
  * Guardian will generate an array of serial numbers and pass them to the Hedera SDK for the wipe operation.
* For FT operations:

  * **Rule** remains the required field.
  * No changes are introduced to the FT wipe process.

### Validation Rules
* The Serial Numbers field is required.
* The Serial Numbers expression may contain individual numbers or inclusive ranges (e.g., 1,2-5,10).
* If a range is used (e.g., 2-5), the end value must be greater than or equal to the start value.
* Rule is required for FT operations.

### NFT Wipe Flow
**_Schema-Driven Wipe Flow_**

Serial numbers can be dynamically provided via schema fields or policy formulas. This enables multiple wipe operations for the same token, with different sets of serial numbers, as needed. Can useful for workflows requiring repeated or conditional NFT retirement.

<img width="886" height="3337" alt="FireShot Capture 004 - Guardian -  3 93 78 104" src="https://github.com/user-attachments/assets/e60da834-0507-461b-9dfa-a22a3e0b866f" />
<img width="787" height="287" alt="image" src="https://github.com/user-attachments/assets/ac6aaa2e-e8dd-4d5a-ab40-2787fbaed59a" />


* Example usage
  * Mint NFTs via the Mint Block, with the amount provided by the schema.
  * Add a separate schema for wipe operations.

<img width="985" height="300" alt="image" src="https://github.com/user-attachments/assets/022829b5-d344-4ec1-b26d-e299624cd899" />

  * Retire serial numbers 1, 3, 4, 5, 8, 12, 13, 14, 15, (entered dynamically in schema).

<img width="1098" height="832" alt="image" src="https://github.com/user-attachments/assets/d17401f6-3608-4d80-b3b4-3377bc8e4f40" />
<img width="1912" height="1907" alt="image" src="https://github.com/user-attachments/assets/9429d05c-ec0e-4bc3-abb8-6f2feb7b51af" />


**_Single Wipe Flow (Per User, Per Token)_**

A constant value for Serial Numbers Expression (for example, 1,2-5,10) can be provided. This allows a one-time wipe of specific NFTs per user and per token throughout the policy lifecycle.

<img width="788" height="283" alt="image" src="https://github.com/user-attachments/assets/60349543-c9e6-4a7f-ba74-5b1c1d2f07b9" />

* Example usage
  * Mint 20 NFTs using the Mint Block.
  * (Minting amount must be ≥ highest serial number to be retired)
  * Retire serial numbers 10,12,13,14,18. 
  
<img width="1790" height="828" alt="image" src="https://github.com/user-attachments/assets/da926dd8-19e8-4c52-a80d-4114887957de" />
<img width="1912" height="1457" alt="image" src="https://github.com/user-attachments/assets/b85f85e3-3e5d-481e-aeae-e4eeb94c1f7f" />


Transaction History of Single NFT
<img width="1847" height="420" alt="image" src="https://github.com/user-attachments/assets/793ad878-e0c2-4425-a1e2-6765b02dd7f1" />


### FT Wipe Flow

No changes to the existing FT token wipe flow.

<img width="975" height="410" alt="image" src="https://github.com/user-attachments/assets/f60f4776-5c50-4a80-baf0-474a842c8479" />

* Example usage
  * Create an FT token using schema-driven Mint Block.
  * Use Wipe Block to retire 1 token (based on Rule).
  
  
<img width="975" height="385" alt="image" src="https://github.com/user-attachments/assets/3bd6b26f-3656-4e37-a1d6-68387e944a14" />
<img width="975" height="425" alt="image" src="https://github.com/user-attachments/assets/4ef2fe95-7002-494d-95c0-e19592dfdb0f" />
<img width="1896" height="643" alt="image" src="https://github.com/user-attachments/assets/385cf245-3bf0-4866-8984-9a65801fffed" />


