### PR TITLE
feat: implement project mint linking and enhance issuance tracking in…

### DIFF
--- a/sustainable-explorer/frontend/composables/api/index.ts
+++ b/sustainable-explorer/frontend/composables/api/index.ts
@@ -1,3 +1,4 @@
 export * from './useRegistriesApi';
 export * from './useMethodologiesApi';
 export * from './useSummaryApi';
+export * from './useIssuancesApi';

--- a/sustainable-explorer/frontend/composables/api/useIssuancesApi.ts
+++ b/sustainable-explorer/frontend/composables/api/useIssuancesApi.ts
@@ -1,0 +1,126 @@
+import type { NetworkId } from '~/composables/useNetwork';
+import type { IssuanceListItem } from '~/types/models';
+
+export type IssuanceSortKey = 'mintDate' | 'amount' | 'projectName' | 'tokenId';
+export type IssuanceSortDir = 'asc' | 'desc';
+
+export interface IssuancesMeta {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+}
+
+export interface IssuancesResponse {
+    data: Record<string, any>[];
+    meta: IssuancesMeta;
+}
+
+export interface UseIssuancesApiOptions {
+    page: Ref<number>;
+    limit: Ref<number>;
+    search: Ref<string>;
+    network: Ref<NetworkId | string>;
+    sortBy: Ref<IssuanceSortKey | null>;
+    sortDir: Ref<IssuanceSortDir | null>;
+    filters: Ref<Record<string, any>>;
+}
+
+const ISSUANCE_FILTER_KEYS = ['dateFrom', 'dateTo', 'tokenType', 'projectId'] as const;
+
+const emptyResponse = (limit: number): IssuancesResponse => ({
+    data: [],
+    meta: { page: 1, limit, total: 0, totalPages: 1 },
+});
+
+function mapApiIssuance(raw: Record<string, any>): IssuanceListItem {
+    return {
+        mintConsensusTimestamp: raw['mintConsensusTimestamp'] ?? '',
+        tokenId: raw['tokenId'] ?? null,
+        tokenName: raw['tokenName'] ?? null,
+        symbol: raw['symbol'] ?? null,
+        tokenType: raw['tokenType'] ?? null,
+        amount: typeof raw['amount'] === 'number' ? raw['amount'] : 0,
+        mintDate: raw['mintDate'] ?? null,
+        projectId: raw['projectId'] ?? null,
+        projectName: raw['projectName'] ?? null,
+        methodology: raw['methodology'] ?? null,
+        methodologyId: raw['methodologyId'] ?? null,
+        country: raw['country'] ?? null,
+        registry: raw['registry'] ?? null,
+        linkMethod: raw['linkMethod'] ?? 'unknown',
+    };
+}
+
+export const useIssuancesApi = (opts: UseIssuancesApiOptions) => {
+    const config = useRuntimeConfig();
+    const baseURL = import.meta.server
+        ? (config.apiBaseUrl as string)
+        : (config.public.apiBaseUrl as string);
+
+    const buildQuery = (): Record<string, string | number> => {
+        const q: Record<string, string | number> = {
+            page: opts.page.value,
+            limit: opts.limit.value,
+        };
+        const search = opts.search.value?.trim();
+        if (search) q.search = search;
+        if (opts.sortBy.value && opts.sortDir.value) {
+            q.sortBy = opts.sortBy.value;
+            q.sortDir = opts.sortDir.value;
+        }
+        const filters = opts.filters.value ?? {};
+        for (const key of ISSUANCE_FILTER_KEYS) {
+            const raw = filters[key];
+            if (raw === null || raw === undefined) continue;
+            if (typeof raw === 'string') {
+                const trimmed = raw.trim();
+                if (trimmed) q[key] = trimmed;
+            }
+        }
+        return q;
+    };
+
+    const url = computed(() => `/api/v1/${opts.network.value}/issuances`);
+
+    const key = computed(() => {
+        const q = buildQuery();
+        return `issuances:${opts.network.value}:${JSON.stringify(q)}`;
+    });
+
+    const { data, pending, error, refresh } = useAsyncData<IssuancesResponse>(
+        key.value,
+        async () => {
+            try {
+                const res = await $fetch<IssuancesResponse>(url.value, {
+                    baseURL,
+                    query: buildQuery(),
+                });
+                return res ?? emptyResponse(opts.limit.value);
+            } catch (err) {
+                console.error('[useIssuancesApi] fetch failed:', err);
+                return emptyResponse(opts.limit.value);
+            }
+        },
+        {
+            default: () => emptyResponse(opts.limit.value),
+            watch: [
+                opts.page,
+                opts.limit,
+                opts.search,
+                opts.network,
+                opts.sortBy,
+                opts.sortDir,
+                opts.filters,
+            ],
+        },
+    );
+
+    const issuances = computed<IssuanceListItem[]>(() =>
+        (data.value?.data ?? []).map(mapApiIssuance),
+    );
+
+    const meta = computed(() => data.value?.meta ?? emptyResponse(opts.limit.value).meta);
+
+    return { issuances, meta, pending, error, refresh };
+};

--- a/sustainable-explorer/frontend/composables/api/useSummaryApi.ts
+++ b/sustainable-explorer/frontend/composables/api/useSummaryApi.ts
@@ -10,12 +10,18 @@ export interface RegistryBreakdownItemDto {
     totalIssued: number;
 }
 
+export interface SectorBreakdownItemDto {
+    sector: string;
+    totalIssued: number;
+}
+
 export interface DashboardSummaryDto {
     totalIssued: number;
     totalRetired: number;
     totalActive: number;
     timeline: TimelinePointDto[];
     registryBreakdown: RegistryBreakdownItemDto[];
+    sectorBreakdown: SectorBreakdownItemDto[];
 }
 
 const emptyDashboardSummary = (): DashboardSummaryDto => ({
@@ -24,6 +30,7 @@ const emptyDashboardSummary = (): DashboardSummaryDto => ({
     totalActive: 0,
     timeline: [],
     registryBreakdown: [],
+    sectorBreakdown: [],
 });
 
 export const useDashboardSummaryApi = (opts: { network: Ref<NetworkId | string> }) => {

--- a/sustainable-explorer/frontend/composables/useDashboard.ts
+++ b/sustainable-explorer/frontend/composables/useDashboard.ts
@@ -170,7 +170,7 @@ export function useDashboard(
         return vals.length > 0 ? Math.max(...vals) : 1;
     });
     const issuanceTotal = computed(() =>
-        Math.round(issuanceMonths.value.reduce((sum, m) => sum + m.value, 0) * 10) / 10,
+        Math.round((dashboardSummary.value?.totalIssued ?? 0) / 1_000_000 * 10) / 10,
     );
 
     // Convert HCS consensusTimestamp (Unix seconds string) to relative time string

--- a/sustainable-explorer/frontend/composables/useDashboard.ts
+++ b/sustainable-explorer/frontend/composables/useDashboard.ts
@@ -512,20 +512,26 @@ export function useDashboard(
             .sort((a, b) => b.projectCount - a.projectCount);
     });
 
-    // Override sectorBreakdown — group real projects by normalized sector
+    // Override sectorBreakdown — project counts from local batch, credit counts from API
     const sectorBreakdownReal = computed(() => {
-        const groups: Record<string, { projectCount: number; creditCount: number }> = {};
+        const projectGroups: Record<string, number> = {};
         for (const p of _realProjects.value) {
             const label = p.sector || 'Others';
-            if (!groups[label]) groups[label] = { projectCount: 0, creditCount: 0 };
-            groups[label].projectCount++;
-            groups[label].creditCount += p.totalIssued ?? p.credits ?? 0;
+            projectGroups[label] = (projectGroups[label] ?? 0) + 1;
         }
-        return Object.entries(groups)
-            .map(([label, data]) => ({
+
+        const creditMap: Record<string, number> = {};
+        for (const s of dashboardSummary.value?.sectorBreakdown ?? []) {
+            const label = s.sector || 'Others';
+            creditMap[label] = (creditMap[label] ?? 0) + s.totalIssued;
+        }
+
+        const allLabels = new Set([...Object.keys(projectGroups), ...Object.keys(creditMap)]);
+        return Array.from(allLabels)
+            .map(label => ({
                 label,
-                projectCount: data.projectCount,
-                creditCount: data.creditCount,
+                projectCount: projectGroups[label] ?? 0,
+                creditCount: creditMap[label] ?? 0,
                 color: getSectorColor(label),
             }))
             .sort((a, b) => b.projectCount - a.projectCount);

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -202,22 +202,28 @@
     },
     "credits": {
         "title": "Issuances",
-        "subtitle": "Tokens issued on Hedera",
-        "searchPlaceholder": "Search by name, symbol, token ID...",
+        "subtitle": "Carbon credit mint events across all projects on the Guardian network",
+        "searchPlaceholder": "Search by project name, token name, or token ID...",
         "noMatch": "No issuances match your filters",
         "supplyTooltip": "Total token supply minted on Hedera. For fungible tokens this is the total supply. For NFTs this is the number of unique serials.",
+        "amountTooltip": "Number of carbon credits minted in this event.",
         "columns": {
+            "date": "Date",
             "token": "Token",
-            "symbol": "Symbol",
-            "type": "Type",
-            "supply": "Supply",
+            "amount": "Amount",
             "project": "Project",
+            "methodology": "Methodology",
+            "type": "Type",
             "registry": "Registry",
+            "symbol": "Symbol",
+            "supply": "Supply",
             "rawData": "Raw Data"
         },
         "filters": {
             "tokenType": "Token Type",
-            "registry": "Registry"
+            "registry": "Registry",
+            "dateFrom": "From",
+            "dateTo": "To"
         }
     },
     "methodologies": {

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -141,7 +141,24 @@
         "mtco2AnnualEst": "MtCO2 Annual Est.",
         "sector": "Sector",
         "registry": "Registry",
-        "totalIssuancesLabel": "Total Issuances"
+        "totalIssuancesLabel": "Total Issuances",
+        "activityTypes": {
+            "project": "New project registered",
+            "policy": "Policy published",
+            "registry": "New registry joined",
+            "credit": "Issuances minted",
+            "verification": "Verification completed",
+            "retirement": "Credits retired"
+        },
+        "sectors": {
+            "Energy": "Energy",
+            "Industrial Process": "Industrial Process",
+            "Land Use & Forestry": "Land Use & Forestry",
+            "Waste": "Waste",
+            "Fugitive Emissions": "Fugitive Emissions",
+            "Transport": "Transport",
+            "Others": "Others"
+        }
     },
     "projects": {
         "title": "Projects",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -202,22 +202,28 @@
     },
     "credits": {
         "title": "Emisiones",
-        "subtitle": "Tokens emitidos en Hedera",
-        "searchPlaceholder": "Buscar por nombre, símbolo, ID de token...",
+        "subtitle": "Eventos de acuñación de créditos de carbono en todos los proyectos de la red Guardian",
+        "searchPlaceholder": "Buscar por nombre de proyecto, token o ID de token...",
         "noMatch": "Ninguna emisión coincide con tus filtros",
         "supplyTooltip": "Suministro total de tokens acuñado en Hedera. Para tokens fungibles es el suministro total. Para NFTs es el número de serials únicos.",
+        "amountTooltip": "Número de créditos de carbono acuñados en este evento.",
         "columns": {
+            "date": "Fecha",
             "token": "Token",
-            "symbol": "Símbolo",
-            "type": "Tipo",
-            "supply": "Suministro",
+            "amount": "Cantidad",
             "project": "Proyecto",
+            "methodology": "Metodología",
+            "type": "Tipo",
             "registry": "Registro",
+            "symbol": "Símbolo",
+            "supply": "Suministro",
             "rawData": "Datos brutos"
         },
         "filters": {
             "tokenType": "Tipo de token",
-            "registry": "Registro"
+            "registry": "Registro",
+            "dateFrom": "Desde",
+            "dateTo": "Hasta"
         }
     },
     "methodologies": {

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -141,7 +141,24 @@
         "mtco2AnnualEst": "MtCO2 anual est.",
         "sector": "Sector",
         "registry": "Registro",
-        "totalIssuancesLabel": "Emisiones totales"
+        "totalIssuancesLabel": "Emisiones totales",
+        "activityTypes": {
+            "project": "Nuevo proyecto registrado",
+            "policy": "Política publicada",
+            "registry": "Nuevo registro incorporado",
+            "credit": "Emisiones acuñadas",
+            "verification": "Verificación completada",
+            "retirement": "Créditos retirados"
+        },
+        "sectors": {
+            "Energy": "Energía",
+            "Industrial Process": "Proceso Industrial",
+            "Land Use & Forestry": "Uso del Suelo y Silvicultura",
+            "Waste": "Residuos",
+            "Fugitive Emissions": "Emisiones Fugitivas",
+            "Transport": "Transporte",
+            "Others": "Otros"
+        }
     },
     "projects": {
         "title": "Proyectos",

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -1,40 +1,104 @@
 <script setup lang="ts">
-import { Coins, FileJson } from 'lucide-vue-next';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
+import type { IssuanceSortKey, IssuanceSortDir } from '~/composables/api/useIssuancesApi';
 import { formatCredits } from '~/lib/format';
-import { generateCreditVc } from '~/lib/mock-vc';
 
 const { t } = useI18n();
-const { credits, total, filterOptions } = useCredits();
+const { network } = useNetwork();
+const route = useRoute();
+const router = useRouter();
 
-const vcViewerOpen = ref(false);
-const vcViewerTitle = ref('');
-const vcViewerData = ref<Record<string, any> | null>(null);
+const pageSize = ref(route.query.limit ? parseInt(route.query.limit as string) : 20);
+const currentPage = ref(route.query.page ? parseInt(route.query.page as string) : 1);
+const searchQuery = ref((route.query.q as string) || '');
+const sortKey = ref<IssuanceSortKey | null>((route.query.sort as IssuanceSortKey) || 'mintDate');
+const sortDir = ref<IssuanceSortDir | null>((route.query.dir as IssuanceSortDir) || 'desc');
 
-function viewVc(c: any) {
-    vcViewerTitle.value = c.name;
-    vcViewerData.value = generateCreditVc(c, c.project);
-    vcViewerOpen.value = true;
+const RESERVED = new Set(['q', 'page', 'sort', 'dir', 'limit']);
+const initialFilters: Record<string, string> = {};
+for (const [k, v] of Object.entries(route.query)) {
+    if (!RESERVED.has(k) && typeof v === 'string' && v) initialFilters[k] = v;
+}
+const activeFilters = ref<Record<string, string>>(initialFilters);
+
+function syncUrl() {
+    const query: Record<string, string> = {};
+    if (searchQuery.value) query.q = searchQuery.value;
+    if (currentPage.value > 1) query.page = String(currentPage.value);
+    if (sortKey.value && sortDir.value && !(sortKey.value === 'mintDate' && sortDir.value === 'desc')) {
+        query.sort = sortKey.value;
+        query.dir = sortDir.value;
+    }
+    for (const [k, v] of Object.entries(activeFilters.value)) {
+        if (v) query[k] = v;
+    }
+    router.replace({ query });
 }
 
-const allCredits = computed(() => credits.value.map(c => ({
-    ...c,
-    supplyFormatted: formatCredits(c.supply),
-})));
+function toggleSort(key: IssuanceSortKey) {
+    if (sortKey.value === key) {
+        if (sortDir.value === 'asc') sortDir.value = 'desc';
+        else if (sortDir.value === 'desc') { sortKey.value = null; sortDir.value = null; }
+        else sortDir.value = 'asc';
+    } else {
+        sortKey.value = key;
+        sortDir.value = 'asc';
+    }
+    currentPage.value = 1;
+    syncUrl();
+}
 
-const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters } =
-    useFilteredPagination(allCredits, {
-        searchFields: ['name', 'symbol', 'tokenId', 'project', 'registry'],
-        pageSize: 8,
-        defaultSort: { key: 'supply', dir: 'desc' },
-    });
+function setFilter(key: string, value: string) {
+    activeFilters.value = { ...activeFilters.value, [key]: value };
+    currentPage.value = 1;
+    syncUrl();
+}
+
+function clearFilters() {
+    activeFilters.value = {};
+    searchQuery.value = '';
+    currentPage.value = 1;
+    syncUrl();
+}
+
+watch(searchQuery, () => { currentPage.value = 1; syncUrl(); });
+watch(currentPage, syncUrl);
+
+const { issuances, meta, pending } = useIssuancesApi({
+    page: currentPage,
+    limit: pageSize,
+    search: searchQuery,
+    network,
+    sortBy: sortKey,
+    sortDir,
+    filters: activeFilters,
+});
+
+function formatDate(dateStr: string | null): string {
+    if (!dateStr) return '—';
+    const d = new Date(dateStr);
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+const typeLabel: Record<string, string> = {
+    FUNGIBLE_COMMON: 'Fungible',
+    NON_FUNGIBLE_UNIQUE: 'NFT',
+};
+const typeColor: Record<string, string> = {
+    FUNGIBLE_COMMON: 'bg-stat-blue/10 text-stat-blue',
+    NON_FUNGIBLE_UNIQUE: 'bg-stat-amber/10 text-stat-amber',
+};
 
 const filters = computed<FilterOption[]>(() => [
-    { key: 'type', label: t('credits.filters.tokenType'), options: filterOptions.value.types.map((x: string) => ({ value: x, label: x })) },
-    { key: 'registry', label: t('credits.filters.registry'), options: filterOptions.value.registries.map((r: string) => ({ value: r, label: r })) },
+    {
+        key: 'tokenType',
+        label: t('credits.filters.tokenType'),
+        options: [
+            { value: 'FUNGIBLE_COMMON', label: 'Fungible' },
+            { value: 'NON_FUNGIBLE_UNIQUE', label: 'Non-Fungible (NFT)' },
+        ],
+    },
 ]);
-
-const typeColor: Record<string, string> = { Fungible: 'bg-stat-blue/10 text-stat-blue', 'Non-Fungible': 'bg-stat-amber/10 text-stat-amber' };
 </script>
 
 <template>
@@ -45,48 +109,135 @@ const typeColor: Record<string, string> = { Fungible: 'bg-stat-blue/10 text-stat
         </div>
 
         <div class="px-6 pb-3">
-            <FilterBar v-model="searchQuery" :filters="filters" :active-filters="activeFilters" :result-count="filtered.length" :total-count="total" :search-placeholder="$t('credits.searchPlaceholder')" @filter="setFilter" @clear="clearFilters" />
+            <FilterBar
+                v-model="searchQuery"
+                :filters="filters"
+                :active-filters="activeFilters"
+                :result-count="meta.total"
+                :total-count="meta.total"
+                :search-placeholder="$t('credits.searchPlaceholder')"
+                @filter="setFilter"
+                @clear="clearFilters"
+            />
+
+            <!-- Date range filter -->
+            <div class="flex items-center gap-2 mt-2.5 flex-wrap">
+                <span class="text-[11px] text-muted-foreground">{{ $t('common.from') }}</span>
+                <input
+                    type="date"
+                    :value="activeFilters.dateFrom || ''"
+                    class="h-7 rounded-md border border-border bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                    @input="setFilter('dateFrom', ($event.target as HTMLInputElement).value)"
+                />
+                <span class="text-[11px] text-muted-foreground">{{ $t('common.to') }}</span>
+                <input
+                    type="date"
+                    :value="activeFilters.dateTo || ''"
+                    class="h-7 rounded-md border border-border bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                    @input="setFilter('dateTo', ($event.target as HTMLInputElement).value)"
+                />
+                <button
+                    v-if="activeFilters.dateFrom || activeFilters.dateTo"
+                    class="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+                    @click="() => { setFilter('dateFrom', ''); setFilter('dateTo', ''); }"
+                >
+                    {{ $t('common.clear') }}
+                </button>
+            </div>
         </div>
 
         <div class="px-6 pb-6">
-            <div class="rounded-xl border bg-card overflow-hidden">
-                <table class="w-full text-sm">
+            <div class="rounded-xl border bg-card overflow-x-auto">
+                <table class="w-full text-sm min-w-[800px]">
                     <thead>
                         <tr class="border-b bg-muted/30">
-                            <SortableHeader :label="$t('credits.columns.token')" sort-key="name" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
-                            <SortableHeader :label="$t('credits.columns.symbol')" sort-key="symbol" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
-                            <SortableHeader :label="$t('credits.columns.type')" sort-key="type" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
-                            <SortableHeader :label="$t('credits.columns.supply')" sort-key="supply" align="right" :tooltip="$t('credits.supplyTooltip')" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
-                            <SortableHeader :label="$t('credits.columns.project')" sort-key="project" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
-                            <SortableHeader :label="$t('credits.columns.registry')" sort-key="registry" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
-                            <th class="text-center py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider"><span class="inline-flex items-center gap-1">{{ $t('credits.columns.rawData') }} <InfoTooltip :text="$t('tooltips.viewRawData')" /></span></th>
+                            <SortableHeader :label="$t('credits.columns.date')" sort-key="mintDate" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
+                            <SortableHeader :label="$t('credits.columns.token')" sort-key="tokenId" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
+                            <SortableHeader :label="$t('credits.columns.amount')" sort-key="amount" align="right" :tooltip="$t('credits.amountTooltip')" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
+                            <SortableHeader :label="$t('credits.columns.project')" sort-key="projectName" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
+                            <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('credits.columns.methodology') }}</th>
+                            <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('credits.columns.type') }}</th>
+                            <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('credits.columns.registry') }}</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y">
-                        <tr v-for="c in paginated" :key="c.id" class="hover:bg-muted/30 transition-colors cursor-pointer">
-                            <td class="py-3 px-4"><div><span class="font-medium text-foreground">{{ c.name }}</span><p class="text-[11px] text-muted-foreground/60 font-mono">{{ c.tokenId }}</p></div></td>
-                            <td class="py-3 px-4 font-mono text-xs">{{ c.symbol }}</td>
-                            <td class="py-3 px-4"><span :class="[typeColor[c.type], 'text-xs font-medium rounded-full px-2 py-0.5']">{{ c.type }}</span></td>
-                            <td class="py-3 px-4 text-right tabular-nums font-medium">{{ c.supplyFormatted }}</td>
-                            <td class="py-3 px-4 text-muted-foreground">{{ c.project }}</td>
-                            <td class="py-3 px-4 text-muted-foreground">{{ c.registry }}</td>
-                            <td class="py-3 px-3 text-center">
-                                <button
-                                    class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                                    :title="$t('common.viewRawData')"
-                                    @click.stop="viewVc(c)"
+                        <!-- Skeleton rows -->
+                        <tr v-if="pending" v-for="i in pageSize" :key="`skel-${i}`" class="animate-pulse">
+                            <td class="py-3 px-4"><div class="h-4 w-24 rounded bg-muted" /></td>
+                            <td class="py-3 px-4">
+                                <div class="h-4 w-28 rounded bg-muted mb-1" />
+                                <div class="h-3 w-20 rounded bg-muted" />
+                            </td>
+                            <td class="py-3 px-4"><div class="h-4 w-16 rounded bg-muted ml-auto" /></td>
+                            <td class="py-3 px-4"><div class="h-4 w-32 rounded bg-muted" /></td>
+                            <td class="py-3 px-4"><div class="h-4 w-20 rounded bg-muted" /></td>
+                            <td class="py-3 px-4"><div class="h-5 w-16 rounded-full bg-muted" /></td>
+                            <td class="py-3 px-4"><div class="h-4 w-24 rounded bg-muted" /></td>
+                        </tr>
+                        <!-- Data rows -->
+                        <tr
+                            v-else
+                            v-for="item in issuances"
+                            :key="item.mintConsensusTimestamp"
+                            class="hover:bg-muted/30 transition-colors"
+                        >
+                            <td class="py-3 px-4 text-xs text-muted-foreground whitespace-nowrap">
+                                {{ formatDate(item.mintDate) }}
+                            </td>
+                            <td class="py-3 px-4">
+                                <div class="font-medium text-foreground text-sm leading-tight">
+                                    {{ item.tokenName || item.tokenId || '—' }}
+                                </div>
+                                <div class="font-mono text-[10px] text-muted-foreground/60 mt-0.5 flex items-center gap-1.5">
+                                    <span>{{ item.tokenId || '' }}</span>
+                                    <span v-if="item.symbol" class="rounded bg-muted px-1 py-px text-muted-foreground font-sans">{{ item.symbol }}</span>
+                                </div>
+                            </td>
+                            <td class="py-3 px-4 text-right tabular-nums font-medium text-foreground whitespace-nowrap">
+                                {{ formatCredits(item.amount) }}
+                            </td>
+                            <td class="py-3 px-4">
+                                <NuxtLink
+                                    v-if="item.projectId"
+                                    :to="`/projects/${item.projectId}`"
+                                    class="text-sm text-foreground hover:text-primary transition-colors line-clamp-2"
                                 >
-                                    <FileJson class="h-3.5 w-3.5" />
-                                </button>
+                                    {{ item.projectName || item.projectId }}
+                                </NuxtLink>
+                                <span v-else class="text-sm text-muted-foreground">—</span>
+                            </td>
+                            <td class="py-3 px-4">
+                                <span v-if="item.methodology" class="text-xs text-muted-foreground">
+                                    {{ item.methodology }}
+                                </span>
+                                <span v-else class="text-xs text-muted-foreground/40">—</span>
+                            </td>
+                            <td class="py-3 px-4">
+                                <span
+                                    v-if="item.tokenType"
+                                    :class="[typeColor[item.tokenType] || 'bg-muted text-muted-foreground', 'text-xs font-medium rounded-full px-2 py-0.5 whitespace-nowrap']"
+                                >
+                                    {{ typeLabel[item.tokenType] || item.tokenType }}
+                                </span>
+                                <span v-else class="text-xs text-muted-foreground/40">—</span>
+                            </td>
+                            <td class="py-3 px-4 text-xs text-muted-foreground">
+                                {{ item.registry || '—' }}
                             </td>
                         </tr>
-                        <tr v-if="paginated.length === 0"><td colspan="7" class="py-12 text-center text-sm text-muted-foreground">{{ $t('credits.noMatch') }}</td></tr>
+                        <tr v-if="!pending && issuances.length === 0">
+                            <td colspan="7" class="py-12 text-center text-sm text-muted-foreground">{{ $t('credits.noMatch') }}</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
-            <Pagination v-model:current-page="currentPage" :total-pages="totalPages" :total-items="filtered.length" :page-size="pageSize" />
-        </div>
 
-        <VcJsonViewer :open="vcViewerOpen" :title="vcViewerTitle" :data="vcViewerData" @close="vcViewerOpen = false" />
+            <Pagination
+                v-model:current-page="currentPage"
+                v-model:page-size="pageSize"
+                :total-pages="meta.totalPages"
+                :total-items="meta.total"
+            />
+        </div>
     </div>
 </template>

--- a/sustainable-explorer/frontend/pages/index.vue
+++ b/sustainable-explorer/frontend/pages/index.vue
@@ -573,7 +573,7 @@ const filteredStats = computed(() => {
                             <div class="space-y-2 flex-1 min-w-0 pt-1">
                                 <div v-for="s in sectorBreakdown" :key="s.label" class="flex items-center gap-2">
                                     <span class="h-2.5 w-2.5 shrink-0 rounded-full" :style="{ backgroundColor: s.color }" />
-                                    <span class="text-xs text-muted-foreground truncate flex-1">{{ s.label }}</span>
+                                    <span class="text-xs text-muted-foreground truncate flex-1">{{ $t(`dashboard.sectors.${s.label}`, s.label) }}</span>
                                     <span class="text-xs font-medium text-foreground tabular-nums shrink-0">
                                         {{ sectorTotal > 0 ? ((chartMode === 'projects' ? s.projectCount : s.creditCount) / sectorTotal * 100).toFixed(1) : '0.0' }}%
                                     </span>
@@ -761,7 +761,7 @@ const filteredStats = computed(() => {
                             <component :is="activityIcons[item.type]" :class="[activityColors[item.type], 'h-4 w-4']" />
                         </div>
                         <div class="flex-1 min-w-0">
-                            <p class="text-sm font-medium text-foreground">{{ item.action }}</p>
+                            <p class="text-sm font-medium text-foreground">{{ $t(`dashboard.activityTypes.${item.type}`, item.action) }}</p>
                             <p class="text-xs text-muted-foreground truncate">{{ item.detail }}</p>
                         </div>
                         <div class="flex items-center gap-1 shrink-0">

--- a/sustainable-explorer/frontend/pages/index.vue
+++ b/sustainable-explorer/frontend/pages/index.vue
@@ -81,9 +81,7 @@ const issuancePeriod = ref<TimePeriod>('monthly');
 const retirementPeriod = ref<TimePeriod>('monthly');
 
 const issuanceSeriesData = computed(() => buildIssuanceSeries(issuancePeriod.value));
-const issuanceSeriesTotal = computed(() =>
-    Math.round(issuanceSeriesData.value.reduce((s, d) => s + d.value, 0) * 10) / 10,
-);
+const issuanceSeriesTotal = computed(() => issuanceTotal.value);
 
 const retirementSeriesData = computed(() => buildRetirementSeries(retirementPeriod.value));
 const retirementSeriesTotal = computed(() =>

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -362,18 +362,6 @@ const lifecycleSummary = computed(() => {
             </div>
           </div>
         </div>
-        <div class="flex items-center gap-2 shrink-0">
-          <a
-            v-if="hashscanUrl"
-            :href="hashscanUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 rounded-lg border bg-card px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
-          >
-            <ExternalLink class="h-4 w-4 text-primary" />
-            {{ $t('methodologies.detail.viewOnHashScan') }}
-          </a>
-        </div>
       </div>
 
       <!-- Summary card -->

--- a/sustainable-explorer/frontend/types/models.ts
+++ b/sustainable-explorer/frontend/types/models.ts
@@ -1,3 +1,20 @@
+export interface IssuanceListItem {
+    mintConsensusTimestamp: string;
+    tokenId: string | null;
+    tokenName: string | null;
+    symbol: string | null;
+    tokenType: string | null;
+    amount: number;
+    mintDate: string | null;
+    projectId: string | null;
+    projectName: string | null;
+    methodology: string | null;
+    methodologyId: string | null;
+    country: string | null;
+    registry: string | null;
+    linkMethod: string;
+}
+
 export interface ProjectIssuance {
     tokenId: string;
     name: string | null;

--- a/sustainable-explorer/src/api/api.module.ts
+++ b/sustainable-explorer/src/api/api.module.ts
@@ -11,6 +11,7 @@ import { MethodologiesController } from './controllers/methodologies.controller'
 import { PolicySchemasController } from './controllers/policy-schemas.controller';
 import { ProjectsController } from './controllers/project.controller';
 import { SummaryController } from './controllers/summary.controller';
+import { IssuancesController } from './controllers/issuance.controller';
 
 // Services
 import { RegistriesService } from './services/registries.service';
@@ -18,6 +19,7 @@ import { MethodologiesService } from './services/methodologies.service';
 import { PolicySchemasService } from './services/policy-schemas.service';
 import { ProjectsService } from './services/project.service';
 import { SummaryService } from './services/summary.service';
+import { IssuancesService } from './services/issuance.service';
 
 @Module({
     imports: [
@@ -32,6 +34,7 @@ import { SummaryService } from './services/summary.service';
         PolicySchemasController,
         ProjectsController,
         SummaryController,
+        IssuancesController,
     ],
     providers: [
         NetworkDataSourceRegistry,
@@ -40,6 +43,7 @@ import { SummaryService } from './services/summary.service';
         PolicySchemasService,
         ProjectsService,
         SummaryService,
+        IssuancesService,
     ],
 })
 export class ApiModule {}

--- a/sustainable-explorer/src/api/controllers/issuance.controller.ts
+++ b/sustainable-explorer/src/api/controllers/issuance.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { IssuancesService } from '../services/issuance.service';
+import { IssuanceQueryDto, PaginatedIssuancesDto } from '../dto/issuance.dto';
+
+@ApiTags('issuances')
+@Controller('api/v1/:network/issuances')
+export class IssuancesController {
+    constructor(private readonly issuancesService: IssuancesService) {}
+
+    @Get()
+    @ApiOperation({
+        summary: 'List Issuances',
+        description:
+            'Returns a paginated list of all MintToken events linked to projects on the specified network. ' +
+            'Supports full-text search across project name and token name, filtering by date range, ' +
+            'token type, and project, plus sorting by mint date, amount, or project name.',
+    })
+    @ApiParam({
+        name: 'network',
+        enum: ['mainnet', 'testnet', 'previewnet'],
+        description: 'Hedera network',
+    })
+    @ApiResponse({ status: 200, type: PaginatedIssuancesDto })
+    @ApiResponse({ status: 404, description: 'Network not configured on this API instance' })
+    async findAll(
+        @Param('network') network: string,
+        @Query() query: IssuanceQueryDto,
+    ): Promise<PaginatedIssuancesDto> {
+        return this.issuancesService.findAll(network, query);
+    }
+}

--- a/sustainable-explorer/src/api/dto/issuance.dto.ts
+++ b/sustainable-explorer/src/api/dto/issuance.dto.ts
@@ -1,0 +1,91 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationQueryDto, PaginatedResponse } from './pagination.dto';
+import { IssuanceListRow } from '../repositories/issuance.repository';
+
+export class IssuanceQueryDto extends PaginationQueryDto {
+    @ApiPropertyOptional({ description: 'Filter by mint date from (YYYY-MM-DD inclusive)' })
+    @IsOptional()
+    @IsString()
+    dateFrom?: string;
+
+    @ApiPropertyOptional({ description: 'Filter by mint date to (YYYY-MM-DD inclusive)' })
+    @IsOptional()
+    @IsString()
+    dateTo?: string;
+
+    @ApiPropertyOptional({ description: 'Filter by token type (FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE)' })
+    @IsOptional()
+    @IsString()
+    tokenType?: string;
+
+    @ApiPropertyOptional({ description: 'Filter by project source timestamp (exact match)' })
+    @IsOptional()
+    @IsString()
+    projectId?: string;
+}
+
+export class IssuanceListItemDto {
+    @ApiProperty({ description: 'HCS consensus timestamp of the MintToken VC message' })
+    mintConsensusTimestamp: string;
+
+    @ApiProperty({ nullable: true, description: 'Hedera token ID (e.g. 0.0.12345)' })
+    tokenId: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Token name from token_cache' })
+    tokenName: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Token symbol from token_cache' })
+    symbol: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Token type: FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE' })
+    tokenType: string | null;
+
+    @ApiProperty({ description: 'Credits minted in this event' })
+    amount: number;
+
+    @ApiProperty({ nullable: true, description: 'Mint date (YYYY-MM-DD)' })
+    mintDate: string | null;
+
+    @ApiProperty({ nullable: true, description: 'sourceTimestamp of the linked project' })
+    projectId: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Display name of the linked project' })
+    projectName: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Methodology name of the linked project' })
+    methodology: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Methodology slug of the linked project' })
+    methodologyId: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Country of the linked project' })
+    country: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Registry display name' })
+    registry: string | null;
+
+    @ApiProperty({ description: 'How this mint was linked to the project: relationship | topic_scope' })
+    linkMethod: string;
+
+    static fromRow(row: IssuanceListRow): IssuanceListItemDto {
+        return {
+            mintConsensusTimestamp: row.mintConsensusTimestamp,
+            tokenId: row.tokenId,
+            tokenName: row.tokenName,
+            symbol: row.symbol,
+            tokenType: row.tokenType,
+            amount: row.amount,
+            mintDate: row.mintDate,
+            projectId: row.projectId,
+            projectName: row.projectName,
+            methodology: row.methodology,
+            methodologyId: row.methodologyId,
+            country: row.country,
+            registry: row.registry,
+            linkMethod: row.linkMethod,
+        };
+    }
+}
+
+export class PaginatedIssuancesDto extends PaginatedResponse<IssuanceListItemDto> {}

--- a/sustainable-explorer/src/api/dto/summary.dto.ts
+++ b/sustainable-explorer/src/api/dto/summary.dto.ts
@@ -16,6 +16,14 @@ export class RegistryBreakdownItemDto {
     totalIssued: number;
 }
 
+export class SectorBreakdownItemDto {
+    @ApiProperty({ description: 'Sector label derived from linked project businessData' })
+    sector: string;
+
+    @ApiProperty({ description: 'Total MintToken VC amounts issued under this sector' })
+    totalIssued: number;
+}
+
 export class DashboardSummaryDto {
     @ApiProperty({ description: 'Total credits issued (sum of all MintToken VC amounts)' })
     totalIssued: number;
@@ -31,4 +39,7 @@ export class DashboardSummaryDto {
 
     @ApiProperty({ type: [RegistryBreakdownItemDto], description: 'Issuances grouped by registry' })
     registryBreakdown: RegistryBreakdownItemDto[];
+
+    @ApiProperty({ type: [SectorBreakdownItemDto], description: 'Issuances grouped by sector (linked projects only)' })
+    sectorBreakdown: SectorBreakdownItemDto[];
 }

--- a/sustainable-explorer/src/api/repositories/issuance.repository.ts
+++ b/sustainable-explorer/src/api/repositories/issuance.repository.ts
@@ -1,0 +1,37 @@
+export interface IssuanceListRow {
+    mintConsensusTimestamp: string;
+    tokenId: string | null;
+    tokenName: string | null;
+    symbol: string | null;
+    tokenType: string | null;
+    amount: number;
+    mintDate: string | null;
+    projectId: string | null;
+    projectName: string | null;
+    methodology: string | null;
+    methodologyId: string | null;
+    country: string | null;
+    registry: string | null;
+    linkMethod: string;
+}
+
+export interface IssuanceListQuery {
+    page: number;
+    limit: number;
+    search?: string;
+    sortBy?: string;
+    sortDir?: 'asc' | 'desc';
+    dateFrom?: string;
+    dateTo?: string;
+    tokenType?: string;
+    projectId?: string;
+}
+
+export interface IssuanceListResult {
+    rows: IssuanceListRow[];
+    total: number;
+}
+
+export abstract class IssuanceRepository {
+    abstract findAll(query: IssuanceListQuery): Promise<IssuanceListResult>;
+}

--- a/sustainable-explorer/src/api/repositories/pg-issuance.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-issuance.repository.ts
@@ -1,0 +1,151 @@
+import { DataSource } from 'typeorm';
+import {
+    IssuanceRepository,
+    IssuanceListQuery,
+    IssuanceListResult,
+    IssuanceListRow,
+} from './issuance.repository';
+
+// COALESCE expressions used in both SELECT and ORDER BY / WHERE
+const TOKEN_ID_EXPR = `COALESCE(pml.token_id, m.documents -> 'credentialSubject' -> 0 ->> 'tokenId')`;
+const AMOUNT_EXPR = `COALESCE(pml.amount, (m.documents -> 'credentialSubject' -> 0 ->> 'amount')::numeric)`;
+const MINT_DATE_EXPR = `COALESCE(pml.mint_date::date, to_timestamp(m."consensusTimestamp"::double precision)::date)`;
+
+const SORT_COLUMN_MAP: Record<string, string> = {
+    mintDate: MINT_DATE_EXPR,
+    amount: AMOUNT_EXPR,
+    projectName: `proj."displayName"`,
+    tokenId: TOKEN_ID_EXPR,
+};
+
+const BASE_FROM = `
+    FROM message m
+    LEFT JOIN project_mint_link pml ON pml.mint_consensus_timestamp = m."consensusTimestamp"
+    LEFT JOIN business_view proj
+        ON proj."sourceTimestamp" = pml.project_source_timestamp
+        AND proj."viewType" = 'PROJECT'
+    LEFT JOIN LATERAL (
+        SELECT "displayName" AS registry_name
+        FROM business_view
+        WHERE "viewType" = 'REGISTRY'
+          AND "registryDid" = proj."registryDid"
+        ORDER BY "createdAt" DESC NULLS LAST
+        LIMIT 1
+    ) reg ON true
+    LEFT JOIN token_cache tc ON tc."tokenId" = ${TOKEN_ID_EXPR}
+`;
+
+export class PgIssuanceRepository extends IssuanceRepository {
+    constructor(private readonly dataSource: DataSource) {
+        super();
+    }
+
+    async findAll(query: IssuanceListQuery): Promise<IssuanceListResult> {
+        const { page, limit, search, sortBy, sortDir, dateFrom, dateTo, tokenType, projectId } = query;
+        const offset = (page - 1) * limit;
+
+        const params: unknown[] = [];
+        const whereClauses: string[] = [
+            `m.type = 'VC-Document'`,
+            `m.documents -> 'credentialSubject' -> 0 ->> 'type' ILIKE '%MintToken%'`,
+        ];
+
+        const addParam = (value: unknown): string => {
+            params.push(value);
+            return `$${params.length}`;
+        };
+
+        if (dateFrom) {
+            whereClauses.push(`${MINT_DATE_EXPR} >= ${addParam(dateFrom)}::date`);
+        }
+        if (dateTo) {
+            whereClauses.push(`${MINT_DATE_EXPR} <= ${addParam(dateTo)}::date`);
+        }
+        if (tokenType) {
+            whereClauses.push(`tc.type = ${addParam(tokenType)}`);
+        }
+        if (projectId) {
+            whereClauses.push(`pml.project_source_timestamp = ${addParam(projectId)}`);
+        }
+        if (search) {
+            const like = `%${search.trim()}%`;
+            whereClauses.push(
+                `(proj."displayName" ILIKE ${addParam(like)} OR tc.name ILIKE ${addParam(like)} OR ${TOKEN_ID_EXPR} ILIKE ${addParam(like)})`,
+            );
+        }
+
+        const whereClause = `WHERE ${whereClauses.join(' AND ')}`;
+
+        const sortExpr = SORT_COLUMN_MAP[sortBy ?? ''] ?? MINT_DATE_EXPR;
+        const dir = sortDir === 'asc' ? 'ASC' : 'DESC';
+        const orderBy = `${sortExpr} ${dir} NULLS LAST, m."consensusTimestamp" DESC`;
+
+        const limitParam = addParam(limit);
+        const offsetParam = addParam(offset);
+
+        const rowsSql = `
+            SELECT
+                m."consensusTimestamp"                              AS mint_consensus_timestamp,
+                ${TOKEN_ID_EXPR}                                    AS token_id,
+                ${AMOUNT_EXPR}                                      AS amount,
+                ${MINT_DATE_EXPR}                                   AS mint_date,
+                pml.link_method,
+                pml.project_source_timestamp                        AS project_id,
+                proj."displayName"                                  AS project_name,
+                proj."businessData" ->> 'methodology'               AS methodology,
+                proj."businessData" ->> 'methodologyId'             AS methodology_id,
+                proj."businessData" ->> 'country'                   AS country,
+                reg.registry_name,
+                tc.name                                             AS token_name,
+                tc.symbol,
+                tc.type                                             AS token_type
+            ${BASE_FROM}
+            ${whereClause}
+            ORDER BY ${orderBy}
+            LIMIT ${limitParam} OFFSET ${offsetParam}
+        `;
+
+        const countParams = params.slice(0, params.length - 2);
+        const countSql = `SELECT COUNT(*)::int AS total ${BASE_FROM} ${whereClause}`;
+
+        const [rawRows, countResult]: [
+            Array<Record<string, unknown>>,
+            Array<{ total: number }>,
+        ] = await Promise.all([
+            this.dataSource.query(rowsSql, params),
+            this.dataSource.query(countSql, countParams),
+        ]);
+
+        return {
+            rows: rawRows.map(r => PgIssuanceRepository.mapRow(r)),
+            total: countResult[0]?.total ?? 0,
+        };
+    }
+
+    private static mapRow(r: Record<string, unknown>): IssuanceListRow {
+        const mintDate = r['mint_date'];
+        let mintDateStr: string | null = null;
+        if (mintDate instanceof Date) {
+            mintDateStr = mintDate.toISOString().split('T')[0];
+        } else if (typeof mintDate === 'string' && mintDate) {
+            mintDateStr = mintDate.split('T')[0];
+        }
+
+        return {
+            mintConsensusTimestamp: String(r['mint_consensus_timestamp'] ?? ''),
+            tokenId: r['token_id'] != null ? String(r['token_id']) : null,
+            tokenName: r['token_name'] != null ? String(r['token_name']) : null,
+            symbol: r['symbol'] != null ? String(r['symbol']) : null,
+            tokenType: r['token_type'] != null ? String(r['token_type']) : null,
+            amount: r['amount'] != null ? Number(r['amount']) : 0,
+            mintDate: mintDateStr,
+            projectId: r['project_id'] != null ? String(r['project_id']) : null,
+            projectName: r['project_name'] != null ? String(r['project_name']) : null,
+            methodology: r['methodology'] != null ? String(r['methodology']) : null,
+            methodologyId: r['methodology_id'] != null ? String(r['methodology_id']) : null,
+            country: r['country'] != null ? String(r['country']) : null,
+            registry: r['registry_name'] != null ? String(r['registry_name']) : null,
+            linkMethod: r['link_method'] != null ? String(r['link_method']) : 'unlinked',
+        };
+    }
+}

--- a/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
@@ -187,56 +187,85 @@ export class PgMethodologyRepository extends MethodologyRepository {
 
         const row = rawRows[0];
 
-        // Resolve the topic IDs to look up CREDIT rows.
-        // businessData.policyTopicId is the Guardian policy topic; relatedTopicId is the
-        // instance topic stored on the business_view row. We union both and deduplicate
-        // so that credits linked to either topic are captured.
         const policyTopicId = (row.businessData as Record<string, any> | null)?.['topicId'] as string | null;
         const instanceTopicId = row.relatedTopicId;
-        const topicIds = [...new Set([policyTopicId, instanceTopicId].filter((t): t is string => !!t))];
+
+        // Expand topic search to include all project instance topics under this methodology
+        // so MintToken VCs on project sub-topics are captured alongside those on the
+        // methodology's own instance topic.
+        const projectTopicRows: Array<{ relatedTopicId: string }> = policyTopicId
+            ? await this.dataSource.query(
+                `SELECT DISTINCT "relatedTopicId"
+                 FROM business_view
+                 WHERE "viewType" = 'PROJECT'
+                   AND "businessData"->>'policyTopicId' = $1
+                   AND "relatedTopicId" IS NOT NULL`,
+                [policyTopicId],
+            )
+            : [];
+
+        const topicIds = [
+            ...new Set([
+                policyTopicId,
+                instanceTopicId,
+                ...projectTopicRows.map(r => r.relatedTopicId),
+            ].filter((t): t is string => !!t)),
+        ];
 
         let issuances: IssuanceRow[] = [];
         if (topicIds.length > 0) {
-            const placeholders = topicIds.map((_, i) => `$${i + 1}`).join(', ');
-            const creditRows: Array<{
-                tokenId: string | null;
-                name: string | null;
-                symbol: string | null;
-                type: string | null;
-                supply: string | null;
-                mintDate: Date | null;
-                raw_vc: Record<string, any> | null;
+            const mintTokenRows: Array<{
+                token_id: string | null;
+                amount: string | null;
+                mint_date: string | null;
+                documents: Record<string, any> | null;
             }> = await this.dataSource.query(
-                `
-                SELECT
-                    COALESCE(tc."tokenId", bv."businessData"->>'tokenId') AS "tokenId",
-                    COALESCE(tc.name,      bv."displayName")              AS name,
-                    COALESCE(tc.symbol,    bv."businessData"->>'symbol')  AS symbol,
-                    tc.type,
-                    tc."totalSupply"                                      AS supply,
-                    bv."createdAt"                                        AS "mintDate",
-                    m.documents                                           AS raw_vc
-                FROM business_view bv
-                LEFT JOIN token_cache tc
-                    ON tc."tokenId" = bv."businessData"->>'tokenId'
-                LEFT JOIN message m
-                    ON m."consensusTimestamp" = bv."sourceTimestamp"
-                WHERE bv."viewType" = 'CREDIT'
-                  AND bv."relatedTopicId" IN (${placeholders})
-                ORDER BY bv."createdAt" ASC
-                `,
-                topicIds,
+                `SELECT
+                    m.documents -> 'credentialSubject' -> 0 ->> 'tokenId' AS token_id,
+                    m.documents -> 'credentialSubject' -> 0 ->> 'amount'  AS amount,
+                    m.documents -> 'credentialSubject' -> 0 ->> 'date'    AS mint_date,
+                    m.documents
+                 FROM message m
+                 WHERE m."topicId" = ANY($1::varchar[])
+                   AND m.type = 'VC-Document'
+                   AND m.documents -> 'credentialSubject' -> 0 ->> 'type' ILIKE '%MintToken%'
+                 ORDER BY m."consensusTimestamp" ASC`,
+                [topicIds],
             );
 
-            issuances = creditRows.map(r => ({
-                tokenId: r.tokenId ?? '',
-                name: r.name ?? null,
-                symbol: r.symbol ?? null,
-                type: r.type ?? null,
-                supply: r.supply != null ? parseFloat(r.supply) : 0,
-                mintDate: r.mintDate ? r.mintDate.toISOString().split('T')[0] : null,
-                rawVc: r.raw_vc ?? null,
-            }));
+            if (mintTokenRows.length > 0) {
+                const mintsByToken = new Map<string, { total: number; mintDate: string | null; rawVc: Record<string, any> | null }>();
+                for (const r of mintTokenRows) {
+                    if (!r.token_id) continue;
+                    const existing = mintsByToken.get(r.token_id) ?? { total: 0, mintDate: r.mint_date, rawVc: r.documents };
+                    existing.total += r.amount != null ? Number(r.amount) : 0;
+                    existing.rawVc = r.documents;
+                    mintsByToken.set(r.token_id, existing);
+                }
+
+                const distinctTokenIds = Array.from(mintsByToken.keys());
+                const tokenMeta: Array<{ tokenId: string; name: string | null; symbol: string | null; type: string | null }> =
+                    await this.dataSource.query(
+                        `SELECT "tokenId", name, symbol, type
+                         FROM token_cache
+                         WHERE "tokenId" = ANY($1::varchar[])`,
+                        [distinctTokenIds],
+                    );
+                const metaMap = new Map(tokenMeta.map(t => [t.tokenId, t]));
+
+                issuances = [...mintsByToken.entries()].map(([tokenId, data]) => {
+                    const meta = metaMap.get(tokenId);
+                    return {
+                        tokenId,
+                        name: meta?.name ?? null,
+                        symbol: meta?.symbol ?? null,
+                        type: meta?.type ?? null,
+                        supply: data.total,
+                        mintDate: data.mintDate ? new Date(data.mintDate).toISOString().split('T')[0] : null,
+                        rawVc: data.rawVc,
+                    };
+                });
+            }
         }
 
         // Aggregate lifecycle stats for NFT tokens: total minted (all serials) and
@@ -263,9 +292,20 @@ export class PgMethodologyRepository extends MethodologyRepository {
                     [nftTokenIds],
                 );
 
+            const nftStatMap = new Map(nftStats.map(s => [s.tokenId, s]));
+
             for (const s of nftStats) {
                 totalIssued += parseInt(s.total_minted, 10);
                 totalRetired += parseInt(s.total_retired, 10);
+            }
+
+            // nft_cache is ground truth for NFT supply — overwrite VC-derived supply
+            // which can be incomplete when mints occurred on sub-topics not searched.
+            for (const issuance of issuances) {
+                if (issuance.type === TokenType.NonFungibleUnique) {
+                    const stat = nftStatMap.get(issuance.tokenId);
+                    if (stat) issuance.supply = parseInt(stat.total_minted, 10);
+                }
             }
         }
 

--- a/sustainable-explorer/src/api/repositories/pg-project.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-project.repository.ts
@@ -42,22 +42,11 @@ const REGISTRY_NAME_JOIN = `
     ) reg ON true
 `;
 
-/**
- * LATERAL subquery joined into findAll to count per-project MintToken VCs
- * published back to the project's instance topic by Guardian after each mint.
- *
- * Guardian encodes the credentialSubject type differently across versions:
- *   older: plain "MintToken"
- *   newer: "{uuid}&#MintToken&{version}" (schema IRI format)
- * ILIKE '%MintToken%' handles both.
- */
 const ISSUANCE_COUNT_JOIN = `
     LEFT JOIN LATERAL (
         SELECT COUNT(*)::int AS issuance_count
-        FROM message m
-        WHERE m."topicId" = bv."relatedTopicId"
-          AND m.type = 'VC-Document'
-          AND m.documents -> 'credentialSubject' -> 0 ->> 'type' ILIKE '%MintToken%'
+        FROM project_mint_link pml
+        WHERE pml.project_source_timestamp = bv."sourceTimestamp"
     ) mint ON true
 `;
 
@@ -178,9 +167,11 @@ export class PgProjectRepository extends ProjectRepository {
             `
             SELECT
                 bv.*,
-                reg.registry_name
+                reg.registry_name,
+                mint.issuance_count
             FROM business_view bv
             ${REGISTRY_NAME_JOIN}
+            ${ISSUANCE_COUNT_JOIN}
             WHERE bv."viewType" = 'PROJECT'
               AND bv."sourceTimestamp" = $1
             LIMIT 1
@@ -194,41 +185,39 @@ export class PgProjectRepository extends ProjectRepository {
         const policyTopicId = (row.businessData as Record<string, any> | null)?.['policyTopicId'] as string | null;
         const instanceTopicId = row.relatedTopicId;
 
-        // Step 1 — try per-project attribution via MintToken VCs published back to
-        // the project's instance topic by Guardian after each mint event.
-        // Each MintToken VC has: { type: "MintToken", tokenId, amount, date }
+        // Step 1 — look up per-project mints from project_mint_link.
+        // The linker pre-resolves each MintToken to its specific project via the
+        // relationships chain, so grouped projects (multiple projects per instance
+        // topic) are correctly split rather than double-counted.
         let issuances: IssuanceRow[] = [];
         let totalIssued = 0;
         let totalRetired = 0;
 
         const mintTokenRows: Array<{
             token_id: string | null;
-            amount: string | null;
-            mint_date: string | null;
+            amount: number | null;
+            mint_date: Date | null;
             documents: Record<string, any> | null;
-        }> = instanceTopicId
-            ? await this.dataSource.query(
-                `SELECT
-                    m.documents -> 'credentialSubject' -> 0 ->> 'tokenId' AS token_id,
-                    m.documents -> 'credentialSubject' -> 0 ->> 'amount'  AS amount,
-                    m.documents -> 'credentialSubject' -> 0 ->> 'date'    AS mint_date,
-                    m.documents
-                 FROM message m
-                 WHERE m."topicId" = $1
-                   AND m.type = 'VC-Document'
-                   AND m.documents -> 'credentialSubject' -> 0 ->> 'type' ILIKE '%MintToken%'
-                 ORDER BY m."consensusTimestamp" ASC`,
-                [instanceTopicId],
-            )
-            : [];
+        }> = await this.dataSource.query(
+            `SELECT
+                pml.token_id,
+                pml.amount,
+                pml.mint_date,
+                m.documents
+             FROM project_mint_link pml
+             JOIN message m ON m."consensusTimestamp" = pml.mint_consensus_timestamp
+             WHERE pml.project_source_timestamp = $1
+             ORDER BY pml.mint_date ASC NULLS LAST`,
+            [id],
+        );
 
         if (mintTokenRows.length > 0) {
             // Aggregate minted amount per token; keep last MintToken VC as raw data
-            const mintsByToken = new Map<string, { total: number; mintDate: string | null; rawVc: Record<string, any> | null }>();
+            const mintsByToken = new Map<string, { total: number; mintDate: Date | null; rawVc: Record<string, any> | null }>();
             for (const r of mintTokenRows) {
                 if (!r.token_id) continue;
                 const existing = mintsByToken.get(r.token_id) ?? { total: 0, mintDate: r.mint_date, rawVc: r.documents };
-                existing.total += parseInt(r.amount ?? '0', 10);
+                existing.total += r.amount != null ? Number(r.amount) : 0;
                 existing.rawVc = r.documents;
                 mintsByToken.set(r.token_id, existing);
             }
@@ -257,7 +246,7 @@ export class PgProjectRepository extends ProjectRepository {
                     type: meta?.type ?? null,
                     supply: data.total,
                     mintDate: data.mintDate
-                        ? new Date(data.mintDate).toISOString().split('T')[0]
+                        ? data.mintDate.toISOString().split('T')[0]
                         : null,
                     rawVc: data.rawVc,
                 };

--- a/sustainable-explorer/src/api/repositories/pg-summary.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-summary.repository.ts
@@ -10,7 +10,8 @@ export class PgSummaryRepository {
                 SELECT
                     (documents -> 'credentialSubject' -> 0 ->> 'amount')::numeric AS amount,
                     "consensusTimestamp"::double precision                          AS ts,
-                    documents -> 'credentialSubject' -> 0 ->> 'tokenId'            AS token_id
+                    "consensusTimestamp"                                            AS consensus_ts,
+                    documents ->> 'issuer'                                         AS issuer_did
                 FROM message
                 WHERE type = 'VC-Document'
                   AND documents -> 'credentialSubject' -> 0 ->> 'type' ILIKE '%MintToken%'
@@ -31,18 +32,35 @@ export class PgSummaryRepository {
                     SELECT json_agg(r ORDER BY r.total_issued DESC)
                     FROM (
                         SELECT
-                            COALESCE(bv_reg."displayName", bv_credit."registryDid", 'Unknown') AS registry,
+                            COALESCE(reg.display_name, m.issuer_did, 'Unknown') AS registry,
                             SUM(m.amount)::bigint AS total_issued
                         FROM mints m
-                        LEFT JOIN business_view bv_credit
-                            ON bv_credit."viewType" = 'CREDIT'
-                            AND bv_credit."businessData" ->> 'tokenId' = m.token_id
-                        LEFT JOIN business_view bv_reg
-                            ON bv_reg."viewType" = 'REGISTRY'
-                            AND bv_reg."registryDid" = bv_credit."registryDid"
+                        LEFT JOIN LATERAL (
+                            SELECT "displayName" AS display_name
+                            FROM business_view
+                            WHERE "viewType" = 'REGISTRY'
+                              AND "registryDid" = m.issuer_did
+                            ORDER BY "createdAt" DESC NULLS LAST
+                            LIMIT 1
+                        ) reg ON m.issuer_did IS NOT NULL
                         GROUP BY 1
                     ) r
-                ) AS registry_breakdown
+                ) AS registry_breakdown,
+                (
+                    SELECT json_agg(s ORDER BY s.total_issued DESC)
+                    FROM (
+                        SELECT
+                            COALESCE(NULLIF(proj."businessData" ->> 'sector', ''), 'Others') AS sector,
+                            SUM(m.amount)::bigint AS total_issued
+                        FROM mints m
+                        JOIN project_mint_link pml
+                            ON pml.mint_consensus_timestamp = m.consensus_ts
+                        JOIN business_view proj
+                            ON proj."sourceTimestamp" = pml.project_source_timestamp
+                            AND proj."viewType" = 'PROJECT'
+                        GROUP BY 1
+                    ) s
+                ) AS sector_breakdown
         `;
 
         const retiredSql = `
@@ -56,6 +74,7 @@ export class PgSummaryRepository {
                 total_issued: string;
                 timeline: Array<{ period: string; total_issued: string }> | null;
                 registry_breakdown: Array<{ registry: string; total_issued: string }> | null;
+                sector_breakdown: Array<{ sector: string; total_issued: string }> | null;
             }>,
             Array<{ total_retired: string }>,
         ] = await Promise.all([
@@ -78,6 +97,10 @@ export class PgSummaryRepository {
             registryBreakdown: (row?.registry_breakdown ?? []).map(r => ({
                 registry: r.registry,
                 totalIssued: parseInt(r.total_issued, 10),
+            })),
+            sectorBreakdown: (row?.sector_breakdown ?? []).map(s => ({
+                sector: s.sector,
+                totalIssued: parseInt(s.total_issued, 10),
             })),
         };
     }

--- a/sustainable-explorer/src/api/services/issuance.service.ts
+++ b/sustainable-explorer/src/api/services/issuance.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { IssuanceQueryDto, IssuanceListItemDto, PaginatedIssuancesDto } from '../dto/issuance.dto';
+import { PaginatedResponse } from '../dto/pagination.dto';
+import { NetworkDataSourceRegistry } from '../database/network-datasource.registry';
+import { PgIssuanceRepository } from '../repositories/pg-issuance.repository';
+
+@Injectable()
+export class IssuancesService {
+    constructor(private readonly dataSources: NetworkDataSourceRegistry) {}
+
+    async findAll(
+        network: string,
+        query: IssuanceQueryDto,
+    ): Promise<PaginatedIssuancesDto> {
+        const ds = this.dataSources.getDataSource(network);
+        const repo = new PgIssuanceRepository(ds);
+
+        const page = query.page ?? 1;
+        const limit = query.limit ?? 20;
+
+        const result = await repo.findAll({
+            page,
+            limit,
+            search: query.search,
+            sortBy: query.sortBy,
+            sortDir: query.sortDir,
+            dateFrom: query.dateFrom,
+            dateTo: query.dateTo,
+            tokenType: query.tokenType,
+            projectId: query.projectId,
+        });
+
+        const data = result.rows.map(row => IssuanceListItemDto.fromRow(row));
+        return new PaginatedResponse(data, result.total, page, limit) as PaginatedIssuancesDto;
+    }
+}

--- a/sustainable-explorer/src/shared/materialized-views/methodology-stats.mv.ts
+++ b/sustainable-explorer/src/shared/materialized-views/methodology-stats.mv.ts
@@ -32,11 +32,23 @@ export const MV_METHODOLOGY_STATS_CREATE_SQL = `
               AND p."businessData"->>'policyTopicId' = mb.policy_topic_id
         ), 0)::bigint AS project_count,
         COALESCE((
-            SELECT COUNT(*)
+            SELECT COUNT(DISTINCT m.documents -> 'credentialSubject' -> 0 ->> 'tokenId')
             FROM message m
-            WHERE m."topicId" = mb.policy_topic_id
-              AND m.type = 'Token'
-              AND m.options->>'tokenId' IS NOT NULL
+            WHERE m.type = 'VC-Document'
+              AND m.documents -> 'credentialSubject' -> 0 ->> 'type' ILIKE '%MintToken%'
+              AND m.documents -> 'credentialSubject' -> 0 ->> 'tokenId' IS NOT NULL
+              AND m."topicId" IN (
+                  SELECT topic FROM (
+                      VALUES (mb.policy_topic_id), (mb."relatedTopicId")
+                      UNION ALL
+                      SELECT bv."relatedTopicId"
+                      FROM business_view bv
+                      WHERE bv."viewType" = 'PROJECT'
+                        AND bv."businessData"->>'policyTopicId' = mb.policy_topic_id
+                        AND bv."relatedTopicId" IS NOT NULL
+                  ) t(topic)
+                  WHERE topic IS NOT NULL
+              )
         ), 0)::bigint AS issuance_count,
         COALESCE((
             SELECT COUNT(DISTINCT ps."schemaId")

--- a/sustainable-explorer/src/worker/processors/business-view-builder.processor.ts
+++ b/sustainable-explorer/src/worker/processors/business-view-builder.processor.ts
@@ -5,6 +5,7 @@ import { DataSource } from "typeorm";
 import Redis from "ioredis";
 import { QUEUE_NAMES } from "@shared/config/bullmq.config";
 import { buildProjectViewsPolicyBased } from "../project-mapper/improved-heuristic.mapper";
+import { ensureMintProjectLinkTable, buildMintProjectLinks } from "../project-mapper/mint-project-linker";
 
 /**
  * Mapping from HCS message types to business domain view types.
@@ -35,6 +36,10 @@ export class BusinessViewBuilderProcessor extends WorkerHost {
         @Inject("REDICT_PUB") private readonly redis: Redis,
     ) {
         super();
+    }
+
+    async onModuleInit(): Promise<void> {
+        await ensureMintProjectLinkTable(this.dataSource);
     }
 
     async process(job: Job): Promise<void> {
@@ -142,6 +147,8 @@ export class BusinessViewBuilderProcessor extends WorkerHost {
             default:
                 await buildProjectViewsPolicyBased(this.dataSource, this.logger);
         }
+
+        await buildMintProjectLinks(this.dataSource, this.logger);
 
         await this.redis.publish(
             "se:events",

--- a/sustainable-explorer/src/worker/processors/mv-refresh.processor.ts
+++ b/sustainable-explorer/src/worker/processors/mv-refresh.processor.ts
@@ -18,20 +18,24 @@ export class MvRefreshProcessor extends WorkerHost implements OnModuleInit {
     }
 
     /**
-     * Ensures all registered materialized views exist on startup.
-     * Uses CREATE MATERIALIZED VIEW IF NOT EXISTS — safe to run repeatedly.
+     * Recreates all registered materialized views on startup so SQL definition
+     * changes take effect automatically without manual DB intervention.
+     * The AS SELECT clause populates data immediately on creation.
      */
     async onModuleInit(): Promise<void> {
         for (const mv of MATERIALIZED_VIEWS) {
             try {
+                await this.dataSource.query(
+                    `DROP MATERIALIZED VIEW IF EXISTS ${mv.name} CASCADE`,
+                );
                 await this.dataSource.query(mv.createSql);
                 if (mv.indexSql) {
                     await this.dataSource.query(mv.indexSql);
                 }
-                this.logger.log(`Ensured materialized view: ${mv.name}`);
+                this.logger.log(`Recreated materialized view: ${mv.name}`);
             } catch (error: unknown) {
                 const message = error instanceof Error ? error.message : String(error);
-                this.logger.error(`Failed to ensure materialized view ${mv.name}: ${message}`);
+                this.logger.error(`Failed to recreate materialized view ${mv.name}: ${message}`);
             }
         }
     }

--- a/sustainable-explorer/src/worker/project-mapper/improved-heuristic.mapper.ts
+++ b/sustainable-explorer/src/worker/project-mapper/improved-heuristic.mapper.ts
@@ -374,6 +374,43 @@ export async function buildProjectViewsPolicyBased(
                 confirmed.resolvedFields = resolveFieldPaths(confirmed.fieldMap);
                 newlyConfirmed.set(topicId, confirmed);
                 confirmedByTopic.set(topicId, confirmed);
+            } else if (entries.length > 1) {
+                // TIE: multiple schemas pass geo+name. Apply tiebreaker: keep only
+                // schemas whose UUID actually appears in VC credentialSubject.type.
+                // Sub-schemas (like "Project Description" embedded inside "Project")
+                // are never used directly as VC types and are eliminated here.
+                const tiedUuids = entries.map(e => e.schemaUuid);
+                const vcMatches: Array<{ schema_id: string }> = await dataSource.query(`
+                    SELECT DISTINCT split_part(
+                        documents->'credentialSubject'->0->>'type', '&', 1
+                    ) AS schema_id
+                    FROM message
+                    WHERE type = 'VC-Document'
+                      AND split_part(
+                            documents->'credentialSubject'->0->>'type', '&', 1
+                          ) = ANY($1)
+                    LIMIT $2
+                `, [tiedUuids, tiedUuids.length]);
+
+                const usedUuids = new Set(vcMatches.map(r => r.schema_id));
+                const surviving = entries.filter(e => usedUuids.has(e.schemaUuid));
+
+                if (surviving.length === 1) {
+                    const confirmed = surviving[0];
+                    confirmed.resolvedFields = resolveFieldPaths(confirmed.fieldMap);
+                    newlyConfirmed.set(topicId, confirmed);
+                    confirmedByTopic.set(topicId, confirmed);
+                    logger.log(
+                        `Schema TIE resolved for topic ${topicId}: ` +
+                        `confirmed ${confirmed.schemaUuid} (only tied schema found in VCs)`,
+                    );
+                } else {
+                    logger.warn(
+                        `Schema TIE unresolved for topic ${topicId}: ` +
+                        `${entries.length} schemas pass geo+name, ` +
+                        `${surviving.length} appear in VCs — skipping confirmation`,
+                    );
+                }
             }
         }
 

--- a/sustainable-explorer/src/worker/project-mapper/mint-project-linker.ts
+++ b/sustainable-explorer/src/worker/project-mapper/mint-project-linker.ts
@@ -1,0 +1,175 @@
+import { Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+/**
+ * Ensures the project_mint_link table exists.
+ * Called once from BusinessViewBuilderProcessor.onModuleInit().
+ */
+export async function ensureMintProjectLinkTable(dataSource: DataSource): Promise<void> {
+    await dataSource.query(`
+        CREATE TABLE IF NOT EXISTS project_mint_link (
+            mint_consensus_timestamp varchar(30)  PRIMARY KEY,
+            project_source_timestamp varchar(30)  NOT NULL,
+            project_topic_id         varchar(20)  NOT NULL,
+            token_id                 varchar(20),
+            amount                   bigint,
+            mint_date                timestamptz,
+            link_method              varchar(20)  NOT NULL DEFAULT 'topic_scope'
+        );
+        CREATE INDEX IF NOT EXISTS idx_pml_project_src
+            ON project_mint_link (project_source_timestamp);
+        CREATE INDEX IF NOT EXISTS idx_pml_token_id
+            ON project_mint_link (token_id);
+    `);
+}
+
+/**
+ * Resolves each unlinked MintToken VC to its specific project and upserts
+ * the result into project_mint_link.
+ *
+ * Called directly from BusinessViewBuilderProcessor after project views are
+ * built — no separate queue needed, the whole run takes a few seconds.
+ *
+ * Resolution strategy:
+ *   1. Walk options.relationships recursively (up to 15 hops) until an
+ *      ancestor consensusTimestamp matches a business_view PROJECT row.
+ *      Using sourceTimestamp as the project key correctly splits grouped
+ *      projects (multiple project VCs sharing one instance topic).
+ *   2. Fallback to topic-scope only when the instance topic has exactly one
+ *      project. Grouped topics without a resolved chain are skipped.
+ */
+export async function buildMintProjectLinks(
+    dataSource: DataSource,
+    logger: Logger,
+): Promise<void> {
+    const unlinked: Array<{
+        consensusTimestamp: string;
+        topicId: string;
+        token_id: string | null;
+        amount: string | null;
+        mint_date: string | null;
+    }> = await dataSource.query(`
+        SELECT
+            m."consensusTimestamp",
+            m."topicId",
+            m.documents->'credentialSubject'->0->>'tokenId' AS token_id,
+            m.documents->'credentialSubject'->0->>'amount'  AS amount,
+            m.documents->'credentialSubject'->0->>'date'    AS mint_date
+        FROM message m
+        WHERE m.type = 'VC-Document'
+          AND m.documents->'credentialSubject'->0->>'type' ILIKE '%MintToken%'
+          AND NOT EXISTS (
+              SELECT 1 FROM project_mint_link pml
+              WHERE pml.mint_consensus_timestamp = m."consensusTimestamp"
+          )
+        ORDER BY m."consensusTimestamp"
+    `);
+
+    if (unlinked.length === 0) return;
+
+    logger.log(`MintProjectLinker: linking ${unlinked.length} new mint(s)`);
+
+    let linked = 0;
+    let fallback = 0;
+    let skipped = 0;
+
+    for (const mint of unlinked) {
+        // Step 1 — relationship chain traversal
+        const chainRows: Array<{ project_source_timestamp: string; project_topic_id: string }> =
+            await dataSource.query(`
+                WITH RECURSIVE rel_chain(ts, depth) AS (
+                    SELECT
+                        jsonb_array_elements_text(m.options->'relationships')::varchar AS ts,
+                        1 AS depth
+                    FROM message m
+                    WHERE m."consensusTimestamp" = $1
+                      AND m.options->'relationships' IS NOT NULL
+                      AND jsonb_typeof(m.options->'relationships') = 'array'
+                      AND jsonb_array_length(m.options->'relationships') > 0
+
+                    UNION ALL
+
+                    SELECT
+                        jsonb_array_elements_text(p.options->'relationships')::varchar,
+                        rc.depth + 1
+                    FROM rel_chain rc
+                    JOIN message p ON p."consensusTimestamp" = rc.ts
+                    WHERE rc.depth < 15
+                      AND p.options->'relationships' IS NOT NULL
+                      AND p.options->'relationships' != 'null'::jsonb
+                      AND jsonb_typeof(p.options->'relationships') = 'array'
+                )
+                SELECT
+                    bv."sourceTimestamp"  AS project_source_timestamp,
+                    bv."relatedTopicId"   AS project_topic_id
+                FROM rel_chain rc
+                JOIN business_view bv
+                    ON bv."sourceTimestamp" = rc.ts
+                   AND bv."viewType" = 'PROJECT'
+                ORDER BY rc.depth ASC
+                LIMIT 1
+            `, [mint.consensusTimestamp]);
+
+        let projectSourceTs: string;
+        let projectTopicId: string;
+        let linkMethod: string;
+
+        if (chainRows.length > 0) {
+            projectSourceTs = chainRows[0].project_source_timestamp;
+            projectTopicId = chainRows[0].project_topic_id;
+            linkMethod = 'relationship';
+            linked++;
+        } else {
+            // Step 2 — topic-scope fallback (only for unambiguous single-project topics)
+            const fallbackRows: Array<{ sourceTimestamp: string; relatedTopicId: string }> =
+                await dataSource.query(`
+                    SELECT "sourceTimestamp", "relatedTopicId"
+                    FROM business_view
+                    WHERE "viewType" = 'PROJECT'
+                      AND "relatedTopicId" = $1
+                `, [mint.topicId]);
+
+            if (fallbackRows.length !== 1) {
+                if (fallbackRows.length > 1) {
+                    logger.warn(
+                        `MintToken ${mint.consensusTimestamp}: grouped topic ${mint.topicId} — ` +
+                        `chain unresolved, skipping to avoid misattribution`,
+                    );
+                }
+                skipped++;
+                continue;
+            }
+
+            projectSourceTs = fallbackRows[0].sourceTimestamp;
+            projectTopicId = fallbackRows[0].relatedTopicId;
+            linkMethod = 'topic_scope';
+            fallback++;
+        }
+
+        const amount = mint.amount != null ? Math.round(parseFloat(mint.amount)) : null;
+        const mintDate = mint.mint_date ? new Date(mint.mint_date) : null;
+
+        await dataSource.query(`
+            INSERT INTO project_mint_link (
+                mint_consensus_timestamp,
+                project_source_timestamp,
+                project_topic_id,
+                token_id,
+                amount,
+                mint_date,
+                link_method
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (mint_consensus_timestamp) DO UPDATE SET
+                project_source_timestamp = EXCLUDED.project_source_timestamp,
+                project_topic_id         = EXCLUDED.project_topic_id,
+                token_id                 = EXCLUDED.token_id,
+                amount                   = EXCLUDED.amount,
+                mint_date                = EXCLUDED.mint_date,
+                link_method              = EXCLUDED.link_method
+        `, [mint.consensusTimestamp, projectSourceTs, projectTopicId, mint.token_id, amount, mintDate, linkMethod]);
+    }
+
+    logger.log(
+        `MintProjectLinker: ${linked} via relationship, ${fallback} via topic-scope, ${skipped} skipped`,
+    );
+}


### PR DESCRIPTION
**Strategy A — Relationship Chain Traversal (preferred)**

Each HCS message (MintToken) has a options.relationships field — an array of ancestor consensusTimestamp values pointing to earlier messages in the same workflow.

  1. Walk that chain recursively (up to 15 hops)
  2. For each ancestor timestamp, check if it exists in business_view as a viewType = 'PROJECT' row (matching on
  sourceTimestamp)
  3. If found → that project "owns" this mint

This is the accurate path because multiple projects can live on the same Guardian instance topic. Using
sourceTimestamp as the key (not topicId) correctly splits them apart.

 **Strategy B — Topic-scope Fallback**

 If no relationship chain resolves:
  1. Look up which project's relatedTopicId matches the mint's topicId
  2. Only proceed if exactly one project maps to that topic — if multiple projects share it, skip entirely to avoid
  misattribution