### PR TITLE
feat: implement of Sync Status page and QueueEventsBus for BullMQ and…

### DIFF
--- a/sustainable-explorer/.env.example
+++ b/sustainable-explorer/.env.example
@@ -78,6 +78,19 @@ GEMINI_MODEL=gemini-2.5-flash
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4.1-mini
 
+# --- Worker Autoscaler — maximum concurrency ceiling per queue ---
+# The in-process autoscaler raises concurrency when waiting > 100 and lowers
+# it when the queue drains. These caps prevent runaway scaling.
+# Pattern: WORKER_<QUEUE_BASE_UPPER>_MAX_CONCURRENCY
+# Defaults to max(baseline × 4, baseline + 4) when not set.
+WORKER_MIRROR_NODE_TOPICS_MAX_CONCURRENCY=
+WORKER_MIRROR_NODE_MESSAGES_MAX_CONCURRENCY=
+WORKER_MIRROR_NODE_TOKENS_MAX_CONCURRENCY=
+WORKER_IPFS_FILES_MAX_CONCURRENCY=
+WORKER_POLICY_DECODE_MAX_CONCURRENCY=
+WORKER_MAINTENANCE_REFRESH_MVS_MAX_CONCURRENCY=
+WORKER_MAINTENANCE_BUILD_BUSINESS_VIEWS_MAX_CONCURRENCY=
+
 # --- Maintenance ---
 MV_REFRESH_INTERVAL=60
 
@@ -89,3 +102,20 @@ MIRROR_NODE_POLL_DELAY=30000
 # --- Logging ---
 LOG_LEVEL=info
 GUARDIAN_ENV=
+
+# --- Frontend (Nuxt) ---
+# Server-side SSR fetch base URL — the URL Nuxt uses on the server to call the API.
+# In Docker: set to http://api:3030 (internal service name).
+# In dev: leave blank — defaults to http://localhost:3030.
+NUXT_API_BASE_URL=
+
+# Client-side API base URL — the URL the browser uses to call the API.
+# In dev: leave blank — Nuxt proxies /api/v1/** to localhost:3030 via routeRules.
+# In production: set to the externally-reachable API URL, e.g. http://<host>:3030.
+NUXT_PUBLIC_API_BASE_URL=
+
+# SSE (Server-Sent Events) base URL — must bypass the Nitro dev proxy because
+# Nitro buffers the response body, which breaks the text/event-stream protocol.
+# In dev: leave blank — defaults to http://localhost:3030 (direct connection).
+# In production: set to the same externally-reachable API URL as above.
+NUXT_PUBLIC_SSE_API_BASE_URL=

--- a/sustainable-explorer/README.md
+++ b/sustainable-explorer/README.md
@@ -143,6 +143,35 @@ sustainable-explorer/
 └── .env.example                    Environment variable template
 ```
 
+## Queue Worker Resilience
+
+### IPFS multi-gateway fallback
+Set `IPFS_GATEWAYS=https://gateway1.io/ipfs/,https://gateway2.io/ipfs/` (comma-separated). Per-gateway timeout: `IPFS_FETCH_TIMEOUT` (default: 180000 ms). All gateways are tried in order before a job fails.
+
+### IPFS failure persistence
+Permanent failures (404, invalid CID, 410 Gone) are immediately moved to the failed set without consuming remaining retries (`UnrecoverableError`). Transient failures (network timeouts, 5xx errors) retry per the BullMQ `attempts` config (5x for IPFS). All failures are persisted to the `ipfs_fetch_failure` table with error category, attempt count, and last error text. On subsequent successful fetch the failure record is removed and an `ipfs-fetch-recovered` event is published.
+
+### Manual retry budget
+Via the API, failed jobs can be manually retried. The `manualRetryCount` column in `ipfs_fetch_failure` tracks how many times a CID has been manually re-queued, allowing the API layer to enforce retry budgets (e.g. max 3 manual retries before requiring `{ force: true }`).
+
+### In-process autoscaler
+`QueueAutoscalerService` adjusts BullMQ worker concurrency at runtime without restarting the process. Concurrency bounds are:
+- Minimum: startup baseline from `getQueueConfigs()` (env-var controlled, e.g. `WORKER_IPFS_CONCURRENCY=3`)
+- Maximum: `WORKER_<QUEUE>_MAX_CONCURRENCY` env var, or `max(baseline * 4, baseline + 4)` if unset
+
+Example env var names (replace hyphens with underscores, uppercase):
+- `WORKER_IPFS_FILES_MAX_CONCURRENCY`
+- `WORKER_MIRROR_NODE_TOPICS_MAX_CONCURRENCY`
+
+Scaling rules (checked every 30s, leader-elected per network):
+- Scale up: `waiting > 100` → `concurrency += 2` (immediate)
+- Scale down: `waiting < 10` and `active < 50% concurrency` for 2 consecutive cycles → `concurrency -= 1`
+
+**For production load, scale horizontally** (more worker containers with `WORKER_QUEUES` partitioning). In-process scaling is a smoothing layer only.
+
+### Nginx / reverse proxy (SSE)
+Add `proxy_buffering off;` to the nginx location block serving `/api/v1/*/queues/events` to prevent SSE buffering.
+
 ## Documentation
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — Data pipeline architecture, deduplication, leader election, horizontal scaling, business data mapping

--- a/sustainable-explorer/frontend/composables/api/index.ts
+++ b/sustainable-explorer/frontend/composables/api/index.ts
@@ -1,2 +1,3 @@
 export * from './useRegistriesApi';
 export * from './useMethodologiesApi';
+export * from './useQueueStatusApi';

--- a/sustainable-explorer/frontend/composables/api/useQueueStatusApi.ts
+++ b/sustainable-explorer/frontend/composables/api/useQueueStatusApi.ts
@@ -1,0 +1,260 @@
+import type { NetworkId } from '~/composables/useNetwork';
+
+// ─── DTOs ────────────────────────────────────────────────────────────────────
+
+export interface QueueCounts {
+    waiting: number;
+    active: number;
+    completed: number;
+    failed: number;
+    delayed: number;
+    paused: number;
+}
+
+export interface QueueConfig {
+    concurrency: number;
+    attempts: number;
+    backoffType: string;
+    backoffDelay: number;
+}
+
+export interface QueueStatusItemDto {
+    baseName: string;
+    fullName: string;
+    counts: QueueCounts;
+    config: QueueConfig;
+    isPaused: boolean;
+}
+
+export interface FailedJobDto {
+    id: string;
+    name: string;
+    data: any;
+    failedReason: string;
+    stacktrace: string[];
+    attemptsMade: number;
+    manualRetryCount: number;
+    timestamp: number;
+    processedOn: number;
+    finishedOn: number;
+}
+
+export interface FailedJobListDto {
+    total: number;
+    items: FailedJobDto[];
+}
+
+export interface FailedJobGroupDto {
+    reason: string;
+    count: number;
+    sampleJobIds: string[];
+}
+
+export interface SyncTopicDto {
+    topicId: string;
+    messageCount: number;
+    hasNext: boolean;
+    lastUpdate: string;
+    status: string;
+}
+
+export interface SyncTokenDto {
+    tokenId: string;
+    serialNumber: number;
+    hasNext: boolean;
+    type: string;
+}
+
+export interface SyncStatusDto {
+    lastSyncedAt: string | null;
+    lagSeconds: number;
+    totalTopics: number;
+    syncedTopics: number;
+    totalMessages: number;
+    topics: SyncTopicDto[];
+    tokens: SyncTokenDto[];
+}
+
+// ─── Empty factories ─────────────────────────────────────────────────────────
+
+const emptyFailedJobList = (): FailedJobListDto => ({ total: 0, items: [] });
+const emptySyncStatus = (): SyncStatusDto => ({
+    lastSyncedAt: null,
+    lagSeconds: 0,
+    totalTopics: 0,
+    syncedTopics: 0,
+    totalMessages: 0,
+    topics: [],
+    tokens: [],
+});
+
+// ─── useQueueListApi ──────────────────────────────────────────────────────────
+
+export const useQueueListApi = (opts: { network: Ref<NetworkId | string> }) => {
+    const config = useRuntimeConfig();
+    const baseURL = import.meta.server
+        ? (config.apiBaseUrl as string)
+        : (config.public.apiBaseUrl as string);
+
+    const url = computed(() => `/api/v1/${opts.network.value}/queues`);
+    const key = computed(() => `queue-list:${opts.network.value}`);
+
+    const { data, pending, error, refresh } = useAsyncData<QueueStatusItemDto[]>(
+        key.value,
+        async () => {
+            try {
+                const res = await $fetch<QueueStatusItemDto[]>(url.value, { baseURL });
+                return res ?? [];
+            } catch (err: any) {
+                const msg: string = err?.message ?? String(err);
+                if (!msg.includes('ECONNREFUSED') && !msg.includes('no response')) {
+                    console.error('[useQueueListApi] fetch failed:', msg);
+                }
+                return [];
+            }
+        },
+        {
+            default: () => [] as QueueStatusItemDto[],
+            watch: [opts.network],
+        },
+    );
+
+    return { data, pending, error, refresh };
+};
+
+// ─── useQueueFailedJobsApi ────────────────────────────────────────────────────
+
+export const useQueueFailedJobsApi = (opts: {
+    network: Ref<NetworkId | string>;
+    baseName: Ref<string | null>;
+    limit?: number;
+    offset?: Ref<number>;
+}) => {
+    const config = useRuntimeConfig();
+    const baseURL = import.meta.server
+        ? (config.apiBaseUrl as string)
+        : (config.public.apiBaseUrl as string);
+
+    const limit = opts.limit ?? 50;
+    const offset = opts.offset ?? ref(0);
+
+    const key = computed(
+        () => `queue-failed:${opts.network.value}:${opts.baseName.value}:${offset.value}`,
+    );
+
+    const { data, pending, error, refresh } = useAsyncData<FailedJobListDto>(
+        () => key.value,
+        async () => {
+            if (!opts.baseName.value) return emptyFailedJobList();
+            try {
+                const res = await $fetch<FailedJobListDto>(
+                    `/api/v1/${opts.network.value}/queues/${opts.baseName.value}/failed`,
+                    {
+                        baseURL,
+                        query: { limit, offset: offset.value, groupByReason: false },
+                    },
+                );
+                return res ?? emptyFailedJobList();
+            } catch (err: any) {
+                const msg: string = err?.message ?? String(err);
+                if (!msg.includes('ECONNREFUSED') && !msg.includes('no response')) {
+                    console.error('[useQueueFailedJobsApi] fetch failed:', msg);
+                }
+                return emptyFailedJobList();
+            }
+        },
+        {
+            default: () => emptyFailedJobList(),
+        },
+    );
+
+    return { data, pending, error, refresh };
+};
+
+// ─── useQueueFailedGroupsApi ──────────────────────────────────────────────────
+
+export const useQueueFailedGroupsApi = (opts: {
+    network: Ref<NetworkId | string>;
+    baseName: Ref<string | null>;
+}) => {
+    const config = useRuntimeConfig();
+    const baseURL = import.meta.server
+        ? (config.apiBaseUrl as string)
+        : (config.public.apiBaseUrl as string);
+
+    const key = computed(
+        () => `queue-failed-groups:${opts.network.value}:${opts.baseName.value}`,
+    );
+
+    const { data, pending, error, refresh } = useAsyncData<FailedJobGroupDto[]>(
+        () => key.value,
+        async () => {
+            if (!opts.baseName.value) return [];
+            try {
+                const res = await $fetch<{ groups: FailedJobGroupDto[] }>(
+                    `/api/v1/${opts.network.value}/queues/${opts.baseName.value}/failed`,
+                    {
+                        baseURL,
+                        query: { limit: 200, offset: 0, groupByReason: true },
+                    },
+                );
+                return res?.groups ?? [];
+            } catch (err: any) {
+                const msg: string = err?.message ?? String(err);
+                if (!msg.includes('ECONNREFUSED') && !msg.includes('no response')) {
+                    console.error('[useQueueFailedGroupsApi] fetch failed:', msg);
+                }
+                return [];
+            }
+        },
+        {
+            default: () => [] as FailedJobGroupDto[],
+        },
+    );
+
+    return { data, pending, error, refresh };
+};
+
+// ─── useSyncStatusApi ─────────────────────────────────────────────────────────
+
+export const useSyncStatusApi = (opts: { network: Ref<NetworkId | string> }) => {
+    const config = useRuntimeConfig();
+    const baseURL = import.meta.server
+        ? (config.apiBaseUrl as string)
+        : (config.public.apiBaseUrl as string);
+
+    const url = computed(() => `/api/v1/${opts.network.value}/sync-status`);
+    const key = computed(() => `sync-status:${opts.network.value}`);
+
+    const available = ref(true);
+
+    watch(opts.network, () => {
+        available.value = true;
+    });
+
+    const { data, pending, error, refresh } = useAsyncData<SyncStatusDto>(
+        () => key.value,
+        async () => {
+            try {
+                const res = await $fetch<SyncStatusDto>(url.value, { baseURL });
+                available.value = true;
+                return res ?? emptySyncStatus();
+            } catch (err: any) {
+                if (err?.statusCode === 404 || err?.status === 404) {
+                    available.value = false;
+                    return emptySyncStatus();
+                }
+                const msg: string = (err as any)?.message ?? String(err);
+                if (!msg.includes('ECONNREFUSED') && !msg.includes('no response')) {
+                    console.error('[useSyncStatusApi] fetch failed:', msg);
+                }
+                return emptySyncStatus();
+            }
+        },
+        {
+            default: () => emptySyncStatus(),
+        },
+    );
+
+    return { data, pending, error, refresh, available };
+};

--- a/sustainable-explorer/frontend/composables/useQueueEventsSse.ts
+++ b/sustainable-explorer/frontend/composables/useQueueEventsSse.ts
@@ -1,0 +1,182 @@
+export interface LiveCounts {
+    waiting: number;
+    active: number;
+    completed: number;
+    failed: number;
+    delayed: number;
+    paused: number;
+}
+
+export interface RecentFailure {
+    queueBase: string;
+    jobId: string;
+    failedReason: string;
+    ts: number;
+}
+
+export interface RecentEvent {
+    type: string;
+    payload: Record<string, any>;
+    ts: number;
+}
+
+const EVENT_BUFFER_SIZE = 50;
+// job-completed is throttled per queue: at most 1 entry every 5 s in the feed.
+// Failed/stalled/IPFS events always pass through immediately.
+const COMPLETION_THROTTLE_MS = 5_000;
+
+export const useQueueEventsSse = (opts: { network: Ref<string>; baseURL: string }) => {
+    const isConnected = ref(false);
+    const liveCounts = ref<Record<string, LiveCounts>>({});
+    const recentFailures = ref<RecentFailure[]>([]);
+    const recentEvents = ref<RecentEvent[]>([]);
+    const lastEventAt = ref<number>(Date.now());
+
+    // Throttle: track when each queue last emitted a job-completed row
+    const lastCompletionTs = new Map<string, number>();
+
+    let es: EventSource | null = null;
+
+    const prepend = (evt: RecentEvent) => {
+        recentEvents.value = [evt, ...recentEvents.value].slice(0, EVENT_BUFFER_SIZE);
+    };
+
+    const connect = () => {
+        if (!import.meta.client) return;
+
+        if (es) {
+            es.close();
+            es = null;
+            isConnected.value = false;
+        }
+
+        const url = `${opts.baseURL}/api/v1/${opts.network.value}/queues/events`;
+
+        try {
+            es = new EventSource(url);
+
+            es.onopen = () => {
+                isConnected.value = true;
+                lastEventAt.value = Date.now();
+            };
+
+            es.onerror = () => {
+                isConnected.value = false;
+            };
+
+            es.onmessage = (event: MessageEvent) => {
+                lastEventAt.value = Date.now();
+                try {
+                    handleEvent(JSON.parse(event.data));
+                } catch { /* ignore */ }
+            };
+
+            const eventTypes = [
+                'job-completed', 'job-failed', 'job-active', 'job-waiting',
+                'job-stalled', 'counts-changed', 'se-event', 'heartbeat',
+            ];
+
+            for (const type of eventTypes) {
+                es.addEventListener(type, (event: Event) => {
+                    lastEventAt.value = Date.now();
+                    isConnected.value = true;
+                    try {
+                        handleEvent({ type, ...JSON.parse((event as MessageEvent).data) });
+                    } catch { /* ignore */ }
+                });
+            }
+        } catch (err) {
+            console.error('[useQueueEventsSse] connect failed:', (err as Error)?.message ?? String(err));
+            isConnected.value = false;
+        }
+    };
+
+    const handleEvent = (data: Record<string, any>) => {
+        const type = data.type as string;
+        const now = Date.now();
+
+        switch (type) {
+            case 'counts-changed': {
+                const base = data.queueBase as string;
+                if (base) {
+                    liveCounts.value = {
+                        ...liveCounts.value,
+                        [base]: {
+                            waiting:   data.counts?.waiting   ?? 0,
+                            active:    data.counts?.active    ?? 0,
+                            completed: data.counts?.completed ?? 0,
+                            failed:    data.counts?.failed    ?? 0,
+                            delayed:   data.counts?.delayed   ?? 0,
+                            paused:    data.counts?.paused    ?? 0,
+                        },
+                    };
+                }
+                break;
+            }
+
+            case 'job-completed': {
+                // Throttle: skip if this queue emitted a completion row recently
+                const base = (data.queueBase ?? 'unknown') as string;
+                const last = lastCompletionTs.get(base) ?? 0;
+                if (now - last >= COMPLETION_THROTTLE_MS) {
+                    lastCompletionTs.set(base, now);
+                    prepend({ type: 'job-completed', payload: data, ts: now });
+                }
+                break;
+            }
+
+            case 'job-failed': {
+                recentFailures.value = [
+                    {
+                        queueBase:    data.queueBase    ?? '',
+                        jobId:        data.jobId        ?? '',
+                        failedReason: data.failedReason ?? 'Unknown error',
+                        ts:           now,
+                    },
+                    ...recentFailures.value,
+                ].slice(0, 200);
+                prepend({ type: 'job-failed', payload: data, ts: now });
+                break;
+            }
+
+            case 'job-stalled':
+                prepend({ type: 'job-stalled', payload: data, ts: now });
+                break;
+
+            case 'se-event': {
+                const payload = data.payload ?? data;
+                const evType = payload.type as string;
+                if (
+                    evType === 'ipfs-fetch-failed' ||
+                    evType === 'ipfs-fetch-recovered' ||
+                    evType === 'document-loaded'
+                ) {
+                    prepend({ type: evType, payload, ts: now });
+                }
+                break;
+            }
+
+            case 'heartbeat':
+                break;
+
+            default:
+                break;
+        }
+    };
+
+    if (import.meta.client) {
+        watch(() => opts.network.value, () => {
+            lastCompletionTs.clear();
+            connect();
+        });
+
+        onMounted(() => { connect(); });
+
+        onUnmounted(() => {
+            if (es) { es.close(); es = null; }
+            isConnected.value = false;
+        });
+    }
+
+    return { isConnected, liveCounts, recentFailures, recentEvents, lastEventAt };
+};

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -503,17 +503,67 @@
     "subtitle": "Data pipeline and worker queue metrics",
     "dataSyncedUpTo": "Data Synced Up To",
     "topicsIndexed": "Topics Indexed",
-    "topicsIndexedSub": "of ~1,700 discovered",
+    "topicsDiscovered": "discovered",
     "messagesProcessed": "Messages Processed",
-    "messagesProcessedSub": "{count} pending in queue",
+    "pendingInQueue": "pending in queue",
     "queueStatus": "Queue Status",
     "queueStatusSub": "BullMQ worker queues",
+        "connectionLive": "Live",
+        "connectionPolling": "Polling",
+        "lastUpdated": "Last updated",
+        "totalWaiting": "Total Waiting",
+        "totalFailed": "Total Failed",
     "columns": {
       "queue": "Queue",
       "waiting": "Waiting",
       "active": "Active",
       "completed": "Completed",
-      "failed": "Failed"
+      "failed": "Failed",
+            "delayed": "Delayed",
+            "concurrency": "Concurrency",
+            "status": "Status",
+            "actions": "Actions"
+        },
+        "queueStatuses": {
+            "active": "Active",
+            "idle": "Idle",
+            "paused": "Paused"
+        },
+        "actions": {
+            "pause": "Pause",
+            "resume": "Resume",
+            "viewFailures": "View failures",
+            "retryAll": "Retry all"
+        },
+        "failedDrawer": {
+            "title": "Failed jobs",
+            "byReason": "By reason",
+            "allFailed": "All failed",
+            "retryJob": "Retry",
+            "forceRetry": "Override retry limit (force)",
+            "budgetExhausted": "Retry budget exhausted",
+            "attempts": "Attempts",
+            "manualRetries": "Manual retries"
+        },
+        "syncHealth": {
+            "title": "Sync Health",
+            "lastSynced": "Last Synced",
+            "lag": "Lag",
+            "topics": "Topics",
+            "tokens": "Tokens"
+        },
+        "activity": {
+            "title": "Recent Activity",
+            "events": "events",
+            "filterAll": "All",
+            "filterFailures": "Failures only",
+            "empty": "No recent events — waiting for queue activity...",
+            "emptyFailures": "No failures recorded in this session"
+        },
+        "retryAll": {
+            "confirm": "Retry all failed jobs?",
+            "force": "Override retry limit (force)",
+            "result": "Retried {retried} jobs, skipped {skipped}"
     }
   },
   "vcViewer": {

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -503,17 +503,67 @@
     "subtitle": "Métricas del pipeline de datos y las colas de trabajadores",
     "dataSyncedUpTo": "Datos sincronizados hasta",
     "topicsIndexed": "Tópicos indexados",
-    "topicsIndexedSub": "de ~1.700 descubiertos",
+    "topicsDiscovered": "descubiertos",
     "messagesProcessed": "Mensajes procesados",
-    "messagesProcessedSub": "{count} pendientes en cola",
+    "pendingInQueue": "pendientes en cola",
     "queueStatus": "Estado de las colas",
     "queueStatusSub": "Colas de trabajadores BullMQ",
+        "connectionLive": "En vivo",
+        "connectionPolling": "Sondeando",
+        "lastUpdated": "Última actualización",
+        "totalWaiting": "Total en espera",
+        "totalFailed": "Total fallidos",
     "columns": {
       "queue": "Cola",
       "waiting": "En espera",
       "active": "Activas",
       "completed": "Completadas",
-      "failed": "Fallidas"
+      "failed": "Fallidas",
+            "delayed": "Diferidas",
+            "concurrency": "Concurrencia",
+            "status": "Estado",
+            "actions": "Acciones"
+        },
+        "queueStatuses": {
+            "active": "Activa",
+            "idle": "Inactiva",
+            "paused": "En pausa"
+        },
+        "actions": {
+            "pause": "Pausar",
+            "resume": "Reanudar",
+            "viewFailures": "Ver fallos",
+            "retryAll": "Reintentar todo"
+        },
+        "failedDrawer": {
+            "title": "Trabajos fallidos",
+            "byReason": "Por motivo",
+            "allFailed": "Todos los fallidos",
+            "retryJob": "Reintentar",
+            "forceRetry": "Ignorar límite de reintentos (forzar)",
+            "budgetExhausted": "Presupuesto de reintentos agotado",
+            "attempts": "Intentos",
+            "manualRetries": "Reintentos manuales"
+        },
+        "syncHealth": {
+            "title": "Salud de sincronización",
+            "lastSynced": "Última sincronización",
+            "lag": "Retraso",
+            "topics": "Tópicos",
+            "tokens": "Tokens"
+        },
+        "activity": {
+            "title": "Actividad reciente",
+            "events": "eventos",
+            "filterAll": "Todos",
+            "filterFailures": "Solo fallos",
+            "empty": "Sin eventos recientes — esperando actividad de las colas...",
+            "emptyFailures": "No se registraron fallos en esta sesión"
+        },
+        "retryAll": {
+            "confirm": "¿Reintentar todos los trabajos fallidos?",
+            "force": "Ignorar límite de reintentos (forzar)",
+            "result": "Reintentados {retried} trabajos, omitidos {skipped}"
     }
   },
   "vcViewer": {

--- a/sustainable-explorer/frontend/layouts/default.vue
+++ b/sustainable-explorer/frontend/layouts/default.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import { Toaster } from 'vue-sonner';
+</script>
+
 <template>
     <div class="flex min-h-screen">
         <AppSidebar />
@@ -7,5 +11,6 @@
                 <slot />
             </main>
         </div>
+        <Toaster position="bottom-right" rich-colors />
     </div>
 </template>

--- a/sustainable-explorer/frontend/nuxt.config.ts
+++ b/sustainable-explorer/frontend/nuxt.config.ts
@@ -57,6 +57,11 @@ export default defineNuxtConfig({
             //   (e.g., `http://<host>:3030`) via NUXT_PUBLIC_API_BASE_URL.
             //   Nuxt automatically overrides public.* from NUXT_PUBLIC_* env vars.
             apiBaseUrl: '',
+            // SSE (EventSource) must bypass the Nitro proxy — connect directly to the API.
+            // Override via NUXT_PUBLIC_SSE_API_BASE_URL in production.
+            sseApiBaseUrl: process.env.NUXT_PUBLIC_SSE_API_BASE_URL || 'http://localhost:3030',
+            // Reverse-geocoding endpoint. Override via NUXT_PUBLIC_GEOCODER_URL.
+            geocoderUrl: 'https://nominatim.openstreetmap.org/reverse',
         },
     },
 
@@ -74,4 +79,8 @@ export default defineNuxtConfig({
     },
 
     compatibilityDate: '2025-01-01',
+
+    experimental: {
+        appManifest: false,
+    },
 });

--- a/sustainable-explorer/frontend/pages/status.vue
+++ b/sustainable-explorer/frontend/pages/status.vue
@@ -1,87 +1,632 @@
 <script setup lang="ts">
-import { Activity, CheckCircle2, Clock, AlertCircle } from 'lucide-vue-next';
+import {
+    AlertCircle,
+    CheckCircle2,
+    ChevronDown,
+    Clock,
+    Loader2,
+    RefreshCw,
+    X,
+} from 'lucide-vue-next';
+import type {
+    FailedJobDto,
+    QueueStatusItemDto,
+} from '~/composables/api/useQueueStatusApi';
 
-const { locale } = useI18n();
-const localeTag = computed(() => (locale.value === 'es' ? 'es-ES' : 'en-US'));
+const { t } = useI18n();
+const { network } = useNetwork();
+const config = useRuntimeConfig();
 
-const queues = [
-    { name: 'mirror-node-topics', waiting: 3, active: 2, completed: 1247, failed: 0 },
-    { name: 'mirror-node-messages', waiting: 45, active: 10, completed: 52340, failed: 12 },
-    { name: 'mirror-node-tokens', waiting: 0, active: 1, completed: 890, failed: 0 },
-    { name: 'ipfs-files', waiting: 18, active: 3, completed: 8920, failed: 45 },
-    { name: 'guardian-api-sync', waiting: 0, active: 0, completed: 340, failed: 2 },
-    { name: 'maintenance-refresh-mvs', waiting: 0, active: 0, completed: 1440, failed: 0 },
-];
+// ─── API composables ──────────────────────────────────────────────────────────
 
-const syncDate = new Date(Date.now() - 15 * 60 * 1000);
-const syncDateFormatted = computed(() =>
-    syncDate.toLocaleDateString(localeTag.value, { month: 'short', day: 'numeric', year: 'numeric' }),
+const {
+    data: queueList,
+    pending: queuePending,
+    refresh: refreshQueues,
+} = useQueueListApi({ network });
+
+const {
+    data: syncStatus,
+    available: syncAvailable,
+} = useSyncStatusApi({ network });
+
+// ─── SSE ─────────────────────────────────────────────────────────────────────
+
+// SSE must bypass the Nitro proxy (which buffers text/event-stream).
+// Use sseApiBaseUrl which points directly to the NestJS API.
+const sseBaseURL = import.meta.client
+    ? (config.public.sseApiBaseUrl as string) || 'http://localhost:3030'
+    : '';
+
+const { isConnected, liveCounts, recentFailures, recentEvents, lastEventAt } =
+    useQueueEventsSse({ network, baseURL: sseBaseURL });
+
+// ─── Poll fallback (30s) ──────────────────────────────────────────────────────
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+onMounted(() => {
+    pollTimer = setInterval(() => {
+        refreshQueues();
+    }, 30_000);
+});
+
+onUnmounted(() => {
+    if (pollTimer) clearInterval(pollTimer);
+});
+
+// ─── Merged queue list ────────────────────────────────────────────────────────
+
+const mergedQueues = computed<QueueStatusItemDto[]>(() => {
+    return (queueList.value ?? []).map((q) => {
+        const live = liveCounts.value[q.baseName];
+        if (!live) return q;
+        return { ...q, counts: { ...q.counts, ...live } };
+    });
+});
+
+// ─── Summary stats ────────────────────────────────────────────────────────────
+
+const totalWaiting = computed(() =>
+    mergedQueues.value.reduce((s, q) => s + q.counts.waiting, 0),
 );
-const syncTimeFormatted = computed(() =>
-    syncDate.toLocaleTimeString(localeTag.value, { hour: '2-digit', minute: '2-digit', hour12: true }),
-);
+
+// ─── Last updated counter ─────────────────────────────────────────────────────
+
+const secondsSinceUpdate = ref(0);
+
+let clockTimer: ReturnType<typeof setInterval> | null = null;
+
+onMounted(() => {
+    clockTimer = setInterval(() => {
+        secondsSinceUpdate.value = Math.floor((Date.now() - lastEventAt.value) / 1000);
+    }, 1000);
+});
+
+onUnmounted(() => {
+    if (clockTimer) clearInterval(clockTimer);
+});
+
+// ─── Sync health ──────────────────────────────────────────────────────────────
+
+const syncPanelOpen = ref(true);
+
+const lagColor = computed(() => {
+    const lag = syncStatus.value?.lagSeconds ?? 0;
+    if (lag < 60) return 'text-stat-green';
+    if (lag < 300) return 'text-stat-amber';
+    return 'text-stat-rose';
+});
+
+function formatRelativeTime(ts: string | null): string {
+    if (!ts) return '—';
+    const diff = Date.now() - new Date(ts).getTime();
+    const s = Math.floor(diff / 1000);
+    if (s < 60) return `${s}s ago`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
+}
+
+function formatLagHuman(seconds: number): string {
+    if (seconds < 60) return `${seconds}s lag`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m lag`;
+    return `${Math.floor(seconds / 3600)}h lag`;
+}
+
+const lastSyncedDisplay = computed(() => {
+    const raw = syncStatus.value?.lastSyncedAt ?? null;
+    if (!raw) return '—';
+    return formatRelativeTime(raw);
+});
+
+// ─── Toast helper (using vue-sonner via global) ───────────────────────────────
+
+// vue-sonner is available via `import { toast } from 'vue-sonner'` at runtime.
+// We use dynamic import to avoid SSR issues.
+async function showToast(message: string, type: 'success' | 'error' = 'success') {
+    if (!import.meta.client) return;
+    try {
+        const { toast } = await import('vue-sonner');
+        if (type === 'success') toast.success(message);
+        else toast.error(message);
+    } catch {
+        console.log('[toast]', type, message);
+    }
+}
+
+// ─── Pause / Resume ───────────────────────────────────────────────────────────
+
+const actionPending = ref<Record<string, boolean>>({});
+
+async function pauseQueue(baseName: string) {
+    actionPending.value[baseName] = true;
+    try {
+        await $fetch(`/api/v1/${network.value}/queues/${baseName}/pause`, {
+            method: 'POST',
+            baseURL: import.meta.client ? (config.public.apiBaseUrl as string) || '' : '',
+        });
+        await refreshQueues();
+    } catch (err: any) {
+        showToast(`Failed to pause ${baseName}: ${err?.message ?? 'Unknown error'}`, 'error');
+    } finally {
+        actionPending.value[baseName] = false;
+    }
+}
+
+async function resumeQueue(baseName: string) {
+    actionPending.value[baseName] = true;
+    try {
+        await $fetch(`/api/v1/${network.value}/queues/${baseName}/resume`, {
+            method: 'POST',
+            baseURL: import.meta.client ? (config.public.apiBaseUrl as string) || '' : '',
+        });
+        await refreshQueues();
+    } catch (err: any) {
+        showToast(`Failed to resume ${baseName}: ${err?.message ?? 'Unknown error'}`, 'error');
+    } finally {
+        actionPending.value[baseName] = false;
+    }
+}
+
+// ─── Retry all failed ─────────────────────────────────────────────────────────
+
+interface RetryAllState {
+    baseName: string;
+    failedCount: number;
+    force: boolean;
+    pending: boolean;
+}
+
+const retryAllState = ref<RetryAllState | null>(null);
+
+function openRetryAll(q: QueueStatusItemDto) {
+    retryAllState.value = {
+        baseName: q.baseName,
+        failedCount: q.counts.failed,
+        force: false,
+        pending: false,
+    };
+}
+
+function cancelRetryAll() {
+    retryAllState.value = null;
+}
+
+async function confirmRetryAll() {
+    if (!retryAllState.value) return;
+    retryAllState.value.pending = true;
+    const { baseName, force } = retryAllState.value;
+    try {
+        const result = await $fetch<{ retried: number; skipped: number; errors: any[] }>(
+            `/api/v1/${network.value}/queues/${baseName}/retry-all-failed`,
+            {
+                method: 'POST',
+                body: { force },
+                baseURL: import.meta.client ? (config.public.apiBaseUrl as string) || '' : '',
+            },
+        );
+        retryAllState.value = null;
+        showToast(
+            t('status.retryAll.result', {
+                retried: result.retried,
+                skipped: result.skipped,
+            }),
+        );
+        await refreshQueues();
+    } catch (err: any) {
+        retryAllState.value = null;
+        showToast(
+            `Retry all failed for ${baseName}: ${err?.message ?? 'Unknown error'}`,
+            'error',
+        );
+    }
+}
+
+// ─── Failed jobs drawer ───────────────────────────────────────────────────────
+
+const drawerBaseName = ref<string | null>(null);
+const drawerTab = ref<'byReason' | 'allFailed'>('byReason');
+const failedPageOffset = ref(0);
+
+function openDrawer(baseName: string) {
+    drawerBaseName.value = baseName;
+    drawerTab.value = 'byReason';
+    failedPageOffset.value = 0;
+}
+
+function closeDrawer() {
+    drawerBaseName.value = null;
+}
+
+const { data: failedJobs, pending: failedPending, refresh: refreshFailed } =
+    useQueueFailedJobsApi({
+        network,
+        baseName: drawerBaseName,
+        limit: 50,
+        offset: failedPageOffset,
+    });
+
+const { data: failedGroups, pending: groupsPending, refresh: refreshGroups } =
+    useQueueFailedGroupsApi({
+        network,
+        baseName: drawerBaseName,
+    });
+
+// ─── Per-job retry state ──────────────────────────────────────────────────────
+
+interface JobRetryState {
+    confirming: boolean;
+    force: boolean;
+    pending: boolean;
+    error: string | null;
+    done: boolean;
+}
+
+const jobRetryStates = ref<Record<string, JobRetryState>>({});
+
+function getJobRetry(jobId: string): JobRetryState {
+    if (!jobRetryStates.value[jobId]) {
+        jobRetryStates.value[jobId] = {
+            confirming: false,
+            force: false,
+            pending: false,
+            error: null,
+            done: false,
+        };
+    }
+    return jobRetryStates.value[jobId];
+}
+
+function startConfirmRetry(jobId: string) {
+    const state = getJobRetry(jobId);
+    state.confirming = true;
+    state.error = null;
+}
+
+function cancelRetry(jobId: string) {
+    const state = getJobRetry(jobId);
+    state.confirming = false;
+    state.force = false;
+}
+
+const MANUAL_RETRY_BUDGET = 3;
+
+async function confirmRetryJob(job: FailedJobDto) {
+    const state = getJobRetry(job.id);
+    state.pending = true;
+    state.error = null;
+
+    if (!drawerBaseName.value) return;
+
+    try {
+        await $fetch(
+            `/api/v1/${network.value}/queues/${drawerBaseName.value}/jobs/${job.id}/retry`,
+            {
+                method: 'POST',
+                body: { force: state.force },
+                baseURL: import.meta.client ? (config.public.apiBaseUrl as string) || '' : '',
+            },
+        );
+        state.done = true;
+        state.confirming = false;
+        showToast(`Job ${job.id} queued for retry`);
+        // Refresh after short delay so animation can play
+        setTimeout(() => refreshFailed(), 800);
+    } catch (err: any) {
+        const status = err?.statusCode ?? err?.status;
+        if (status === 429) {
+            state.error = t('status.failedDrawer.budgetExhausted');
+        } else if (status === 409) {
+            state.error = 'Job is no longer in failed state, refreshing...';
+            setTimeout(() => refreshFailed(), 800);
+        } else {
+            state.error = err?.message ?? 'Retry failed';
+        }
+        state.pending = false;
+        state.confirming = false;
+    }
+}
+
+// ─── Activity feed — filter ───────────────────────────────────────────────────
+
+const activityFilter = ref<'all' | 'failures'>('all');
+
+const filteredEvents = computed(() => {
+    if (activityFilter.value === 'failures') {
+        return recentEvents.value.filter(
+            (ev) => ev.type === 'job-failed' || ev.type === 'ipfs-fetch-failed',
+        );
+    }
+    return recentEvents.value;
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function queueStatus(q: QueueStatusItemDto): 'paused' | 'active' | 'idle' {
+    if (q.isPaused) return 'paused';
+    const counts = mergedQueues.value.find((m) => m.baseName === q.baseName)?.counts ?? q.counts;
+    if (counts.active > 0) return 'active';
+    return 'idle';
+}
+
+const eventBadgeClass: Record<string, string> = {
+    'job-failed': 'bg-stat-rose/10 text-stat-rose',
+    'job-completed': 'bg-stat-green/10 text-stat-green',
+    'job-stalled': 'bg-stat-amber/10 text-stat-amber',
+    'ipfs-fetch-failed': 'bg-stat-rose/10 text-stat-rose',
+    'ipfs-fetch-recovered': 'bg-stat-green/10 text-stat-green',
+    'document-loaded': 'bg-stat-blue/10 text-stat-blue',
+};
+
+function eventLabel(type: string): string {
+    const map: Record<string, string> = {
+        'job-failed': 'Job Failed',
+        'job-completed': 'Job Completed',
+        'job-stalled': 'Job Stalled',
+        'ipfs-fetch-failed': 'IPFS Fetch Failed',
+        'ipfs-fetch-recovered': 'IPFS Recovered',
+        'document-loaded': 'Document Loaded',
+    };
+    return map[type] ?? type;
+}
+
+function eventDetails(ev: { type: string; payload: Record<string, any> }): string {
+    const p = ev.payload;
+    if (ev.type === 'job-failed') {
+        const where = [p.queueBase, p.jobId].filter(Boolean).join(' / ');
+        const why = p.failedReason ? ` — ${String(p.failedReason).slice(0, 80)}` : '';
+        return where + why;
+    }
+    if (ev.type === 'job-completed' || ev.type === 'job-stalled') {
+        return [p.queueBase, p.jobId].filter(Boolean).join(' / ');
+    }
+    if (ev.type === 'ipfs-fetch-failed') {
+        const cid = p.cid ?? p.jobId ?? '';
+        const why = p.error ? ` — ${String(p.error).slice(0, 60)}` : '';
+        return cid + why;
+    }
+    if (ev.type === 'ipfs-fetch-recovered') {
+        return p.cid ?? p.jobId ?? '';
+    }
+    if (ev.type === 'document-loaded') {
+        return p.topicId ?? p.messageId ?? '';
+    }
+    return '';
+}
+
+function formatTs(ts: number): string {
+    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
 </script>
 
 <template>
     <div class="space-y-0">
+        <!-- Page header -->
         <div class="px-6 pt-6 pb-5">
             <h1 class="text-2xl font-bold text-foreground">{{ $t('status.title') }}</h1>
             <p class="text-sm text-muted-foreground mt-1">{{ $t('status.subtitle') }}</p>
         </div>
 
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 px-6 pb-6">
+        <!-- Section A: Stat cards -->
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 px-6 pb-4">
+            <!-- Data synced up to -->
             <div class="rounded-xl border bg-card p-4">
-                <span class="text-xs font-medium uppercase tracking-wider text-muted-foreground">{{ $t('status.dataSyncedUpTo') }}</span>
-                <div class="text-lg font-bold text-foreground mt-2">{{ syncDateFormatted }}</div>
+                <span class="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    {{ $t('status.dataSyncedUpTo') }}
+                </span>
+                <div class="text-lg font-bold text-foreground mt-2">
+                    {{ syncStatus?.lastSyncedAt ? new Date(syncStatus.lastSyncedAt).toLocaleDateString([], { month: 'long', day: 'numeric', year: 'numeric' }) : '—' }}
+                </div>
                 <div class="flex items-center gap-1.5 mt-1">
-                    <CheckCircle2 class="h-3.5 w-3.5 text-stat-green" />
-                    <span class="text-xs text-muted-foreground">{{ syncTimeFormatted }}</span>
+                    <Clock class="h-3.5 w-3.5 text-muted-foreground" />
+                    <span class="text-xs text-muted-foreground">
+                        {{ syncStatus?.lastSyncedAt ? new Date(syncStatus.lastSyncedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '—' }}
+                    </span>
                 </div>
             </div>
+
+            <!-- Topics indexed -->
             <div class="rounded-xl border bg-card p-4">
-                <span class="text-xs font-medium uppercase tracking-wider text-muted-foreground">{{ $t('status.topicsIndexed') }}</span>
-                <div class="text-2xl font-bold text-foreground mt-2">1,247</div>
-                <p class="text-xs text-muted-foreground mt-1">{{ $t('status.topicsIndexedSub') }}</p>
+                <span class="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    {{ $t('status.topicsIndexed') }}
+                </span>
+                <div class="text-2xl font-bold tabular-nums text-foreground mt-2">
+                    {{ (syncStatus?.syncedTopics ?? 0).toLocaleString() }}
+                </div>
+                <p class="text-xs text-muted-foreground mt-1">
+                    of ~{{ (syncStatus?.totalTopics ?? 0).toLocaleString() }} {{ $t('status.topicsDiscovered') }}
+                </p>
             </div>
+
+            <!-- Messages processed -->
             <div class="rounded-xl border bg-card p-4">
-                <span class="text-xs font-medium uppercase tracking-wider text-muted-foreground">{{ $t('status.messagesProcessed') }}</span>
-                <div class="text-2xl font-bold text-foreground mt-2">52,340</div>
-                <p class="text-xs text-muted-foreground mt-1">{{ $t('status.messagesProcessedSub', { count: 45 }) }}</p>
+                <span class="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    {{ $t('status.messagesProcessed') }}
+                </span>
+                <div class="text-2xl font-bold tabular-nums text-foreground mt-2">
+                    {{ (syncStatus?.totalMessages ?? 0).toLocaleString() }}
+                </div>
+                <p class="text-xs text-muted-foreground mt-1">
+                    {{ totalWaiting.toLocaleString() }} {{ $t('status.pendingInQueue') }}
+                    <span v-if="totalWaiting > 0" class="text-stat-amber">↑</span>
+                </p>
             </div>
         </div>
 
-        <div class="border-t">
-            <div class="px-6 py-4">
-                <h2 class="text-base font-semibold text-foreground">{{ $t('status.queueStatus') }}</h2>
-                <p class="text-xs text-muted-foreground mt-0.5">{{ $t('status.queueStatusSub') }}</p>
+        <!-- Section B: Connection status banner -->
+        <div class="px-6 pb-4">
+            <div class="flex items-center justify-between rounded-lg border bg-card px-4 py-2.5 text-sm">
+                <div class="flex items-center gap-2">
+                    <span
+                        class="inline-block h-2 w-2 rounded-full"
+                        :class="isConnected ? 'bg-stat-green animate-pulse' : 'bg-stat-amber'"
+                    />
+                    <span class="font-medium">
+                        {{ isConnected ? $t('status.connectionLive') : $t('status.connectionPolling') }}
+                    </span>
+                </div>
+                <span class="text-xs text-muted-foreground">
+                    {{ $t('status.lastUpdated') }}:
+                    {{ secondsSinceUpdate === 0 ? 'just now' : `${secondsSinceUpdate}s ago` }}
+                </span>
             </div>
+        </div>
+
+        <!-- Section C: Queue table -->
+        <div class="border-t">
+            <div class="px-6 py-4 flex items-center justify-between">
+                <div>
+                    <h2 class="text-base font-semibold text-foreground">{{ $t('status.queueStatus') }}</h2>
+                    <p class="text-xs text-muted-foreground mt-0.5">{{ $t('status.queueStatusSub') }}</p>
+                </div>
+                <button
+                    class="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    :disabled="queuePending"
+                    @click="refreshQueues"
+                >
+                    <RefreshCw class="h-3.5 w-3.5" :class="{ 'animate-spin': queuePending }" />
+                    Refresh
+                </button>
+            </div>
+
             <div class="px-6 pb-6">
                 <div class="rounded-xl border bg-card overflow-hidden">
                     <table class="w-full text-sm">
                         <thead>
                             <tr class="border-b bg-muted/30">
                                 <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.queue') }}</th>
-                                <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.waiting') }}</th>
-                                <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.active') }}</th>
-                                <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.completed') }}</th>
-                                <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.failed') }}</th>
+                                <th class="text-right py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.waiting') }}</th>
+                                <th class="text-right py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.active') }}</th>
+                                <th class="text-right py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.completed') }}</th>
+                                <th class="text-right py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.failed') }}</th>
+                                <th class="text-right py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.delayed') }}</th>
+                                <th class="text-right py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.concurrency') }}</th>
+                                <th class="text-center py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.status') }}</th>
+                                <th class="text-left py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('status.columns.actions') }}</th>
                             </tr>
                         </thead>
                         <tbody class="divide-y">
-                            <tr v-for="q in queues" :key="q.name" class="hover:bg-muted/30 transition-colors">
-                                <td class="py-2.5 px-4 font-mono text-xs text-foreground">{{ q.name }}</td>
-                                <td class="py-2.5 px-4 text-right tabular-nums">
-                                    <span v-if="q.waiting" class="text-stat-amber font-medium">{{ q.waiting }}</span>
+                            <!-- Loading skeleton -->
+                            <template v-if="queuePending && mergedQueues.length === 0">
+                                <tr v-for="i in 4" :key="i" class="animate-pulse">
+                                    <td class="py-3 px-4"><div class="h-4 bg-muted rounded w-40" /></td>
+                                    <td v-for="j in 7" :key="j" class="py-3 px-3"><div class="h-4 bg-muted rounded ml-auto w-8" /></td>
+                                    <td class="py-3 px-3"><div class="h-6 bg-muted rounded w-20" /></td>
+                                </tr>
+                            </template>
+
+                            <!-- Empty state -->
+                            <tr v-else-if="mergedQueues.length === 0 && !queuePending">
+                                <td colspan="9" class="py-12 text-center text-sm text-muted-foreground">
+                                    No queues found
+                                </td>
+                            </tr>
+
+                            <!-- Queue rows -->
+                            <tr
+                                v-for="q in mergedQueues"
+                                :key="q.baseName"
+                                class="hover:bg-muted/30 transition-colors"
+                            >
+                                <!-- Queue name -->
+                                <td class="py-3 px-4 font-mono text-xs text-foreground font-medium">{{ q.baseName }}</td>
+
+                                <!-- Waiting -->
+                                <td class="py-3 px-3 text-right tabular-nums">
+                                    <span :class="q.counts.waiting > 0 ? 'text-stat-amber font-medium' : 'text-muted-foreground'">
+                                        {{ q.counts.waiting }}
+                                    </span>
+                                </td>
+
+                                <!-- Active -->
+                                <td class="py-3 px-3 text-right tabular-nums">
+                                    <span :class="q.counts.active > 0 ? 'text-stat-blue font-medium' : 'text-muted-foreground'">
+                                        {{ q.counts.active }}
+                                    </span>
+                                </td>
+
+                                <!-- Completed -->
+                                <td class="py-3 px-3 text-right tabular-nums text-stat-green">
+                                    {{ q.counts.completed.toLocaleString() }}
+                                </td>
+
+                                <!-- Failed (clickable) -->
+                                <td class="py-3 px-3 text-right tabular-nums">
+                                    <button
+                                        v-if="q.counts.failed > 0"
+                                        class="text-stat-rose font-medium underline decoration-dotted hover:decoration-solid transition-all"
+                                        @click="openDrawer(q.baseName)"
+                                    >
+                                        {{ q.counts.failed }}
+                                    </button>
                                     <span v-else class="text-muted-foreground">0</span>
                                 </td>
-                                <td class="py-2.5 px-4 text-right tabular-nums">
-                                    <span v-if="q.active" class="text-stat-blue font-medium">{{ q.active }}</span>
-                                    <span v-else class="text-muted-foreground">0</span>
+
+                                <!-- Delayed -->
+                                <td class="py-3 px-3 text-right tabular-nums">
+                                    <span :class="q.counts.delayed > 0 ? 'text-muted-foreground font-medium' : 'text-muted-foreground'">
+                                        {{ q.counts.delayed }}
+                                    </span>
                                 </td>
-                                <td class="py-2.5 px-4 text-right tabular-nums text-stat-green">{{ q.completed.toLocaleString() }}</td>
-                                <td class="py-2.5 px-4 text-right tabular-nums">
-                                    <span v-if="q.failed" class="text-stat-rose font-medium">{{ q.failed }}</span>
-                                    <span v-else class="text-muted-foreground">0</span>
+
+                                <!-- Concurrency -->
+                                <td class="py-3 px-3 text-right tabular-nums text-muted-foreground">
+                                    {{ q.config.concurrency }}
+                                </td>
+
+                                <!-- Status badge -->
+                                <td class="py-3 px-3 text-center">
+                                    <span
+                                        class="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2 py-0.5"
+                                        :class="{
+                                            'bg-stat-amber/10 text-stat-amber': queueStatus(q) === 'paused',
+                                            'bg-stat-green/10 text-stat-green': queueStatus(q) === 'active',
+                                            'bg-muted text-muted-foreground': queueStatus(q) === 'idle',
+                                        }"
+                                    >
+                                        <span class="inline-block h-1.5 w-1.5 rounded-full"
+                                            :class="{
+                                                'bg-stat-amber': queueStatus(q) === 'paused',
+                                                'bg-stat-green': queueStatus(q) === 'active',
+                                                'bg-muted-foreground': queueStatus(q) === 'idle',
+                                            }"
+                                        />
+                                        {{ queueStatus(q) === 'paused'
+                                            ? $t('status.queueStatuses.paused')
+                                            : queueStatus(q) === 'active'
+                                                ? $t('status.queueStatuses.active')
+                                                : $t('status.queueStatuses.idle') }}
+                                    </span>
+                                </td>
+
+                                <!-- Actions -->
+                                <td class="py-3 px-3">
+                                    <div class="flex items-center gap-1.5">
+                                        <!-- Pause / Resume hidden — public platform, reserved for admin panel -->
+
+                                        <!-- View failures -->
+                                        <button
+                                            class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs border border-border hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                                            :disabled="q.counts.failed === 0"
+                                            @click="openDrawer(q.baseName)"
+                                        >
+                                            <AlertCircle class="h-3 w-3" />
+                                            {{ $t('status.actions.viewFailures') }}
+                                        </button>
+
+                                        <!-- Retry all -->
+                                        <button
+                                            class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs border border-stat-rose/50 text-stat-rose hover:bg-stat-rose/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                                            :disabled="q.counts.failed === 0"
+                                            @click="openRetryAll(q)"
+                                        >
+                                            <RefreshCw class="h-3 w-3" />
+                                            {{ $t('status.actions.retryAll') }} ({{ q.counts.failed }})
+                                        </button>
+                                    </div>
                                 </td>
                             </tr>
                         </tbody>
@@ -89,5 +634,513 @@ const syncTimeFormatted = computed(() =>
                 </div>
             </div>
         </div>
+
+        <!-- Section D: Sync health panel (collapsible) -->
+        <div v-if="syncAvailable" class="border-t">
+            <button
+                class="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-muted/20 transition-colors"
+                @click="syncPanelOpen = !syncPanelOpen"
+            >
+                <div>
+                    <h2 class="text-base font-semibold text-foreground">{{ $t('status.syncHealth.title') }}</h2>
+                </div>
+                <ChevronDown
+                    class="h-4 w-4 text-muted-foreground transition-transform"
+                    :class="{ 'rotate-180': syncPanelOpen }"
+                />
+            </button>
+
+            <Transition
+                enter-active-class="transition-all duration-200 ease-out"
+                enter-from-class="opacity-0 -translate-y-1"
+                enter-to-class="opacity-100 translate-y-0"
+                leave-active-class="transition-all duration-150 ease-in"
+                leave-from-class="opacity-100 translate-y-0"
+                leave-to-class="opacity-0 -translate-y-1"
+            >
+                <div v-if="syncPanelOpen" class="px-6 pb-6 space-y-4">
+                    <!-- Lag indicator -->
+                    <div class="flex items-center gap-4 rounded-lg border bg-card px-4 py-3">
+                        <div>
+                            <p class="text-xs text-muted-foreground">{{ $t('status.syncHealth.lastSynced') }}</p>
+                            <p class="font-semibold text-foreground">{{ lastSyncedDisplay }}</p>
+                        </div>
+                        <div class="border-l pl-4">
+                            <p class="text-xs text-muted-foreground">{{ $t('status.syncHealth.lag') }}</p>
+                            <p class="font-semibold tabular-nums" :class="lagColor">
+                                {{ syncStatus?.lagSeconds ?? 0 }}s
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- Topics table -->
+                    <div v-if="syncStatus?.topics?.length">
+                        <h3 class="text-sm font-semibold text-foreground mb-2">{{ $t('status.syncHealth.topics') }}</h3>
+                        <div class="rounded-lg border bg-card overflow-hidden">
+                            <table class="w-full text-sm">
+                                <thead>
+                                    <tr class="border-b bg-muted/30">
+                                        <th class="text-left py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Topic ID</th>
+                                        <th class="text-right py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Messages</th>
+                                        <th class="text-center py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Has Next</th>
+                                        <th class="text-center py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Status</th>
+                                        <th class="text-right py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Last Update</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y">
+                                    <tr v-for="topic in syncStatus.topics" :key="topic.topicId" class="hover:bg-muted/20">
+                                        <td class="py-2 px-3 font-mono text-xs">{{ topic.topicId }}</td>
+                                        <td class="py-2 px-3 text-right tabular-nums">{{ topic.messageCount.toLocaleString() }}</td>
+                                        <td class="py-2 px-3 text-center">
+                                            <span
+                                                class="text-xs rounded-full px-2 py-0.5 font-medium"
+                                                :class="topic.hasNext ? 'bg-stat-amber/10 text-stat-amber' : 'bg-muted text-muted-foreground'"
+                                            >
+                                                {{ topic.hasNext ? 'Yes' : 'No' }}
+                                            </span>
+                                        </td>
+                                        <td class="py-2 px-3 text-center">
+                                            <span class="text-xs bg-muted rounded px-1.5 py-0.5">{{ topic.status }}</span>
+                                        </td>
+                                        <td class="py-2 px-3 text-right text-muted-foreground text-xs">{{ formatRelativeTime(topic.lastUpdate) }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <!-- Tokens table -->
+                    <div v-if="syncStatus?.tokens?.length">
+                        <h3 class="text-sm font-semibold text-foreground mb-2">{{ $t('status.syncHealth.tokens') }}</h3>
+                        <div class="rounded-lg border bg-card overflow-hidden">
+                            <table class="w-full text-sm">
+                                <thead>
+                                    <tr class="border-b bg-muted/30">
+                                        <th class="text-left py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Token ID</th>
+                                        <th class="text-right py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Serial</th>
+                                        <th class="text-left py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Type</th>
+                                        <th class="text-center py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Has Next</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y">
+                                    <tr v-for="token in syncStatus.tokens" :key="token.tokenId" class="hover:bg-muted/20">
+                                        <td class="py-2 px-3 font-mono text-xs">{{ token.tokenId }}</td>
+                                        <td class="py-2 px-3 text-right tabular-nums">{{ token.serialNumber }}</td>
+                                        <td class="py-2 px-3 text-xs">{{ token.type }}</td>
+                                        <td class="py-2 px-3 text-center">
+                                            <span
+                                                class="text-xs rounded-full px-2 py-0.5 font-medium"
+                                                :class="token.hasNext ? 'bg-stat-amber/10 text-stat-amber' : 'bg-muted text-muted-foreground'"
+                                            >
+                                                {{ token.hasNext ? 'Yes' : 'No' }}
+                                            </span>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </Transition>
+        </div>
+
+        <!-- Section E: Recent activity feed -->
+        <div class="border-t">
+            <div class="px-6 py-4 flex items-center justify-between">
+                <div>
+                    <h2 class="text-base font-semibold text-foreground">{{ $t('status.activity.title') }}</h2>
+                    <p class="text-xs text-muted-foreground mt-0.5">
+                        {{ filteredEvents.length }} {{ $t('status.activity.events') }}
+                        <span v-if="recentEvents.length >= 50" class="text-stat-amber"> (buffer full — oldest may be lost)</span>
+                    </p>
+                </div>
+                <!-- Filter toggle -->
+                <div class="flex items-center rounded-lg border bg-muted/30 p-0.5 text-xs font-medium">
+                    <button
+                        class="rounded-md px-3 py-1.5 transition-colors"
+                        :class="activityFilter === 'all'
+                            ? 'bg-card text-foreground shadow-sm'
+                            : 'text-muted-foreground hover:text-foreground'"
+                        @click="activityFilter = 'all'"
+                    >
+                        {{ $t('status.activity.filterAll') }}
+                    </button>
+                    <button
+                        class="rounded-md px-3 py-1.5 transition-colors flex items-center gap-1"
+                        :class="activityFilter === 'failures'
+                            ? 'bg-card text-stat-rose shadow-sm'
+                            : 'text-muted-foreground hover:text-foreground'"
+                        @click="activityFilter = 'failures'"
+                    >
+                        {{ $t('status.activity.filterFailures') }}
+                        <span
+                            v-if="recentEvents.filter(e => e.type === 'job-failed' || e.type === 'ipfs-fetch-failed').length > 0"
+                            class="inline-flex items-center justify-center h-4 min-w-4 rounded-full bg-stat-rose/10 text-stat-rose text-[10px] px-1"
+                        >
+                            {{ recentEvents.filter(e => e.type === 'job-failed' || e.type === 'ipfs-fetch-failed').length }}
+                        </span>
+                    </button>
+                </div>
+            </div>
+
+            <div class="px-6 pb-6">
+                <div class="rounded-xl border bg-card overflow-hidden">
+                    <!-- Empty state -->
+                    <div
+                        v-if="filteredEvents.length === 0"
+                        class="py-12 text-center text-sm text-muted-foreground"
+                    >
+                        {{ activityFilter === 'failures' ? $t('status.activity.emptyFailures') : $t('status.activity.empty') }}
+                    </div>
+
+                    <!-- Event rows -->
+                    <div v-else class="divide-y max-h-[480px] overflow-y-auto">
+                        <div
+                            v-for="(ev, idx) in filteredEvents"
+                            :key="`${ev.ts}-${idx}`"
+                            class="flex items-start gap-3 px-4 py-3 hover:bg-muted/20 transition-colors"
+                            :class="(ev.type === 'job-failed' || ev.type === 'ipfs-fetch-failed') ? 'bg-stat-rose/5' : ''"
+                        >
+                            <span class="text-xs text-muted-foreground font-mono shrink-0 pt-0.5 w-18">
+                                {{ formatTs(ev.ts) }}
+                            </span>
+                            <span
+                                class="shrink-0 text-xs font-medium rounded-full px-2 py-0.5 whitespace-nowrap"
+                                :class="eventBadgeClass[ev.type] ?? 'bg-muted text-muted-foreground'"
+                            >
+                                {{ eventLabel(ev.type) }}
+                            </span>
+                            <span class="text-xs text-muted-foreground font-mono min-w-0 break-all">
+                                {{ eventDetails(ev) }}
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        <!-- Retry-all confirmation overlay (inline, above table) -->
+        <Transition
+            enter-active-class="transition-all duration-150 ease-out"
+            enter-from-class="opacity-0 scale-95"
+            enter-to-class="opacity-100 scale-100"
+            leave-active-class="transition-all duration-100 ease-in"
+            leave-from-class="opacity-100 scale-100"
+            leave-to-class="opacity-0 scale-95"
+        >
+            <div
+                v-if="retryAllState"
+                class="fixed inset-0 z-40 flex items-center justify-center bg-black/30"
+                @click.self="cancelRetryAll"
+            >
+                <div class="bg-card rounded-xl border shadow-xl p-6 w-full max-w-md space-y-4 mx-4">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <h3 class="font-semibold text-foreground">{{ $t('status.retryAll.confirm') }}</h3>
+                            <p class="text-sm text-muted-foreground mt-1">
+                                Retry all {{ retryAllState.failedCount }} failed jobs in
+                                <code class="font-mono text-xs bg-muted px-1 rounded">{{ retryAllState.baseName }}</code>?
+                                Jobs that have exceeded the {{ MANUAL_RETRY_BUDGET }}-manual-retry budget will be skipped unless Force is checked.
+                            </p>
+                        </div>
+                        <button class="text-muted-foreground hover:text-foreground" @click="cancelRetryAll">
+                            <X class="h-4 w-4" />
+                        </button>
+                    </div>
+
+                    <label class="flex items-center gap-2 text-sm cursor-pointer select-none">
+                        <input
+                            v-model="retryAllState.force"
+                            type="checkbox"
+                            class="h-4 w-4 rounded border-border"
+                        />
+                        <span>{{ $t('status.retryAll.force') }}</span>
+                    </label>
+
+                    <div class="flex items-center justify-end gap-2">
+                        <button
+                            class="rounded px-3 py-1.5 text-sm border border-border hover:bg-muted transition-colors"
+                            @click="cancelRetryAll"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            class="rounded px-3 py-1.5 text-sm bg-stat-rose text-white hover:bg-stat-rose/90 transition-colors disabled:opacity-50 inline-flex items-center gap-1.5"
+                            :disabled="retryAllState.pending"
+                            @click="confirmRetryAll"
+                        >
+                            <Loader2 v-if="retryAllState.pending" class="h-3.5 w-3.5 animate-spin" />
+                            <RefreshCw v-else class="h-3.5 w-3.5" />
+                            Retry All
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Transition>
+
+        <!-- Failed jobs drawer -->
+        <Transition
+            enter-active-class="transition-transform duration-300 ease-out"
+            enter-from-class="translate-x-full"
+            enter-to-class="translate-x-0"
+            leave-active-class="transition-transform duration-200 ease-in"
+            leave-from-class="translate-x-0"
+            leave-to-class="translate-x-full"
+        >
+            <div
+                v-if="drawerBaseName"
+                class="fixed inset-y-0 right-0 z-50 flex"
+            >
+                <!-- Scrim -->
+                <div
+                    class="fixed inset-0 bg-black/20"
+                    @click="closeDrawer"
+                />
+
+                <!-- Drawer panel -->
+                <div class="relative ml-auto w-full max-w-2xl bg-card border-l shadow-2xl flex flex-col">
+                    <!-- Drawer header -->
+                    <div class="flex items-center justify-between border-b px-5 py-4 shrink-0">
+                        <div>
+                            <h2 class="font-semibold text-foreground">
+                                {{ $t('status.failedDrawer.title') }} —
+                                <code class="font-mono text-sm">{{ drawerBaseName }}</code>
+                            </h2>
+                            <p class="text-xs text-muted-foreground mt-0.5">
+                                {{ failedJobs?.total ?? 0 }} failed job{{ (failedJobs?.total ?? 0) === 1 ? '' : 's' }}
+                            </p>
+                        </div>
+                        <button
+                            class="h-8 w-8 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                            @click="closeDrawer"
+                        >
+                            <X class="h-4 w-4" />
+                        </button>
+                    </div>
+
+                    <!-- Tabs -->
+                    <div class="flex border-b shrink-0">
+                        <button
+                            class="px-5 py-2.5 text-sm font-medium border-b-2 transition-colors"
+                            :class="drawerTab === 'byReason'
+                                ? 'border-primary text-primary'
+                                : 'border-transparent text-muted-foreground hover:text-foreground'"
+                            @click="drawerTab = 'byReason'"
+                        >
+                            {{ $t('status.failedDrawer.byReason') }}
+                        </button>
+                        <button
+                            class="px-5 py-2.5 text-sm font-medium border-b-2 transition-colors"
+                            :class="drawerTab === 'allFailed'
+                                ? 'border-primary text-primary'
+                                : 'border-transparent text-muted-foreground hover:text-foreground'"
+                            @click="drawerTab = 'allFailed'"
+                        >
+                            {{ $t('status.failedDrawer.allFailed') }}
+                        </button>
+                    </div>
+
+                    <!-- Tab content -->
+                    <div class="flex-1 overflow-y-auto p-5 space-y-3">
+
+                        <!-- By reason tab -->
+                        <template v-if="drawerTab === 'byReason'">
+                            <div v-if="groupsPending" class="space-y-3">
+                                <div v-for="i in 3" :key="i" class="rounded-lg border p-4 animate-pulse space-y-2">
+                                    <div class="h-4 bg-muted rounded w-3/4" />
+                                    <div class="h-3 bg-muted rounded w-1/2" />
+                                </div>
+                            </div>
+
+                            <div v-else-if="failedGroups?.length === 0" class="py-12 text-center text-sm text-muted-foreground">
+                                No groups found
+                            </div>
+
+                            <div
+                                v-for="group in failedGroups"
+                                :key="group.reason"
+                                class="rounded-lg border bg-card p-4 space-y-2"
+                            >
+                                <div class="flex items-start justify-between gap-3">
+                                    <p class="text-sm font-medium text-foreground truncate max-w-xs" :title="group.reason">
+                                        {{ group.reason.slice(0, 80) }}{{ group.reason.length > 80 ? '…' : '' }}
+                                    </p>
+                                    <span class="shrink-0 text-xs text-muted-foreground font-medium">
+                                        Count: {{ group.count }}
+                                    </span>
+                                </div>
+                                <div class="flex flex-wrap gap-1">
+                                    <code
+                                        v-for="id in group.sampleJobIds?.slice(0, 3)"
+                                        :key="id"
+                                        class="text-xs bg-muted rounded px-1.5 py-0.5 font-mono"
+                                    >
+                                        {{ id }}
+                                    </code>
+                                </div>
+                                <button
+                                    class="inline-flex items-center gap-1 text-xs rounded px-2 py-1 border border-stat-rose/50 text-stat-rose hover:bg-stat-rose/5 transition-colors"
+                                    @click="openRetryAll({ baseName: drawerBaseName!, fullName: '', counts: { waiting: 0, active: 0, completed: 0, failed: group.count, delayed: 0, paused: 0 }, config: { concurrency: 1, attempts: 3, backoffType: '', backoffDelay: 0 }, isPaused: false })"
+                                >
+                                    <RefreshCw class="h-3 w-3" />
+                                    Retry group
+                                </button>
+                            </div>
+                        </template>
+
+                        <!-- All failed tab -->
+                        <template v-if="drawerTab === 'allFailed'">
+                            <div v-if="failedPending" class="space-y-2">
+                                <div v-for="i in 5" :key="i" class="rounded-lg border p-4 animate-pulse space-y-2">
+                                    <div class="h-4 bg-muted rounded w-full" />
+                                    <div class="h-3 bg-muted rounded w-2/3" />
+                                </div>
+                            </div>
+
+                            <div v-else-if="failedJobs?.items?.length === 0" class="py-12 text-center text-sm text-muted-foreground">
+                                No failed jobs
+                            </div>
+
+                            <div
+                                v-for="job in failedJobs?.items ?? []"
+                                :key="job.id"
+                                class="rounded-lg border bg-card p-4 space-y-2 transition-opacity"
+                                :class="{ 'opacity-0': jobRetryStates[job.id]?.done }"
+                            >
+                                <div class="flex items-start justify-between gap-3">
+                                    <code class="text-xs font-mono text-muted-foreground truncate max-w-50">{{ job.id }}</code>
+                                    <span class="text-xs text-muted-foreground shrink-0">{{ formatRelativeTime(new Date(job.finishedOn ?? job.timestamp).toISOString()) }}</span>
+                                </div>
+
+                                <p class="text-sm text-foreground" :title="job.failedReason">
+                                    {{ job.failedReason.slice(0, 60) }}{{ job.failedReason.length > 60 ? '…' : '' }}
+                                </p>
+
+                                <div class="flex items-center gap-3 text-xs text-muted-foreground">
+                                    <span>{{ $t('status.failedDrawer.attempts') }}: {{ job.attemptsMade }}/{{ mergedQueues.find(q => q.baseName === drawerBaseName)?.config.attempts ?? '?' }}</span>
+                                    <span
+                                        :class="job.manualRetryCount >= MANUAL_RETRY_BUDGET ? 'text-stat-rose font-medium' : ''"
+                                    >
+                                        {{ $t('status.failedDrawer.manualRetries') }}: {{ job.manualRetryCount }}/{{ MANUAL_RETRY_BUDGET }}
+                                    </span>
+                                </div>
+
+                                <!-- Retry controls -->
+                                <div class="flex items-center gap-2">
+                                    <template v-if="!jobRetryStates[job.id]?.confirming && !jobRetryStates[job.id]?.done">
+                                        <button
+                                            class="inline-flex items-center gap-1 text-xs rounded px-2 py-1 border border-border hover:bg-muted transition-colors"
+                                            :class="{ 'opacity-50 cursor-not-allowed': job.manualRetryCount >= MANUAL_RETRY_BUDGET && !jobRetryStates[job.id]?.force }"
+                                            :disabled="job.manualRetryCount >= MANUAL_RETRY_BUDGET && !jobRetryStates[job.id]?.force"
+                                            @click="startConfirmRetry(job.id)"
+                                        >
+                                            <RefreshCw class="h-3 w-3" />
+                                            {{ $t('status.failedDrawer.retryJob') }}
+                                        </button>
+
+                                        <label
+                                            v-if="job.manualRetryCount >= MANUAL_RETRY_BUDGET"
+                                            class="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none"
+                                        >
+                                            <input
+                                                v-model="getJobRetry(job.id).force"
+                                                type="checkbox"
+                                                class="h-3.5 w-3.5 rounded border-border"
+                                            />
+                                            {{ $t('status.failedDrawer.forceRetry') }}
+                                        </label>
+
+                                        <span
+                                            v-if="job.manualRetryCount >= MANUAL_RETRY_BUDGET"
+                                            class="text-xs text-stat-rose"
+                                        >
+                                            {{ $t('status.failedDrawer.budgetExhausted') }}
+                                        </span>
+                                    </template>
+
+                                    <!-- Confirmation inline -->
+                                    <template v-else-if="jobRetryStates[job.id]?.confirming">
+                                        <span class="text-xs text-muted-foreground">Confirm retry?</span>
+                                        <button
+                                            class="inline-flex items-center gap-1 text-xs rounded px-2 py-1 bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+                                            :disabled="jobRetryStates[job.id]?.pending"
+                                            @click="confirmRetryJob(job)"
+                                        >
+                                            <Loader2 v-if="jobRetryStates[job.id]?.pending" class="h-3 w-3 animate-spin" />
+                                            <CheckCircle2 v-else class="h-3 w-3" />
+                                            Yes, retry
+                                        </button>
+                                        <button
+                                            class="text-xs rounded px-2 py-1 border border-border hover:bg-muted transition-colors"
+                                            @click="cancelRetry(job.id)"
+                                        >
+                                            Cancel
+                                        </button>
+                                    </template>
+
+                                    <!-- Done state -->
+                                    <span v-else-if="jobRetryStates[job.id]?.done" class="text-xs text-stat-green flex items-center gap-1">
+                                        <CheckCircle2 class="h-3 w-3" />
+                                        Retried
+                                    </span>
+                                </div>
+
+                                <!-- Inline error -->
+                                <p v-if="jobRetryStates[job.id]?.error" class="text-xs text-stat-rose">
+                                    {{ jobRetryStates[job.id]?.error }}
+                                </p>
+
+                                <!-- Stacktrace collapsible -->
+                                <details v-if="job.stacktrace?.length" class="text-xs">
+                                    <summary class="cursor-pointer text-muted-foreground hover:text-foreground select-none">Stack trace</summary>
+                                    <pre class="mt-2 p-2 bg-muted rounded text-[10px] overflow-x-auto max-h-32 font-mono whitespace-pre-wrap break-all">{{ job.stacktrace.join('\n') }}</pre>
+                                </details>
+                            </div>
+
+                            <!-- Pagination -->
+                            <div v-if="(failedJobs?.total ?? 0) > 50" class="flex items-center justify-between pt-2">
+                                <button
+                                    class="text-xs rounded px-3 py-1.5 border border-border hover:bg-muted transition-colors disabled:opacity-40"
+                                    :disabled="failedPageOffset <= 0"
+                                    @click="failedPageOffset = Math.max(0, failedPageOffset - 50)"
+                                >
+                                    Previous
+                                </button>
+                                <span class="text-xs text-muted-foreground">
+                                    {{ failedPageOffset + 1 }}–{{ Math.min(failedPageOffset + 50, failedJobs?.total ?? 0) }}
+                                    of {{ failedJobs?.total ?? 0 }}
+                                </span>
+                                <button
+                                    class="text-xs rounded px-3 py-1.5 border border-border hover:bg-muted transition-colors disabled:opacity-40"
+                                    :disabled="failedPageOffset + 50 >= (failedJobs?.total ?? 0)"
+                                    @click="failedPageOffset += 50"
+                                >
+                                    Next
+                                </button>
+                            </div>
+                        </template>
+                    </div>
+
+                    <!-- Drawer footer actions -->
+                    <div class="border-t px-5 py-3 flex items-center justify-between shrink-0">
+                        <button
+                            class="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 transition-colors"
+                            :disabled="failedPending"
+                            @click="drawerTab === 'byReason' ? refreshGroups() : refreshFailed()"
+                        >
+                            <RefreshCw class="h-3.5 w-3.5" :class="{ 'animate-spin': failedPending || groupsPending }" />
+                            Refresh
+                        </button>
+                        <button
+                            class="text-sm rounded px-3 py-1.5 border border-border hover:bg-muted transition-colors"
+                            @click="closeDrawer"
+                        >
+                            {{ $t('common.close') }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Transition>
     </div>
 </template>

--- a/sustainable-explorer/src/api/api.module.ts
+++ b/sustainable-explorer/src/api/api.module.ts
@@ -10,12 +10,17 @@ import { RegistriesController } from './controllers/registries.controller';
 import { MethodologiesController } from './controllers/methodologies.controller';
 import { PolicySchemasController } from './controllers/policy-schemas.controller';
 import { ProjectsController } from './controllers/project.controller';
+import { QueueStatusController } from './controllers/queue-status.controller';
 
 // Services
 import { RegistriesService } from './services/registries.service';
 import { MethodologiesService } from './services/methodologies.service';
 import { PolicySchemasService } from './services/policy-schemas.service';
 import { ProjectsService } from './services/project.service';
+
+// Queue management
+import { QueueRegistry } from './queues/queue.registry';
+import { QueueEventsBus } from './queues/queue-events-bus.service';
 
 @Module({
     imports: [
@@ -29,6 +34,7 @@ import { ProjectsService } from './services/project.service';
         MethodologiesController,
         PolicySchemasController,
         ProjectsController,
+        QueueStatusController,
     ],
     providers: [
         NetworkDataSourceRegistry,
@@ -36,6 +42,8 @@ import { ProjectsService } from './services/project.service';
         MethodologiesService,
         PolicySchemasService,
         ProjectsService,
+        QueueRegistry,
+        QueueEventsBus,
     ],
 })
 export class ApiModule {}

--- a/sustainable-explorer/src/api/controllers/queue-status.controller.ts
+++ b/sustainable-explorer/src/api/controllers/queue-status.controller.ts
@@ -1,0 +1,504 @@
+import {
+    Controller,
+    Get,
+    Post,
+    Param,
+    Query,
+    Body,
+    Sse,
+    HttpCode,
+    HttpStatus,
+    ConflictException,
+    HttpException,
+    NotFoundException,
+    Logger,
+    MessageEvent,
+} from '@nestjs/common';
+import {
+    ApiTags,
+    ApiOperation,
+    ApiParam,
+    ApiQuery,
+    ApiResponse,
+    ApiBody,
+} from '@nestjs/swagger';
+import { Job } from 'bullmq';
+import { Observable } from 'rxjs';
+import { IsBoolean, IsInt, IsOptional, Min, Max } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { QueueRegistry } from '../queues/queue.registry';
+import { QueueEventsBus } from '../queues/queue-events-bus.service';
+import { NetworkDataSourceRegistry } from '../database/network-datasource.registry';
+import {
+    QueueStatusItemDto,
+    JobCountsDto,
+    QueueConfigDto,
+    FailedJobDto,
+    FailedJobListDto,
+    FailedJobGroupDto,
+    FailedJobGroupListDto,
+    RetryJobBodyDto,
+    RetryAllFailedBodyDto,
+    RetryAllFailedResultDto,
+    SyncStatusDto,
+    TopicSyncItemDto,
+    TokenSyncItemDto,
+} from '../dto/queue.dto';
+
+// ---------------------------------------------------------------------------
+// Inline query DTOs (simple enough not to warrant separate DTO files)
+// ---------------------------------------------------------------------------
+
+class FailedJobsQueryDto {
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    limit?: number = 50;
+
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    offset?: number = 0;
+
+    @IsOptional()
+    @Transform(({ value }) => value === true || value === 'true' || value === '1')
+    @IsBoolean()
+    groupByReason?: boolean = false;
+}
+
+// ---------------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------------
+
+@ApiTags('queue-status')
+@Controller('api/v1')
+export class QueueStatusController {
+    private readonly logger = new Logger(QueueStatusController.name);
+
+    constructor(
+        private readonly queueRegistry: QueueRegistry,
+        private readonly queueEventsBus: QueueEventsBus,
+        private readonly dataSources: NetworkDataSourceRegistry,
+    ) {}
+
+    // -------------------------------------------------------------------------
+    // SSE — MUST be declared first to avoid `:baseName` wildcard conflicts
+    // -------------------------------------------------------------------------
+
+    /**
+     * GET /:network/queues/events
+     * Server-Sent Events stream — emits real-time queue status updates.
+     */
+    @Sse(':network/queues/events')
+    @ApiOperation({
+        summary: 'Server-Sent Events stream for real-time queue status updates',
+        description:
+            'Streams job lifecycle events (completed, failed, active, waiting, stalled), ' +
+            'debounced counts-changed snapshots, se:events pub/sub messages, ' +
+            'and a heartbeat every 25 s. Connect with EventSource on the client.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'] })
+    @ApiResponse({ status: 200, description: 'SSE stream established' })
+    streamQueueEvents(@Param('network') network: string): Observable<MessageEvent> {
+        // Validate that the network is known before establishing the stream
+        this.queueRegistry.getConfiguredNetworks(); // noop — just proves the service is available
+        return this.queueEventsBus.streamForNetwork(network);
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /:network/queues — list all queues with counts
+    // -------------------------------------------------------------------------
+
+    @Get(':network/queues')
+    @ApiOperation({
+        summary: 'List all BullMQ queues for a network with live job counts',
+        description:
+            'Returns one entry per base queue name.  Counts are fetched live from ' +
+            'BullMQ/Redis on every call — no caching.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'] })
+    @ApiResponse({ status: 200, type: [QueueStatusItemDto] })
+    @ApiResponse({ status: 404, description: 'Network not configured on this API instance' })
+    async listQueues(@Param('network') network: string): Promise<QueueStatusItemDto[]> {
+        const configured = this.queueRegistry.getConfiguredNetworks();
+        if (!configured.includes(network.toLowerCase())) {
+            throw new NotFoundException(
+                `Network "${network}" is not configured. Available: ${configured.join(', ')}`,
+            );
+        }
+
+        const baseNames = this.queueRegistry.listBaseNames();
+        const items: QueueStatusItemDto[] = [];
+
+        for (const base of baseNames) {
+            try {
+                const queue = this.queueRegistry.getQueue(network, base);
+                const qConfig = this.queueRegistry.getQueueConfig(network, base);
+                const [rawCounts, isPaused] = await Promise.all([
+                    queue.getJobCounts('waiting', 'active', 'completed', 'failed', 'delayed', 'paused'),
+                    queue.isPaused(),
+                ]);
+
+                const counts: JobCountsDto = {
+                    waiting: rawCounts['waiting'] ?? 0,
+                    active: rawCounts['active'] ?? 0,
+                    completed: rawCounts['completed'] ?? 0,
+                    failed: rawCounts['failed'] ?? 0,
+                    delayed: rawCounts['delayed'] ?? 0,
+                    paused: rawCounts['paused'] ?? 0,
+                };
+
+                const config: QueueConfigDto = qConfig
+                    ? {
+                          concurrency: qConfig.concurrency,
+                          attempts: qConfig.defaultJobOptions.attempts,
+                          backoffType: qConfig.defaultJobOptions.backoff.type,
+                          backoffDelay: qConfig.defaultJobOptions.backoff.delay,
+                      }
+                    : { concurrency: 0, attempts: 0, backoffType: 'unknown', backoffDelay: 0 };
+
+                const fullName = queue.name;
+
+                items.push({ baseName: base, fullName, counts, config, isPaused });
+            } catch (error: unknown) {
+                if (error instanceof NotFoundException) throw error;
+                const msg = error instanceof Error ? error.message : String(error);
+                this.logger.warn(`Failed to fetch queue info for ${network}:${base}: ${msg}`);
+            }
+        }
+
+        return items;
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /:network/queues/:baseName/failed — failed job list / grouped
+    // -------------------------------------------------------------------------
+
+    @Get(':network/queues/:baseName/failed')
+    @ApiOperation({
+        summary: 'List failed jobs for a specific queue',
+        description:
+            'When groupByReason=false (default): returns a paginated list of failed jobs. ' +
+            'When groupByReason=true: returns jobs grouped by their failure reason.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'] })
+    @ApiParam({ name: 'baseName', description: 'Base queue name, e.g. "mirror-node-topics"' })
+    @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Max items to return (default 50)' })
+    @ApiQuery({ name: 'offset', required: false, type: Number, description: 'Item offset for pagination (default 0)' })
+    @ApiQuery({
+        name: 'groupByReason',
+        required: false,
+        type: Boolean,
+        description: 'When true, group results by failure reason',
+    })
+    @ApiResponse({ status: 200, description: 'Failed job list or grouped summary' })
+    @ApiResponse({ status: 404, description: 'Network or queue not found' })
+    async getFailedJobs(
+        @Param('network') network: string,
+        @Param('baseName') baseName: string,
+        @Query() query: FailedJobsQueryDto,
+    ): Promise<FailedJobListDto | FailedJobGroupListDto> {
+        const queue = this.queueRegistry.getQueue(network, baseName);
+        const limit = query.limit ?? 50;
+        const offset = query.offset ?? 0;
+        const groupByReason = query.groupByReason ?? false;
+
+        // Use getJobCounts for the total — reads ZCARD directly, stays consistent
+        // with the queue list endpoint. getFailedCount() can diverge after removeOnFail trims.
+        const [rawFailed, counts] = await Promise.all([
+            queue.getFailed(offset, offset + limit - 1),
+            queue.getJobCounts('failed'),
+        ]);
+        const total = counts['failed'] ?? 0;
+
+        // Job.fromId returns undefined when the hash is missing (e.g. BullMQ version
+        // mismatch, partial cleanup). Filter those out so the mapping doesn't throw.
+        const failedJobs = (rawFailed as (Job | undefined | null)[]).filter(
+            (j): j is Job => j != null,
+        );
+
+        if (groupByReason) {
+            const groupMap = new Map<string, { count: number; sampleJobIds: string[] }>();
+            for (const job of failedJobs) {
+                const reason = job.failedReason ?? '(unknown)';
+                const entry = groupMap.get(reason) ?? { count: 0, sampleJobIds: [] };
+                entry.count += 1;
+                if (entry.sampleJobIds.length < 5) {
+                    entry.sampleJobIds.push(job.id ?? '');
+                }
+                groupMap.set(reason, entry);
+            }
+
+            const groups: FailedJobGroupDto[] = Array.from(groupMap.entries()).map(([reason, g]) => ({
+                reason,
+                count: g.count,
+                sampleJobIds: g.sampleJobIds,
+            }));
+
+            return { groups };
+        }
+
+        const items: FailedJobDto[] = failedJobs.map((job) => ({
+            id: job.id ?? '',
+            name: job.name,
+            data: job.data as unknown,
+            failedReason: job.failedReason ?? '',
+            stacktrace: (job.stacktrace?.[0] ?? '').split('\n').slice(0, 3),
+            attemptsMade: job.attemptsMade,
+            manualRetryCount: (job.data as Record<string, unknown> | undefined)?.['manualRetryCount'] as number ?? 0,
+            timestamp: job.timestamp,
+            processedOn: job.processedOn ?? 0,
+            finishedOn: job.finishedOn ?? 0,
+        }));
+
+        return { total, items };
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /:network/queues/:baseName/jobs/:jobId/retry — single job retry
+    // -------------------------------------------------------------------------
+
+    @Post(':network/queues/:baseName/jobs/:jobId/retry')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Retry a single failed job',
+        description:
+            'Loads the job from the queue, validates it is in the failed state, ' +
+            'checks the manual retry budget (max 3 unless force=true), ' +
+            'increments manualRetryCount in the job data, then re-queues it.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'] })
+    @ApiParam({ name: 'baseName', description: 'Base queue name' })
+    @ApiParam({ name: 'jobId', description: 'BullMQ job ID' })
+    @ApiBody({ type: RetryJobBodyDto })
+    @ApiResponse({ status: 200, description: 'Job re-queued successfully' })
+    @ApiResponse({ status: 404, description: 'Job not found' })
+    @ApiResponse({ status: 409, description: 'Job is not in failed state' })
+    @ApiResponse({ status: 429, description: 'Manual retry budget exhausted' })
+    async retryJob(
+        @Param('network') network: string,
+        @Param('baseName') baseName: string,
+        @Param('jobId') jobId: string,
+        @Body() body: RetryJobBodyDto,
+    ): Promise<{ ok: boolean; jobId: string; manualRetryCount: number }> {
+        const queue = this.queueRegistry.getQueue(network, baseName);
+
+        const job = await Job.fromId(queue, jobId);
+        if (!job) {
+            throw new NotFoundException(`Job "${jobId}" not found in queue "${queue.name}"`);
+        }
+
+        const state = await job.getState();
+        if (state !== 'failed') {
+            throw new ConflictException({ message: 'Job is not in failed state', state });
+        }
+
+        const data = job.data as Record<string, unknown> | undefined;
+        const currentCount: number = (data?.['manualRetryCount'] as number) ?? 0;
+
+        if (currentCount >= 3 && !body.force) {
+            throw new HttpException(
+                {
+                    message: 'Manual retry budget exhausted. Pass force: true to override.',
+                    manualRetryCount: currentCount,
+                },
+                HttpStatus.TOO_MANY_REQUESTS,
+            );
+        }
+
+        const updatedCount = currentCount + 1;
+        await job.updateData({ ...job.data, manualRetryCount: updatedCount });
+        await job.retry();
+
+        return { ok: true, jobId, manualRetryCount: updatedCount };
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /:network/queues/:baseName/retry-all-failed
+    // -------------------------------------------------------------------------
+
+    @Post(':network/queues/:baseName/retry-all-failed')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Retry all (or a batch of) failed jobs',
+        description:
+            'Fetches up to `limit` failed jobs, applies the per-job manual retry budget, ' +
+            'and re-queues eligible jobs.  Returns counts of retried, skipped, and errored jobs.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'] })
+    @ApiParam({ name: 'baseName', description: 'Base queue name' })
+    @ApiBody({ type: RetryAllFailedBodyDto })
+    @ApiResponse({ status: 200, type: RetryAllFailedResultDto })
+    async retryAllFailed(
+        @Param('network') network: string,
+        @Param('baseName') baseName: string,
+        @Body() body: RetryAllFailedBodyDto,
+    ): Promise<RetryAllFailedResultDto> {
+        const queue = this.queueRegistry.getQueue(network, baseName);
+        const limit = body.limit ?? 100;
+        const force = body.force ?? false;
+        const olderThanMs = body.olderThanMs;
+
+        const failedJobs = await queue.getFailed(0, limit - 1);
+
+        let retried = 0;
+        let skipped = 0;
+        const errors: { jobId: string; reason: string }[] = [];
+
+        for (const job of failedJobs) {
+            try {
+                // Optional age filter
+                if (olderThanMs !== undefined) {
+                    const finishedOn = job.finishedOn ?? 0;
+                    if (Date.now() - finishedOn < olderThanMs) {
+                        skipped++;
+                        continue;
+                    }
+                }
+
+                const data = job.data as Record<string, unknown> | undefined;
+                const currentCount: number = (data?.['manualRetryCount'] as number) ?? 0;
+
+                if (currentCount >= 3 && !force) {
+                    skipped++;
+                    continue;
+                }
+
+                const updatedCount = currentCount + 1;
+                await job.updateData({ ...job.data, manualRetryCount: updatedCount });
+                await job.retry();
+                retried++;
+            } catch (error: unknown) {
+                const reason = error instanceof Error ? error.message : String(error);
+                errors.push({ jobId: job.id ?? '', reason });
+            }
+        }
+
+        return { retried, skipped, errors };
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /:network/queues/:baseName/pause   [RESERVED — admin panel phase]
+    // POST /:network/queues/:baseName/resume  [RESERVED — admin panel phase]
+    // -------------------------------------------------------------------------
+    // These endpoints are intentionally disabled on the public API.
+    // Re-enable when the operator admin panel with authentication is shipped.
+    //
+    // @Post(':network/queues/:baseName/pause')
+    // async pauseQueue(@Param('network') network: string, @Param('baseName') baseName: string) {
+    //     const queue = this.queueRegistry.getQueue(network, baseName);
+    //     await queue.pause();
+    //     return { paused: true };
+    // }
+    //
+    // @Post(':network/queues/:baseName/resume')
+    // async resumeQueue(@Param('network') network: string, @Param('baseName') baseName: string) {
+    //     const queue = this.queueRegistry.getQueue(network, baseName);
+    //     await queue.resume();
+    //     return { paused: false };
+    // }
+
+    // -------------------------------------------------------------------------
+    // GET /:network/sync-status
+    // -------------------------------------------------------------------------
+
+    @Get(':network/sync-status')
+    @ApiOperation({
+        summary: 'Get sync health status for a network',
+        description:
+            'Queries topic_cache and token_cache tables to report the last synced ' +
+            'consensus timestamp, approximate lag, and per-topic/token watermarks.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'] })
+    @ApiResponse({ status: 200, type: SyncStatusDto })
+    @ApiResponse({ status: 404, description: 'Network not configured on this API instance' })
+    async getSyncStatus(@Param('network') network: string): Promise<SyncStatusDto> {
+        const ds = this.dataSources.getDataSource(network);
+
+        const [topicRows, tokenRows, [aggRow]]: [
+            Array<{
+                topicId: string;
+                messages: number;
+                hasNext: boolean;
+                lastUpdate: string;
+                status: string;
+            }>,
+            Array<{
+                tokenId: string;
+                serialNumber: number;
+                hasNext: boolean;
+                type: string | null;
+            }>,
+            Array<{ totalTopics: string; syncedTopics: string; totalMessages: string }>,
+        ] = await Promise.all([
+            ds.query(
+                `SELECT "topicId", messages, "hasNext", "lastUpdate", status
+                 FROM topic_cache
+                 ORDER BY messages DESC
+                 LIMIT 50`,
+            ),
+            ds.query(
+                `SELECT "tokenId", "serialNumber", "hasNext", type
+                 FROM token_cache
+                 LIMIT 50`,
+            ),
+            ds.query(
+                `SELECT COUNT(*)::int AS "totalTopics",
+                        COUNT(*) FILTER (WHERE "hasNext" = false)::int AS "syncedTopics",
+                        COALESCE(SUM(messages), 0)::bigint AS "totalMessages"
+                 FROM topic_cache`,
+            ),
+        ]);
+
+        // lastUpdate is stored as either:
+        //   - milliseconds string: "1778146836950"  (13 digits, from Date.now())
+        //   - Hedera consensus format: "1746620000.123456789" (seconds.nanoseconds)
+        // Normalise to Unix seconds by dividing ms values by 1000.
+        let maxSeconds: number | null = null;
+        for (const row of topicRows) {
+            if (row.lastUpdate) {
+                const raw = parseInt(row.lastUpdate.split('.')[0], 10);
+                const secs = raw > 1e10 ? Math.floor(raw / 1000) : raw;
+                if (!isNaN(secs) && (maxSeconds === null || secs > maxSeconds)) {
+                    maxSeconds = secs;
+                }
+            }
+        }
+
+        const lastSyncedAt = maxSeconds !== null ? new Date(maxSeconds * 1000).toISOString() : null;
+        const lagSeconds =
+            maxSeconds !== null ? Math.max(0, Math.floor(Date.now() / 1000) - maxSeconds) : 0;
+
+        const topics: TopicSyncItemDto[] = topicRows.map((r) => {
+            const raw = parseInt((r.lastUpdate ?? '').split('.')[0], 10);
+            const secs = raw > 1e10 ? Math.floor(raw / 1000) : raw;
+            const lastUpdateIso = !isNaN(secs) && secs > 0 ? new Date(secs * 1000).toISOString() : '';
+            return {
+                topicId: r.topicId,
+                messageCount: Number(r.messages),
+                hasNext: r.hasNext,
+                lastUpdate: lastUpdateIso,
+                status: r.status,
+            };
+        });
+
+        const tokens: TokenSyncItemDto[] = tokenRows.map((r) => ({
+            tokenId: r.tokenId,
+            serialNumber: Number(r.serialNumber),
+            hasNext: r.hasNext,
+            type: r.type,
+        }));
+
+        return {
+            lastSyncedAt,
+            lagSeconds,
+            totalTopics: Number(aggRow?.totalTopics ?? 0),
+            syncedTopics: Number(aggRow?.syncedTopics ?? 0),
+            totalMessages: Number(aggRow?.totalMessages ?? 0),
+            topics,
+            tokens,
+        };
+    }
+}

--- a/sustainable-explorer/src/api/dto/queue.dto.ts
+++ b/sustainable-explorer/src/api/dto/queue.dto.ts
@@ -1,0 +1,248 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsOptional, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+// ---------------------------------------------------------------------------
+// Sub-DTOs
+// ---------------------------------------------------------------------------
+
+export class JobCountsDto {
+    @ApiProperty({ description: 'Jobs waiting to be picked up by a worker' })
+    waiting: number;
+
+    @ApiProperty({ description: 'Jobs currently being processed' })
+    active: number;
+
+    @ApiProperty({ description: 'Jobs that completed successfully' })
+    completed: number;
+
+    @ApiProperty({ description: 'Jobs that exhausted all retry attempts' })
+    failed: number;
+
+    @ApiProperty({ description: 'Jobs scheduled to run at a future time' })
+    delayed: number;
+
+    @ApiProperty({ description: 'Jobs in a queue that has been paused' })
+    paused: number;
+}
+
+export class QueueConfigDto {
+    @ApiProperty({ description: 'Worker concurrency for this queue' })
+    concurrency: number;
+
+    @ApiProperty({ description: 'Maximum number of retry attempts' })
+    attempts: number;
+
+    @ApiProperty({ description: 'Backoff strategy: exponential or fixed', enum: ['exponential', 'fixed'] })
+    backoffType: string;
+
+    @ApiProperty({ description: 'Initial backoff delay in milliseconds' })
+    backoffDelay: number;
+}
+
+// ---------------------------------------------------------------------------
+// Queue status list
+// ---------------------------------------------------------------------------
+
+export class QueueStatusItemDto {
+    @ApiProperty({ description: 'Base queue name without network suffix, e.g. "mirror-node-topics"' })
+    baseName: string;
+
+    @ApiProperty({ description: 'Fully-qualified queue name, e.g. "mirror-node-topics-testnet"' })
+    fullName: string;
+
+    @ApiProperty({ type: JobCountsDto, description: 'Current job count breakdown' })
+    counts: JobCountsDto;
+
+    @ApiProperty({ type: QueueConfigDto, description: 'Static configuration for this queue' })
+    config: QueueConfigDto;
+
+    @ApiProperty({ description: 'Whether the queue is currently paused' })
+    isPaused: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Failed jobs
+// ---------------------------------------------------------------------------
+
+export class FailedJobDto {
+    @ApiProperty({ description: 'BullMQ job ID' })
+    id: string;
+
+    @ApiProperty({ description: 'Job name (type)' })
+    name: string;
+
+    @ApiProperty({ description: 'Job payload data' })
+    data: unknown;
+
+    @ApiProperty({ description: 'The error message that caused the failure' })
+    failedReason: string;
+
+    @ApiProperty({ type: [String], description: 'First 3 lines of the first stack trace entry' })
+    stacktrace: string[];
+
+    @ApiProperty({ description: 'Number of attempts made before the job was marked failed' })
+    attemptsMade: number;
+
+    @ApiProperty({ description: 'Number of times this job has been manually retried via the API' })
+    manualRetryCount: number;
+
+    @ApiProperty({ description: 'Unix timestamp (ms) when the job was created' })
+    timestamp: number;
+
+    @ApiProperty({ description: 'Unix timestamp (ms) when the job started processing' })
+    processedOn: number;
+
+    @ApiProperty({ description: 'Unix timestamp (ms) when the job finished (failed)' })
+    finishedOn: number;
+}
+
+export class FailedJobListDto {
+    @ApiProperty({ description: 'Total number of failed jobs in the queue' })
+    total: number;
+
+    @ApiProperty({ type: [FailedJobDto] })
+    items: FailedJobDto[];
+}
+
+export class FailedJobGroupDto {
+    @ApiProperty({ description: 'The failure reason text used as the grouping key' })
+    reason: string;
+
+    @ApiProperty({ description: 'Number of jobs that share this failure reason' })
+    count: number;
+
+    @ApiProperty({ type: [String], description: 'Up to 5 representative job IDs from this group' })
+    sampleJobIds: string[];
+}
+
+export class FailedJobGroupListDto {
+    @ApiProperty({ type: [FailedJobGroupDto] })
+    groups: FailedJobGroupDto[];
+}
+
+// ---------------------------------------------------------------------------
+// Retry request / response bodies
+// ---------------------------------------------------------------------------
+
+export class RetryJobBodyDto {
+    @ApiPropertyOptional({
+        description:
+            'When true, bypass the 3-retry budget cap and force a retry regardless of manualRetryCount.',
+        default: false,
+    })
+    @IsOptional()
+    @IsBoolean()
+    force?: boolean;
+}
+
+export class RetryAllFailedBodyDto {
+    @ApiPropertyOptional({
+        description:
+            'Only retry jobs older than this many milliseconds (based on job finishedOn timestamp).',
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    olderThanMs?: number;
+
+    @ApiPropertyOptional({
+        description: 'Maximum number of failed jobs to retry in a single call.',
+        default: 100,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(1000)
+    limit?: number = 100;
+
+    @ApiPropertyOptional({
+        description: 'When true, bypass the per-job manual retry budget.',
+        default: false,
+    })
+    @IsOptional()
+    @IsBoolean()
+    force?: boolean;
+}
+
+export class RetryErrorItemDto {
+    @ApiProperty()
+    jobId: string;
+
+    @ApiProperty()
+    reason: string;
+}
+
+export class RetryAllFailedResultDto {
+    @ApiProperty({ description: 'Number of jobs successfully queued for retry' })
+    retried: number;
+
+    @ApiProperty({ description: 'Number of jobs skipped due to retry budget exhaustion' })
+    skipped: number;
+
+    @ApiProperty({ type: [RetryErrorItemDto], description: 'Jobs that could not be retried due to unexpected errors' })
+    errors: RetryErrorItemDto[];
+}
+
+// ---------------------------------------------------------------------------
+// Sync-status
+// ---------------------------------------------------------------------------
+
+export class TopicSyncItemDto {
+    @ApiProperty({ description: 'Hedera topic ID, e.g. "0.0.12345"' })
+    topicId: string;
+
+    @ApiProperty({ description: 'Number of HCS messages processed for this topic' })
+    messageCount: number;
+
+    @ApiProperty({ description: 'Whether there are more messages to fetch' })
+    hasNext: boolean;
+
+    @ApiProperty({ description: 'Hedera consensus timestamp of the last synced message (seconds.nanoseconds)' })
+    lastUpdate: string;
+
+    @ApiProperty({ description: 'Sync status code for this topic', example: 'SYNCED' })
+    status: string;
+}
+
+export class TokenSyncItemDto {
+    @ApiProperty({ description: 'Hedera token ID, e.g. "0.0.99999"' })
+    tokenId: string;
+
+    @ApiProperty({ description: 'Highest NFT serial number processed' })
+    serialNumber: number;
+
+    @ApiProperty({ description: 'Whether there are more NFT serials to fetch' })
+    hasNext: boolean;
+
+    @ApiPropertyOptional({ description: 'Token type', example: 'NON_FUNGIBLE_UNIQUE', nullable: true })
+    type: string | null;
+}
+
+export class SyncStatusDto {
+    @ApiProperty({
+        description: 'ISO-8601 datetime of the most recently synced message, or null if none',
+        nullable: true,
+    })
+    lastSyncedAt: string | null;
+
+    @ApiProperty({ description: 'Approximate lag in seconds between last sync and now' })
+    lagSeconds: number;
+
+    @ApiProperty({ description: 'Total number of topics tracked in topic_cache' })
+    totalTopics: number;
+
+    @ApiProperty({ description: 'Topics fully caught up (hasNext = false)' })
+    syncedTopics: number;
+
+    @ApiProperty({ description: 'Total HCS messages indexed across all topics' })
+    totalMessages: number;
+
+    @ApiProperty({ type: [TopicSyncItemDto], description: 'Top 50 topics by message count' })
+    topics: TopicSyncItemDto[];
+
+    @ApiProperty({ type: [TokenSyncItemDto], description: 'Up to 50 tracked tokens' })
+    tokens: TokenSyncItemDto[];
+}

--- a/sustainable-explorer/src/api/queues/queue-events-bus.service.ts
+++ b/sustainable-explorer/src/api/queues/queue-events-bus.service.ts
@@ -1,0 +1,229 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy, MessageEvent } from '@nestjs/common';
+import { EventEmitter } from 'events';
+import Redis from 'ioredis';
+import { Queue } from 'bullmq';
+import { Observable, fromEvent, interval, merge } from 'rxjs';
+import { map, filter } from 'rxjs/operators';
+import { QueueRegistry } from './queue.registry';
+import { getRedictConfig } from '@shared/config/redict.config';
+
+// ---------------------------------------------------------------------------
+// Internal event shape emitted on the EventEmitter
+// ---------------------------------------------------------------------------
+
+interface QueueBusEvent {
+    network: string;
+    queueBase: string;
+    type: string;
+    [key: string]: unknown;
+}
+
+const BUS_EVENT = 'queue-bus-event';
+const SE_CHANNEL = 'se:events';
+const HEARTBEAT_INTERVAL_MS = 25_000;
+const COUNTS_DEBOUNCE_MS = 500;
+
+/**
+ * Fans out BullMQ QueueEvents + Redis pub/sub messages to per-network
+ * SSE Observable streams.
+ *
+ * Uses Node's built-in EventEmitter (EventEmitter2 is not a project dependency)
+ * plus RxJS fromEvent / interval / merge.
+ */
+@Injectable()
+export class QueueEventsBus implements OnModuleInit, OnModuleDestroy {
+    private readonly logger = new Logger(QueueEventsBus.name);
+    private readonly emitter = new EventEmitter();
+
+    /** Subscriber connection — dedicated, cannot issue other commands. */
+    private subscriber!: Redis;
+
+    /** Debounce timers keyed by "${network}:${queueBase}" */
+    private readonly countTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+    constructor(private readonly registry: QueueRegistry) {
+        // Increase max listeners to avoid Node warnings when many SSE clients connect.
+        this.emitter.setMaxListeners(200);
+    }
+
+    async onModuleInit(): Promise<void> {
+        this.wireQueueEvents();
+        await this.wireRedisSubscriber();
+    }
+
+    async onModuleDestroy(): Promise<void> {
+        // Cancel all debounce timers
+        for (const timer of this.countTimers.values()) {
+            clearTimeout(timer);
+        }
+        this.countTimers.clear();
+
+        // Disconnect subscriber
+        try {
+            this.subscriber.disconnect();
+        } catch {
+            // ignore
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Public API
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Returns an Observable<MessageEvent> that emits queue bus events belonging
+     * to the requested network, plus a heartbeat every 25 s.
+     */
+    streamForNetwork(network: string): Observable<MessageEvent> {
+        const events$ = fromEvent<QueueBusEvent>(this.emitter, BUS_EVENT).pipe(
+            filter((evt) => evt.network === network || evt.type === 'se-event'),
+            map((evt) => this.toMessageEvent(evt)),
+        );
+
+        const heartbeat$ = interval(HEARTBEAT_INTERVAL_MS).pipe(
+            map(() => this.toMessageEvent({ type: 'heartbeat', network, ts: Date.now() })),
+        );
+
+        return merge(events$, heartbeat$);
+    }
+
+    // ---------------------------------------------------------------------------
+    // BullMQ QueueEvents wiring
+    // ---------------------------------------------------------------------------
+
+    private wireQueueEvents(): void {
+        for (const { network, baseName, queue, events } of this.registry.getAllEntries()) {
+            const emit = (extra: Record<string, unknown>) => {
+                const evt: QueueBusEvent = { network, queueBase: baseName, ...extra } as QueueBusEvent;
+                this.emitter.emit(BUS_EVENT, evt);
+                this.scheduleCountsChanged(network, baseName, queue);
+            };
+
+            events.on('completed', ({ jobId, returnvalue }) => {
+                emit({ type: 'job-completed', jobId, returnValue: returnvalue });
+            });
+
+            events.on('failed', ({ jobId, failedReason, prev }) => {
+                emit({ type: 'job-failed', jobId, failedReason, attemptsMade: prev ?? 0 });
+            });
+
+            events.on('active', ({ jobId }) => {
+                emit({ type: 'job-active', jobId });
+            });
+
+            events.on('waiting', ({ jobId }) => {
+                emit({ type: 'job-waiting', jobId });
+            });
+
+            events.on('stalled', ({ jobId }) => {
+                emit({ type: 'job-stalled', jobId });
+            });
+
+            events.on('error', (error: Error) => {
+                this.logger.warn(
+                    `QueueEvents error for ${network}:${baseName}: ${error.message}`,
+                );
+            });
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Counts-changed debounce
+    // ---------------------------------------------------------------------------
+
+    private scheduleCountsChanged(network: string, baseName: string, queue: Queue): void {
+        const timerKey = `${network}:${baseName}`;
+
+        // Reset the timer on each trigger (debounce — not throttle)
+        const existing = this.countTimers.get(timerKey);
+        if (existing !== undefined) {
+            clearTimeout(existing);
+        }
+
+        const timer = setTimeout(async () => {
+            this.countTimers.delete(timerKey);
+            try {
+                const counts = await queue.getJobCounts(
+                    'waiting',
+                    'active',
+                    'completed',
+                    'failed',
+                    'delayed',
+                    'paused',
+                );
+                const evt: QueueBusEvent = {
+                    network,
+                    queueBase: baseName,
+                    type: 'counts-changed',
+                    counts,
+                };
+                this.emitter.emit(BUS_EVENT, evt);
+            } catch (error: unknown) {
+                const msg = error instanceof Error ? error.message : String(error);
+                this.logger.warn(`Failed to fetch job counts for ${timerKey}: ${msg}`);
+            }
+        }, COUNTS_DEBOUNCE_MS);
+
+        this.countTimers.set(timerKey, timer);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Redis subscriber for se:events channel
+    // ---------------------------------------------------------------------------
+
+    private async wireRedisSubscriber(): Promise<void> {
+        const config = getRedictConfig();
+
+        // Subscriber connections must NOT share the same ioredis instance used
+        // by BullMQ — once subscribed the connection cannot issue other commands.
+        // Strip keyPrefix: subscriber channels are not prefixed by ioredis
+        // automatically when using subscribe().
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { keyPrefix: _keyPrefix, ...connectionOpts } = config;
+
+        this.subscriber = new Redis({
+            ...connectionOpts,
+            // Keep the connection alive even if the server is momentarily unavailable.
+            lazyConnect: false,
+        });
+
+        this.subscriber.on('error', (error: Error) => {
+            this.logger.warn(`Redis subscriber error: ${error.message}`);
+        });
+
+        try {
+            await this.subscriber.subscribe(SE_CHANNEL);
+            this.logger.log(`Subscribed to Redis channel "${SE_CHANNEL}"`);
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.logger.error(`Failed to subscribe to "${SE_CHANNEL}": ${msg}`);
+        }
+
+        this.subscriber.on('message', (_channel: string, message: string) => {
+            try {
+                const parsed: unknown = JSON.parse(message);
+                const evt: QueueBusEvent = {
+                    network: '*',       // se:events are cross-network; filter at consumer
+                    queueBase: '',
+                    type: 'se-event',
+                    payload: parsed,
+                };
+                this.emitter.emit(BUS_EVENT, evt);
+            } catch {
+                // Non-JSON message — ignore
+            }
+        });
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private toMessageEvent(evt: Record<string, unknown>): MessageEvent {
+        return {
+            data: JSON.stringify(evt),
+            type: String(evt['type'] ?? 'event'),
+            id: String(Date.now()),
+        };
+    }
+}

--- a/sustainable-explorer/src/api/queues/queue.registry.ts
+++ b/sustainable-explorer/src/api/queues/queue.registry.ts
@@ -1,0 +1,171 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy, NotFoundException } from '@nestjs/common';
+import { Queue, QueueEvents } from 'bullmq';
+import {
+    BASE_QUEUE_NAMES,
+    getQueueConfigs,
+    QueueDefinition,
+} from '@shared/config/bullmq.config';
+import { getConfiguredNetworks } from '@shared/config/database.config';
+import { getRedictConfig } from '@shared/config/redict.config';
+
+/**
+ * Manages one BullMQ Queue + QueueEvents pair per (network × base-queue-name)
+ * combination. Used exclusively by the API process — does NOT use @InjectQueue
+ * because the worker module is not imported here.
+ *
+ * Map key: `${network}:${baseQueueName}` (e.g. "testnet:mirror-node-topics")
+ */
+@Injectable()
+export class QueueRegistry implements OnModuleInit, OnModuleDestroy {
+    private readonly logger = new Logger(QueueRegistry.name);
+    private readonly queues = new Map<string, Queue>();
+    private readonly queueEvents = new Map<string, QueueEvents>();
+    private readonly networks: string[];
+    private readonly baseNames: string[];
+
+    constructor() {
+        this.networks = getConfiguredNetworks();
+        this.baseNames = Object.values(BASE_QUEUE_NAMES);
+    }
+
+    async onModuleInit(): Promise<void> {
+        // Strip keyPrefix — BullMQ manages its own key namespace ('bull:{name}:...').
+        // The worker's BullModule.forRootAsync also omits keyPrefix for the same reason.
+        // Passing keyPrefix would redirect all reads to a non-existent namespace.
+        const { keyPrefix: _kp, ...connection } = getRedictConfig();
+
+        for (const network of this.networks) {
+            for (const base of this.baseNames) {
+                // Build the full queue name directly — same logic as qname() but
+                // without the type constraint that requires a BaseQueueName literal.
+                const fullName = `${base}-${network}`;
+                const mapKey = this.key(network, base);
+
+                try {
+                    const queue = new Queue(fullName, { connection });
+                    const events = new QueueEvents(fullName, { connection });
+
+                    this.queues.set(mapKey, queue);
+                    this.queueEvents.set(mapKey, events);
+
+                    this.logger.log(`Registered queue "${fullName}" [key=${mapKey}]`);
+                } catch (error: unknown) {
+                    const msg = error instanceof Error ? error.message : String(error);
+                    this.logger.error(`Failed to register queue "${fullName}": ${msg}`);
+                }
+            }
+        }
+    }
+
+    async onModuleDestroy(): Promise<void> {
+        const closeAll = async (label: string, map: Map<string, { close(): Promise<void> }>) => {
+            for (const [k, instance] of map.entries()) {
+                try {
+                    await instance.close();
+                } catch (error: unknown) {
+                    const msg = error instanceof Error ? error.message : String(error);
+                    this.logger.warn(`Error closing ${label} "${k}": ${msg}`);
+                }
+            }
+            map.clear();
+        };
+
+        await closeAll('Queue', this.queues as Map<string, { close(): Promise<void> }>);
+        await closeAll('QueueEvents', this.queueEvents as Map<string, { close(): Promise<void> }>);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Public accessors
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Returns the Queue for the given (network, baseName) pair.
+     * Throws NotFoundException if neither the network nor the base name is known.
+     */
+    getQueue(network: string, baseName: string): Queue {
+        const q = this.queues.get(this.key(network, baseName));
+        if (!q) {
+            throw new NotFoundException(
+                `Queue not found: network="${network}", baseName="${baseName}". ` +
+                `Available networks: ${this.networks.join(', ')}. ` +
+                `Available base names: ${this.baseNames.join(', ')}.`,
+            );
+        }
+        return q;
+    }
+
+    /**
+     * Returns the QueueEvents instance for the given (network, baseName) pair.
+     * Throws NotFoundException if not found.
+     */
+    getQueueEvents(network: string, baseName: string): QueueEvents {
+        const qe = this.queueEvents.get(this.key(network, baseName));
+        if (!qe) {
+            throw new NotFoundException(
+                `QueueEvents not found: network="${network}", baseName="${baseName}".`,
+            );
+        }
+        return qe;
+    }
+
+    /**
+     * Returns all (network, baseName) pairs as an iterable.
+     * Useful for the QueueEventsBus to wire up listeners.
+     */
+    getAllEntries(): Array<{ network: string; baseName: string; queue: Queue; events: QueueEvents }> {
+        const result: Array<{ network: string; baseName: string; queue: Queue; events: QueueEvents }> = [];
+        for (const network of this.networks) {
+            for (const base of this.baseNames) {
+                const q = this.queues.get(this.key(network, base));
+                const e = this.queueEvents.get(this.key(network, base));
+                if (q && e) {
+                    result.push({ network, baseName: base, queue: q, events: e });
+                }
+            }
+        }
+        return result;
+    }
+
+    /** Returns all base queue name strings (without network suffix). */
+    listBaseNames(): string[] {
+        return [...this.baseNames];
+    }
+
+    /** Returns all configured network names. */
+    getConfiguredNetworks(): string[] {
+        return [...this.networks];
+    }
+
+    /**
+     * Returns the static QueueDefinition config for a given base queue name,
+     * or undefined if not found.
+     *
+     * Note: getQueueConfigs() builds names using the worker's current HEDERA_NET
+     * env var.  We match by stripping the network suffix so this works correctly
+     * in the API process regardless of which HEDERA_NET is set.
+     */
+    getQueueConfig(_network: string, baseName: string): QueueDefinition | undefined {
+        return getQueueConfigs().find((c) => this.extractBase(c.name) === baseName) as
+            | QueueDefinition
+            | undefined;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private key(network: string, baseName: string): string {
+        return `${network.toLowerCase()}:${baseName}`;
+    }
+
+    /**
+     * Strips the last dash-separated segment (the network suffix) from a full
+     * queue name to recover the base name.
+     * e.g. "mirror-node-topics-testnet" → "mirror-node-topics"
+     */
+    private extractBase(fullName: string): string {
+        const parts = fullName.split('-');
+        // The network suffix is always the last segment.
+        return parts.slice(0, -1).join('-');
+    }
+}

--- a/sustainable-explorer/src/shared/entities/index.ts
+++ b/sustainable-explorer/src/shared/entities/index.ts
@@ -4,6 +4,7 @@ export { TopicCache } from './topic-cache.entity.js';
 export { TokenCache } from './token-cache.entity.js';
 export { NftCache } from './nft-cache.entity.js';
 export { IpfsFile } from './ipfs-file.entity.js';
+export { IpfsFetchFailure } from './ipfs-fetch-failure.entity.js';
 export { BusinessView } from './business-view.entity.js';
 export { PolicySchema } from './policy-schema.entity.js';
 export { SynchronizationTask } from './synchronization-task.entity.js';

--- a/sustainable-explorer/src/shared/entities/ipfs-fetch-failure.entity.ts
+++ b/sustainable-explorer/src/shared/entities/ipfs-fetch-failure.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryColumn, Column } from 'typeorm';
+
+@Entity('ipfs_fetch_failure')
+export class IpfsFetchFailure {
+    @PrimaryColumn({ type: 'text' })
+    cid: string;
+
+    @Column({ type: 'text' })
+    lastError: string;
+
+    @Column({ type: 'varchar', length: 20, default: 'unknown' })
+    errorCategory: 'transient' | 'permanent' | 'unknown';
+
+    @Column({ type: 'int', default: 0 })
+    attemptCount: number;
+
+    @Column({ type: 'int', default: 0 })
+    manualRetryCount: number;
+
+    @Column({ type: 'timestamptz' })
+    firstFailedAt: Date;
+
+    @Column({ type: 'timestamptz' })
+    lastFailedAt: Date;
+
+    @Column({ nullable: true, type: 'text' })
+    messageTimestamp: string | null;
+}

--- a/sustainable-explorer/src/worker/processors/ipfs-fetch.processor.ts
+++ b/sustainable-explorer/src/worker/processors/ipfs-fetch.processor.ts
@@ -1,11 +1,12 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
-import { Inject, Logger } from '@nestjs/common';
-import { Job } from 'bullmq';
+import { Inject, Logger, OnModuleInit } from '@nestjs/common';
+import { Job, UnrecoverableError } from 'bullmq';
 import { DataSource } from 'typeorm';
 import Redis from 'ioredis';
 import { QUEUE_NAMES } from '@shared/config/bullmq.config';
 import { IpfsService } from '../services/ipfs.service';
 import { ProjectMapperService } from '../services/project-mapper.service';
+import { IpfsFetchFailureRepository } from '../repositories/ipfs-fetch-failure.repository';
 
 export interface IpfsFetchJobData {
     cid: string;
@@ -13,8 +14,9 @@ export interface IpfsFetchJobData {
 }
 
 @Processor(QUEUE_NAMES.IPFS_FETCH)
-export class IpfsFetchProcessor extends WorkerHost {
+export class IpfsFetchProcessor extends WorkerHost implements OnModuleInit {
     private readonly logger = new Logger(IpfsFetchProcessor.name);
+    private readonly failureRepo: IpfsFetchFailureRepository;
 
     constructor(
         private readonly ipfsService: IpfsService,
@@ -23,6 +25,14 @@ export class IpfsFetchProcessor extends WorkerHost {
         @Inject('REDICT_PUB') private readonly redis: Redis,
     ) {
         super();
+        this.failureRepo = new IpfsFetchFailureRepository(this.dataSource);
+    }
+
+    /**
+     * Ensures the ipfs_fetch_failure table exists before processing begins.
+     */
+    async onModuleInit(): Promise<void> {
+        await this.failureRepo.ensureTable();
     }
 
     async process(job: Job<IpfsFetchJobData>): Promise<void> {
@@ -38,11 +48,33 @@ export class IpfsFetchProcessor extends WorkerHost {
 
         if (existing.length > 0) {
             this.logger.debug(`CID ${cid} already exists in ipfs_files, skipping fetch`);
+            // Clean up any stale failure record and publish recovery event
+            await this.failureRepo.deleteFailure(cid);
+            await this.redis.publish('se:events', JSON.stringify({
+                type: 'ipfs-fetch-recovered',
+                cid,
+                timestamp: Date.now(),
+            }));
             return;
         }
 
-        // Fetch content from IPFS
-        const content = await this.ipfsService.fetchContent(cid);
+        // Fetch content from IPFS — classify and handle errors
+        let content: Buffer;
+        try {
+            content = await this.ipfsService.fetchContent(cid);
+        } catch (err: unknown) {
+            const error = err instanceof Error ? err : new Error(String(err));
+            const category = IpfsService.classifyError(error);
+
+            if (category === 'permanent') {
+                // Permanent failures (404, invalid CID, 410) should not be retried —
+                // wrap in UnrecoverableError so BullMQ skips remaining attempts.
+                throw new UnrecoverableError(error.message);
+            }
+
+            // Transient failure — rethrow so BullMQ retries per backoff config
+            throw error;
+        }
 
         // Store in ipfs_files
         await this.dataSource.query(
@@ -89,7 +121,17 @@ export class IpfsFetchProcessor extends WorkerHost {
             }
         }
 
-        // Publish event to Redict for real-time consumers
+        // Remove any stale failure record — this CID is now successfully fetched
+        await this.failureRepo.deleteFailure(cid);
+
+        // Publish recovery event (covers both first-time successes and retried successes)
+        await this.redis.publish('se:events', JSON.stringify({
+            type: 'ipfs-fetch-recovered',
+            cid,
+            timestamp: Date.now(),
+        }));
+
+        // Publish document-loaded event for real-time consumers
         await this.redis.publish('se:events', JSON.stringify({
             type: 'document-loaded',
             messageId: messageTimestamp,
@@ -103,9 +145,34 @@ export class IpfsFetchProcessor extends WorkerHost {
 
     @OnWorkerEvent('failed')
     onFailed(job: Job<IpfsFetchJobData>, error: Error): void {
-        this.logger.error(
-            `IPFS fetch job ${job.id} failed for CID ${job.data.cid}: ${error.message}`,
-            error.stack,
-        );
+        void this.handleFailure(job, error);
+    }
+
+    private async handleFailure(job: Job<IpfsFetchJobData>, error: Error): Promise<void> {
+        try {
+            const category = IpfsService.classifyError(error);
+            this.logger.error(
+                `IPFS fetch job ${job.id} failed for CID ${job.data.cid} [${category}]: ${error.message}`,
+                error.stack,
+            );
+
+            await this.failureRepo.upsertFailure(
+                job.data.cid,
+                error.message.slice(0, 1000),
+                category,
+                job.data.messageTimestamp ?? null,
+            );
+
+            await this.redis.publish('se:events', JSON.stringify({
+                type: 'ipfs-fetch-failed',
+                cid: job.data.cid,
+                errorCategory: category,
+                attemptCount: job.attemptsMade,
+                lastError: error.message.slice(0, 500),
+                timestamp: Date.now(),
+            }));
+        } catch (handlerErr) {
+            this.logger.error('Failed to handle IPFS failure event', handlerErr);
+        }
     }
 }

--- a/sustainable-explorer/src/worker/repositories/ipfs-fetch-failure.repository.ts
+++ b/sustainable-explorer/src/worker/repositories/ipfs-fetch-failure.repository.ts
@@ -1,0 +1,71 @@
+import { Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+/**
+ * Thin repository for the ipfs_fetch_failure table.
+ * Uses raw SQL via DataSource.query() — consistent with how all other worker
+ * processors access the database (no TypeORM entity manager).
+ *
+ * The table is created lazily via ensureTable() in the processor's onModuleInit.
+ */
+export class IpfsFetchFailureRepository {
+    private readonly logger = new Logger(IpfsFetchFailureRepository.name);
+
+    constructor(private readonly dataSource: DataSource) {}
+
+    /**
+     * Creates the ipfs_fetch_failure table if it does not already exist.
+     * Safe to call on every startup (idempotent via IF NOT EXISTS).
+     */
+    async ensureTable(): Promise<void> {
+        await this.dataSource.query(`
+            CREATE TABLE IF NOT EXISTS ipfs_fetch_failure (
+                cid text PRIMARY KEY,
+                "lastError" text NOT NULL,
+                "errorCategory" varchar(20) NOT NULL DEFAULT 'unknown',
+                "attemptCount" int NOT NULL DEFAULT 0,
+                "manualRetryCount" int NOT NULL DEFAULT 0,
+                "firstFailedAt" timestamptz NOT NULL,
+                "lastFailedAt" timestamptz NOT NULL,
+                "messageTimestamp" text
+            )
+        `);
+        this.logger.log('Ensured ipfs_fetch_failure table exists');
+    }
+
+    /**
+     * Inserts or updates a failure record for the given CID.
+     * On conflict: increments attemptCount and updates lastError, errorCategory, lastFailedAt.
+     * firstFailedAt is never updated — it records the original failure time.
+     */
+    async upsertFailure(
+        cid: string,
+        lastError: string,
+        errorCategory: string,
+        messageTimestamp: string | null,
+    ): Promise<void> {
+        await this.dataSource.query(
+            `INSERT INTO ipfs_fetch_failure
+                (cid, "lastError", "errorCategory", "attemptCount", "firstFailedAt", "lastFailedAt", "messageTimestamp")
+             VALUES ($1, $2, $3, 1, NOW(), NOW(), $4)
+             ON CONFLICT (cid) DO UPDATE SET
+                "lastError"       = EXCLUDED."lastError",
+                "errorCategory"   = EXCLUDED."errorCategory",
+                "attemptCount"    = ipfs_fetch_failure."attemptCount" + 1,
+                "lastFailedAt"    = NOW()`,
+            [cid, lastError, errorCategory, messageTimestamp],
+        );
+    }
+
+    /**
+     * Removes the failure record for the given CID.
+     * Called when a previously-failing CID is successfully fetched (recovery).
+     * No-op if no record exists.
+     */
+    async deleteFailure(cid: string): Promise<void> {
+        await this.dataSource.query(
+            `DELETE FROM ipfs_fetch_failure WHERE cid = $1`,
+            [cid],
+        );
+    }
+}

--- a/sustainable-explorer/src/worker/services/ipfs.service.ts
+++ b/sustainable-explorer/src/worker/services/ipfs.service.ts
@@ -68,6 +68,29 @@ export class IpfsService {
     }
 
     /**
+     * Classifies an IPFS fetch error as permanent or transient.
+     *
+     * Permanent errors (404, 410, invalid CID) will never succeed on retry —
+     * the processor should use UnrecoverableError to skip remaining BullMQ retries.
+     *
+     * Transient errors (network timeouts, 5xx, connection refused, etc.) may
+     * succeed on a later attempt and should be retried normally.
+     */
+    static classifyError(error: Error): 'transient' | 'permanent' {
+        const msg = (error.message || '').toLowerCase();
+        if (
+            msg.includes('404') ||
+            msg.includes('not found') ||
+            msg.includes('invalid cid') ||
+            msg.includes('410') ||
+            msg.includes('gone')
+        ) {
+            return 'permanent';
+        }
+        return 'transient';
+    }
+
+    /**
      * Basic CID validation. Returns the CID string if valid, null otherwise.
      * Supports CIDv0 (Qm...) and CIDv1 (bafy...) formats.
      */

--- a/sustainable-explorer/src/worker/services/queue-autoscaler.service.ts
+++ b/sustainable-explorer/src/worker/services/queue-autoscaler.service.ts
@@ -1,0 +1,326 @@
+import {
+    Injectable,
+    OnModuleDestroy,
+    OnApplicationBootstrap,
+    Logger,
+    Inject,
+    Optional,
+} from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue, Worker } from 'bullmq';
+import { WorkerHost } from '@nestjs/bullmq';
+import Redis from 'ioredis';
+import {
+    QUEUE_NAMES,
+    BASE_QUEUE_NAMES,
+    getQueueConfigs,
+    getWorkerNetwork,
+} from '@shared/config/bullmq.config';
+
+// Processor imports — we inject the live instances so we can access their
+// underlying BullMQ Worker (via WorkerHost.worker) and mutate concurrency.
+import { TopicSyncProcessor } from '../processors/topic-sync.processor';
+import { MessageProcessProcessor } from '../processors/message-process.processor';
+import { TokenSyncProcessor } from '../processors/token-sync.processor';
+import { IpfsFetchProcessor } from '../processors/ipfs-fetch.processor';
+import { MvRefreshProcessor } from '../processors/mv-refresh.processor';
+import { BusinessViewBuilderProcessor } from '../processors/business-view-builder.processor';
+import { PolicyDecodeProcessor } from '../processors/policy-decode.processor';
+
+interface ScalingEntry {
+    queue: Queue;
+    processor: WorkerHost;
+    minConcurrency: number;
+    maxConcurrency: number;
+}
+
+/**
+ * In-process concurrency autoscaler for BullMQ workers.
+ *
+ * Runs a scaling loop every 30 seconds (leader-elected, scoped per network).
+ * Adjusts each processor's BullMQ Worker.concurrency dynamically based on
+ * queue depth without restarting the process.
+ *
+ * Scale-up rule:  waiting > 100  → concurrency += 2 (immediate)
+ * Scale-down rule: waiting < 10 AND active < 50% concurrency for 2
+ *                  consecutive 30s cycles → concurrency -= 1
+ *
+ * NOTE: This is a smoothing layer only. For sustained load, scale horizontally
+ * (more worker containers partitioned via WORKER_QUEUES).
+ *
+ * Leader election key: se:autoscaler:leader:{network}
+ * (distinct from the scheduler key se:scheduler:leader:{network})
+ */
+@Injectable()
+export class QueueAutoscalerService implements OnApplicationBootstrap, OnModuleDestroy {
+    private readonly logger = new Logger(QueueAutoscalerService.name);
+    private readonly network = getWorkerNetwork();
+    private readonly leaderKey = `se:autoscaler:leader:${this.network}`;
+    private readonly instanceId = `autoscaler-${process.pid}-${Date.now()}`;
+
+    private isLeader = false;
+    private scalingInterval: ReturnType<typeof setInterval> | null = null;
+    private leaderRenewalInterval: ReturnType<typeof setInterval> | null = null;
+    private readonly scaleDownCounters: Record<string, number> = {};
+
+    /** Populated in onApplicationBootstrap once all processors have initialised. */
+    private readonly scalingTargets = new Map<string, ScalingEntry>();
+
+    constructor(
+        // Redict client (same provider as all other workers/schedulers)
+        @Inject('REDICT_PUB') private readonly redis: Redis,
+
+        // Queues
+        @InjectQueue(QUEUE_NAMES.TOPIC_SYNC) private readonly topicQueue: Queue,
+        @InjectQueue(QUEUE_NAMES.MESSAGE_PARSE) private readonly messageQueue: Queue,
+        @InjectQueue(QUEUE_NAMES.TOKEN_SYNC) private readonly tokenQueue: Queue,
+        @InjectQueue(QUEUE_NAMES.IPFS_FETCH) private readonly ipfsQueue: Queue,
+        @InjectQueue(QUEUE_NAMES.MV_REFRESH) private readonly mvQueue: Queue,
+        @InjectQueue(QUEUE_NAMES.BUSINESS_VIEW_BUILD) private readonly bvQueue: Queue,
+        @InjectQueue(QUEUE_NAMES.POLICY_DECODE) private readonly pdQueue: Queue,
+
+        // Processor instances — decorated with @Optional() because worker.module.ts
+        // only registers processors for active queues. NestJS resolves missing
+        // optional providers as undefined rather than throwing.
+        @Optional() private readonly topicProcessor: TopicSyncProcessor,
+        @Optional() private readonly messageProcessor: MessageProcessProcessor,
+        @Optional() private readonly tokenProcessor: TokenSyncProcessor,
+        @Optional() private readonly ipfsProcessor: IpfsFetchProcessor,
+        @Optional() private readonly mvProcessor: MvRefreshProcessor,
+        @Optional() private readonly bvProcessor: BusinessViewBuilderProcessor,
+        @Optional() private readonly pdProcessor: PolicyDecodeProcessor,
+    ) {}
+
+    /**
+     * Runs after all OnModuleInit hooks — at this point every processor's
+     * internal BullMQ Worker instance is guaranteed to be initialized.
+     */
+    async onApplicationBootstrap(): Promise<void> {
+        this.buildScalingTargets();
+
+        if (this.scalingTargets.size === 0) {
+            this.logger.log('[Autoscaler] No active processors found — disabled');
+            return;
+        }
+
+        this.isLeader = await this.tryAcquireLeader();
+
+        if (this.isLeader) {
+            this.logger.log(`[Autoscaler] Acquired leadership (${this.instanceId})`);
+            this.startScalingLoop();
+        } else {
+            this.logger.log('[Autoscaler] Another instance holds the leader lock — standby');
+        }
+
+        // Renew leadership every 15s; take over from a dropped leader
+        this.leaderRenewalInterval = setInterval(async () => {
+            try {
+                const wasLeader = this.isLeader;
+                this.isLeader = await this.tryAcquireLeader();
+
+                if (this.isLeader && wasLeader) {
+                    await this.redis.expire(this.leaderKey, 30);
+                } else if (this.isLeader && !wasLeader) {
+                    this.logger.log('[Autoscaler] Took over leadership');
+                    this.startScalingLoop();
+                } else if (!this.isLeader && wasLeader) {
+                    this.logger.warn('[Autoscaler] Lost leadership — pausing scaling loop');
+                    this.stopScalingLoop();
+                }
+            } catch {
+                // Silent — retry next interval
+            }
+        }, 15_000);
+    }
+
+    onModuleDestroy(): void {
+        this.stopScalingLoop();
+        if (this.leaderRenewalInterval) {
+            clearInterval(this.leaderRenewalInterval);
+            this.leaderRenewalInterval = null;
+        }
+        if (this.isLeader) {
+            this.redis.del(this.leaderKey).catch(() => {});
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Private helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Builds the scaling targets map from processors that are actually
+     * registered in this worker instance.
+     *
+     * NestJS only creates providers for active queues, so an inactive
+     * processor will not be injectable. We rely on optional injection
+     * (processors may be undefined) and guard with a try/catch on
+     * WorkerHost.worker which throws if the BullMQ Worker is not ready.
+     */
+    private buildScalingTargets(): void {
+        const configs = getQueueConfigs();
+        const configMap = new Map(configs.map(c => [c.name, c]));
+
+        const candidates: Array<{
+            baseName: string;
+            queueName: string;
+            queue: Queue;
+            processor: WorkerHost | undefined;
+        }> = [
+            {
+                baseName: BASE_QUEUE_NAMES.TOPIC_SYNC,
+                queueName: QUEUE_NAMES.TOPIC_SYNC,
+                queue: this.topicQueue,
+                processor: this.topicProcessor,
+            },
+            {
+                baseName: BASE_QUEUE_NAMES.MESSAGE_PARSE,
+                queueName: QUEUE_NAMES.MESSAGE_PARSE,
+                queue: this.messageQueue,
+                processor: this.messageProcessor,
+            },
+            {
+                baseName: BASE_QUEUE_NAMES.TOKEN_SYNC,
+                queueName: QUEUE_NAMES.TOKEN_SYNC,
+                queue: this.tokenQueue,
+                processor: this.tokenProcessor,
+            },
+            {
+                baseName: BASE_QUEUE_NAMES.IPFS_FETCH,
+                queueName: QUEUE_NAMES.IPFS_FETCH,
+                queue: this.ipfsQueue,
+                processor: this.ipfsProcessor,
+            },
+            {
+                baseName: BASE_QUEUE_NAMES.MV_REFRESH,
+                queueName: QUEUE_NAMES.MV_REFRESH,
+                queue: this.mvQueue,
+                processor: this.mvProcessor,
+            },
+            {
+                baseName: BASE_QUEUE_NAMES.BUSINESS_VIEW_BUILD,
+                queueName: QUEUE_NAMES.BUSINESS_VIEW_BUILD,
+                queue: this.bvQueue,
+                processor: this.bvProcessor,
+            },
+            {
+                baseName: BASE_QUEUE_NAMES.POLICY_DECODE,
+                queueName: QUEUE_NAMES.POLICY_DECODE,
+                queue: this.pdQueue,
+                processor: this.pdProcessor,
+            },
+        ];
+
+        for (const { baseName, queueName, queue, processor } of candidates) {
+            if (!processor) continue;
+
+            // Verify the underlying BullMQ Worker is accessible
+            try {
+                void processor.worker; // throws if not initialized
+            } catch {
+                // Processor not active in this worker instance
+                continue;
+            }
+
+            const queueConfig = configMap.get(queueName);
+            if (!queueConfig) continue;
+
+            const baseline = queueConfig.concurrency;
+
+            // Allow per-queue max concurrency override via env var.
+            // ENV key pattern: WORKER_MIRROR_NODE_TOPICS_MAX_CONCURRENCY
+            const envKey = baseName.replace(/-/g, '_').toUpperCase();
+            const maxEnv = parseInt(
+                process.env[`WORKER_${envKey}_MAX_CONCURRENCY`] || '0',
+                10,
+            );
+            const maxConcurrency = maxEnv > 0
+                ? maxEnv
+                : Math.max(baseline * 4, baseline + 4);
+
+            this.scalingTargets.set(baseName, {
+                queue,
+                processor,
+                minConcurrency: baseline,
+                maxConcurrency,
+            });
+        }
+
+        this.logger.log(
+            `[Autoscaler] Tracking ${this.scalingTargets.size} processor(s): ` +
+            Array.from(this.scalingTargets.keys()).join(', '),
+        );
+    }
+
+    private startScalingLoop(): void {
+        if (this.scalingInterval) return; // Already running
+        this.scalingInterval = setInterval(() => {
+            void this.runScalingCycle();
+        }, 30_000);
+        this.logger.log('[Autoscaler] Scaling loop started (30s interval)');
+    }
+
+    private stopScalingLoop(): void {
+        if (this.scalingInterval) {
+            clearInterval(this.scalingInterval);
+            this.scalingInterval = null;
+        }
+    }
+
+    private async runScalingCycle(): Promise<void> {
+        for (const [baseName, entry] of this.scalingTargets.entries()) {
+            try {
+                const waiting = await entry.queue.getWaitingCount();
+                const active = await entry.queue.getActiveCount();
+
+                // BullMQ Worker.concurrency is a proper get/set property (verified
+                // in node_modules/bullmq/dist/cjs/classes/worker.js lines 214-224).
+                const workerInstance = entry.processor.worker as Worker;
+                const current: number = workerInstance.concurrency ?? entry.minConcurrency;
+
+                if (waiting > 100 && current < entry.maxConcurrency) {
+                    const next = Math.min(current + 2, entry.maxConcurrency);
+                    workerInstance.concurrency = next;
+                    this.logger.log(
+                        `[Autoscaler] Scale UP ${baseName}: ${current} → ${next} (waiting=${waiting})`,
+                    );
+                    this.scaleDownCounters[baseName] = 0;
+                } else if (waiting < 10 && active < current / 2) {
+                    this.scaleDownCounters[baseName] =
+                        (this.scaleDownCounters[baseName] ?? 0) + 1;
+                    if (this.scaleDownCounters[baseName] >= 2) {
+                        const next = Math.max(current - 1, entry.minConcurrency);
+                        workerInstance.concurrency = next;
+                        this.logger.log(
+                            `[Autoscaler] Scale DOWN ${baseName}: ${current} → ${next}`,
+                        );
+                        this.scaleDownCounters[baseName] = 0;
+                    }
+                } else {
+                    this.scaleDownCounters[baseName] = 0;
+                }
+            } catch (err) {
+                this.logger.warn(
+                    `[Autoscaler] Error scaling ${baseName}: ${(err as Error).message}`,
+                );
+            }
+        }
+    }
+
+    /**
+     * Acquires or verifies the distributed leader lock in Redict.
+     * TTL: 30s. Renewed every 15s by the leader.
+     */
+    private async tryAcquireLeader(): Promise<boolean> {
+        const result = await this.redis.set(
+            this.leaderKey,
+            this.instanceId,
+            'EX', 30,
+            'NX',
+        );
+        if (result === 'OK') return true;
+
+        const current = await this.redis.get(this.leaderKey);
+        return current === this.instanceId;
+    }
+}

--- a/sustainable-explorer/src/worker/worker.module.ts
+++ b/sustainable-explorer/src/worker/worker.module.ts
@@ -29,6 +29,9 @@ import { BusinessViewBuilderProcessor } from './processors/business-view-builder
 // Schedulers
 import { SyncSchedulerService } from './schedulers/sync-scheduler.service';
 
+// Services (extended)
+import { QueueAutoscalerService } from './services/queue-autoscaler.service';
+
 /**
  * Maps queue names to the processor classes that handle them.
  * Only processors for active queues will be registered.
@@ -118,6 +121,10 @@ export class WorkerModule {
                 ...(activeQueues.some(q => q.startsWith('mirror-node'))
                     ? [SyncSchedulerService]
                     : []),
+
+                // Autoscaler — always registered; uses @Optional() for processor
+                // injections so it gracefully handles partial processor sets.
+                QueueAutoscalerService,
             ],
         };
     }


### PR DESCRIPTION

<img width="1910" height="6737" alt="image" src="https://github.com/user-attachments/assets/ac0fb0fd-69bc-4833-bdb7-9103b9b781a7" />

<img width="1910" height="6737" alt="image" src="https://github.com/user-attachments/assets/0dc3e12d-6c76-43d9-bce6-c2fce1e4834f" />

## Contents

1. [Overview](#1-overview)
2. [Backend — QueueRegistry](#2-backend--queueregistry)
3. [Backend — QueueEventsBus (SSE engine)](#3-backend--queueeventsbus-sse-engine)
4. [Backend — QueueStatusController (8 endpoints)](#4-backend--queuestatuscontroller-8-endpoints)
5. [Backend — Sync-Status endpoint and queries](#5-backend--sync-status-endpoint-and-queries)
6. [IPFS Failure Resilience — why a separate table](#6-ipfs-failure-resilience--why-a-separate-table)
7. [In-process Queue Autoscaler](#7-in-process-queue-autoscaler)
8. [Frontend — Composables](#8-frontend--composables)
9. [Frontend — Status Page (status.vue)](#9-frontend--status-pagestatus-vue)
10. [SSE Stream — Performance Analysis](#10-sse-stream--performance-analysis)
11. [Known Constraints and Limits](#11-known-constraints-and-limits)

---

## 1. Overview

The status page surfaces the operational health of the Guardian data pipeline to the public. Before this implementation, the page showed static placeholder values. The implementation replaces those with:

- **Live BullMQ queue metrics** — counts (waiting / active / completed / failed / delayed) per queue, pulled directly from Redis on each API call.
- **Real-time push** — a Server-Sent Events stream so the UI updates within milliseconds of a job state change, without polling.
- **Failed job inspection** — a drawer listing failed jobs with their error reasons, grouped or paginated, with a per-job manual retry API (budget-capped at 3 retries).
- **Sync health** — topic and token watermarks read from `topic_cache` / `token_cache`, showing how current the indexed data is and how far behind the live Hedera network it lags.
- **Stat cards** — "Topics Indexed" and "Messages Processed" aggregate counters derived from a single SQL query against `topic_cache`, replacing generic queue-depth numbers.
- **IPFS failure persistence** — a new `ipfs_fetch_failure` table that survives process restarts, tracks error categories, and powers the retry-budget system. A dedicated table is used rather than adding nullable columns to existing tables — the full justification is in section 6.
- **Concurrency autoscaler** — the worker process dynamically adjusts its BullMQ concurrency based on queue depth, scaling up under load and back down when idle, without needing a process restart or horizontal scale event.
- **Throttled, readable activity feed** — `job-completed` SSE events are throttled to at most one entry per queue per 5 seconds in the live feed. Failures always pass through immediately. The feed holds the latest 50 events in a scrollable list rather than paginating.

---

## 2. Backend — QueueRegistry

**File:** `src/api/queues/queue.registry.ts`

### Why it exists

The NestJS API process does not import the worker module, so it cannot use `@InjectQueue`. The `QueueRegistry` creates its own BullMQ `Queue` and `QueueEvents` pair for every `(network × base-queue-name)` combination at startup, giving the API process read/write access to every queue without depending on worker internals.

### Critical connection fix

BullMQ stores its keys as `bull:{queueName}:{suffix}`. If you pass a `keyPrefix` through the ioredis connection options, BullMQ prepends it again, resulting in `se:bull:{name}:...` which does not match the keys the worker actually wrote. The registry strips `keyPrefix` before creating any connection:

```ts
const { keyPrefix: _kp, ...connection } = getRedictConfig();
const queue = new Queue(fullName, { connection });
const events = new QueueEvents(fullName, { connection });
```

### Map key structure

Each pair is stored under `${network}:${baseName}` (e.g. `mainnet:mirror-node-topics`). The full BullMQ queue name is `${baseName}-${network}` (e.g. `mirror-node-topics-mainnet`), which matches how the worker registers its queues via `qname()`.

---

## 3. Backend — QueueEventsBus (SSE engine)

**File:** `src/api/queues/queue-events-bus.service.ts`

### Architecture

```
BullMQ QueueEvents (per queue) ──► Node EventEmitter ──► RxJS Observable ──► SSE client
                                         ▲
Redis pub/sub (se:events channel) ───────┘
RxJS interval (25s heartbeat) ───────────────────────────────────────────────► SSE client
```

### BullMQ QueueEvents wiring

On `onModuleInit`, the bus iterates every `(network, baseName)` pair from `QueueRegistry` and attaches listeners for five BullMQ events: `completed`, `failed`, `active`, `waiting`, `stalled`. Each listener emits an internal `queue-bus-event` on the Node `EventEmitter`, which all active SSE streams are subscribed to via `fromEvent`.

### Counts-changed debounce

Rather than emitting a full count snapshot for every single job state transition (which would flood fast-processing queues with dozens of events per second), the bus debounces count fetches per queue at 500 ms. Every job lifecycle event schedules a 500 ms countdown; subsequent events in that window reset the timer. After the 500 ms silence, the bus fetches fresh counts from Redis and emits a single `counts-changed` event.

```ts
private scheduleCountsChanged(network, baseName, queue) {
    clearTimeout(this.countTimers.get(timerKey));
    const timer = setTimeout(async () => {
        const counts = await queue.getJobCounts('waiting', 'active', 'completed', 'failed', 'delayed', 'paused');
        this.emitter.emit(BUS_EVENT, { type: 'counts-changed', network, queueBase: baseName, counts });
    }, 500);
    this.countTimers.set(timerKey, timer);
}
```

### Redis pub/sub (se:events channel)

The worker publishes application-level events (IPFS failures, recoveries, document loads) to the `se:events` Redis channel. The bus subscribes to this channel on a **dedicated ioredis connection** — this is required because once a connection issues `SUBSCRIBE`, it can no longer execute other Redis commands. The `keyPrefix` is again stripped from the subscriber connection because ioredis does not automatically prefix channel names in subscribe mode.

### SSE stream construction

`streamForNetwork(network)` builds an `Observable<MessageEvent>` by merging:
1. `fromEvent(emitter, BUS_EVENT)` filtered to the requested network
2. `interval(25_000)` emitting heartbeat frames

NestJS's `@Sse()` decorator natively accepts `Observable<MessageEvent>` and handles HTTP chunked encoding, so no custom streaming code is needed.

---

## 4. Backend — QueueStatusController (8 endpoints)

**File:** `src/api/controllers/queue-status.controller.ts`

The SSE route is declared **first** in the class to prevent NestJS's `:baseName` path parameter from matching `GET /:network/queues/events`.

| Method | Path | Description |
|--------|------|-------------|
| `GET` (SSE) | `/:network/queues/events` | Real-time event stream |
| `GET` | `/:network/queues` | List all queues with live counts |
| `GET` | `/:network/queues/:baseName/failed` | Failed jobs — paginated list or grouped by reason |
| `POST` | `/:network/queues/:baseName/jobs/:jobId/retry` | Retry a single failed job |
| `POST` | `/:network/queues/:baseName/retry-all-failed` | Retry all failed jobs in a queue |
| `GET` | `/:network/sync-status` | Topic/token sync watermarks + aggregate stats |
| `POST` | `/:network/queues/:baseName/pause` | *(commented out — reserved for admin panel)* |
| `POST` | `/:network/queues/:baseName/resume` | *(commented out — reserved for admin panel)* |

### Queue list endpoint

```ts
queue.getJobCounts('waiting', 'active', 'completed', 'failed', 'delayed', 'paused')
```

This single BullMQ call issues one `ZCARD` / `LLEN` per state against Redis (7 commands total per queue). All queues are fetched in a sequential loop — with ~4 queues per network this is around 28 Redis round-trips per API call, all completing in well under 100 ms over a local connection.

### Failed jobs endpoint

`groupByReason=false` (default):
- Calls `queue.getFailed(offset, offset + limit - 1)` — a range scan on the BullMQ failed sorted set.
- Calls `queue.getJobCounts('failed')` in parallel — reads `ZCARD` to get the accurate total regardless of page position.
- Filters out any `undefined`/`null` entries (BullMQ can return undefined for jobs whose hash was deleted but whose sorted set entry remains).

`groupByReason=true`:
- Same `getFailed` call, then aggregates in-process into a `Map<reason, { count, sampleJobIds[] }>`.
- Returns `{ groups: [...] }` rather than `{ total, items }`.

### Retry budget system

Each job's BullMQ `data` object carries a `manualRetryCount` field. On each manual retry via the API:
1. The current count is read from `job.data.manualRetryCount` (defaults to 0 if absent).
2. If `count >= 3` and `force !== true`, returns HTTP 429.
3. Otherwise increments the counter via `job.updateData()` and calls `job.retry()`.

This budget is separate from BullMQ's own automatic retry counter (`attemptsMade`) and survives across restarts because it is stored in the job's data hash in Redis.

### Boolean query param fix

NestJS's `class-transformer` `@Type(() => Boolean)` calls `Boolean('false')` which evaluates to `true` (non-empty string). The fix uses `@Transform`:

```ts
@Transform(({ value }) => value === true || value === 'true' || value === '1')
@IsBoolean()
groupByReason?: boolean = false;
```

---

## 5. Backend — Sync-Status endpoint and queries

**File:** `src/api/controllers/queue-status.controller.ts` → `getSyncStatus()`

Three SQL queries run in a single `Promise.all` against the network's PostgreSQL connection:

### Query 1 — top 50 topics by message count
```sql
SELECT "topicId", messages, "hasNext", "lastUpdate", status
FROM topic_cache
ORDER BY messages DESC
LIMIT 50
```

### Query 2 — up to 50 tracked tokens
```sql
SELECT "tokenId", "serialNumber", "hasNext", type
FROM token_cache
LIMIT 50
```

### Query 3 — aggregate stats (powers the stat cards)
```sql
SELECT
    COUNT(*)::int                                    AS "totalTopics",
    COUNT(*) FILTER (WHERE "hasNext" = false)::int   AS "syncedTopics",
    COALESCE(SUM(messages), 0)::bigint               AS "totalMessages"
FROM topic_cache
```

- `totalTopics` — the full count of rows in `topic_cache`, not limited by the LIMIT 50 on the detail query.
- `syncedTopics` — topics where `hasNext = false`, meaning the worker has fetched all known HCS messages for that topic. This is what the "Topics Indexed" stat card shows.
- `totalMessages` — total HCS messages across all topics. This powers the "Messages Processed" stat card. `::bigint` is used because PostgreSQL's `SUM(int)` returns bigint, which the `pg` driver returns as a string; `Number()` converts it correctly for values below 2^53.

### lastUpdate normalisation

`topic_cache.lastUpdate` stores the update time as a raw millisecond timestamp (`Date.now()` → 13-digit string like `"1778146836950"`). Early code treated this as Unix seconds, producing dates in the year 58317. The normalisation:

```ts
const raw = parseInt((r.lastUpdate ?? '').split('.')[0], 10);
const secs = raw > 1e10 ? Math.floor(raw / 1000) : raw;
const lastUpdateIso = !isNaN(secs) && secs > 0 ? new Date(secs * 1000).toISOString() : '';
```

The `split('.')[0]` handles the legacy Hedera consensus format `"seconds.nanoseconds"`. The `> 1e10` threshold distinguishes ms timestamps (13 digits) from epoch-second timestamps (10 digits), supporting both formats gracefully.

### lagSeconds calculation

```ts
const lagSeconds = maxSeconds !== null
    ? Math.max(0, Math.floor(Date.now() / 1000) - maxSeconds)
    : 0;
```

Takes the most recent `lastUpdate` across all topics and subtracts from wall-clock time. This gives a practical measure of how far behind the indexer is from real-time Hedera activity.

---

## 6. IPFS Failure Resilience — why a separate table

### The question

The system already has an `ipfs_files` table. Could we just add a nullable `status`, `lastError`, or `failedAt` column there instead of introducing a new `ipfs_fetch_failure` entity?

### Why the existing tables cannot be used

**1. `ipfs_files` has a strict invariant: every row holds successfully fetched content.**

The table is the authoritative content store. Every row means "this CID was fetched, here is the content." Adding nullable failure columns would break that invariant, forcing every downstream reader to check `WHERE content IS NOT NULL` or similar. A row in `ipfs_files` with `content = NULL` and `status = 'failed'` is a meaningless mix of two orthogonal concerns.

**2. A single message may reference multiple CIDs; failures are per-CID, not per-message.**

`message.files` is a JSON array of IPFS CIDs. One message can reference five files, two of which fail and three succeed. There is no single column on the `message` row that can represent this state without denormalising it into an array — which is a schema design smell for something that should be a child table.

**3. The same CID can be referenced by many messages.**

IPFS is a content-addressed store. Two different HCS messages published to different topics may reference exactly the same CID. The failure record belongs to the CID, not to either message. Storing it on a message row would either duplicate the record or leave one message's row stale when the other retries successfully.

**4. Recovery is a simple row deletion.**

When a CID is successfully fetched after prior failure, the recovery flow is `DELETE FROM ipfs_fetch_failure WHERE cid = $1`. If failure state lived on the `ipfs_files` row it would require a nullable-to-non-null update across multiple message rows that share the same CID, or the introduction of a separate "pending" state that must be cleaned up.

**5. No migration required on production tables.**

`ipfs_files` and `message` contain the full corpus of indexed content — potentially millions of rows. Adding a column to a large table requires a long-running `ALTER TABLE`, which takes an `ACCESS EXCLUSIVE` lock and blocks all reads and writes for its duration in PostgreSQL. The `ipfs_fetch_failure` table is created at worker startup with `CREATE TABLE IF NOT EXISTS` — no migration, no lock, no downtime.

### The new entity

**File:** `src/shared/entities/ipfs-fetch-failure.entity.ts`

```
┌─────────────────────────────────────────────────────────┐
│ ipfs_fetch_failure                                       │
├──────────────────┬──────────────┬────────────────────── │
│ cid (PK)         │ text         │ IPFS content hash      │
│ lastError        │ text         │ last failure message   │
│ errorCategory    │ varchar(20)  │ 'permanent'/'transient'│
│ attemptCount     │ int          │ total automatic retries│
│ manualRetryCount │ int          │ operator-triggered     │
│ firstFailedAt    │ timestamptz  │ never updated          │
│ lastFailedAt     │ timestamptz  │ updated on each failure│
│ messageTimestamp │ text         │ Hedera consensus ts    │
└──────────────────┴──────────────┴────────────────────── │
```

**Repository:** `src/worker/repositories/ipfs-fetch-failure.repository.ts`

The table is created on worker startup via `CREATE TABLE IF NOT EXISTS` — idempotent, no migration file needed. The upsert query increments `attemptCount` atomically and never overwrites `firstFailedAt`:

```sql
INSERT INTO ipfs_fetch_failure
    (cid, "lastError", "errorCategory", "attemptCount", "firstFailedAt", "lastFailedAt", "messageTimestamp")
VALUES ($1, $2, $3, 1, NOW(), NOW(), $4)
ON CONFLICT (cid) DO UPDATE SET
    "lastError"       = EXCLUDED."lastError",
    "errorCategory"   = EXCLUDED."errorCategory",
    "attemptCount"    = ipfs_fetch_failure."attemptCount" + 1,
    "lastFailedAt"    = NOW()
```

### Error classification

`IpfsService.classifyError()` inspects the HTTP status and error message:
- **permanent** → HTTP 404, 410, or a malformed/invalid CID — the content does not exist and retrying is pointless.
- **transient** → everything else (timeout, 5xx, DNS failure).

For permanent failures the processor throws `UnrecoverableError`, which tells BullMQ to move the job to the failed set immediately without consuming any remaining retry attempts.

### Multi-gateway fallback

The `IPFS_GATEWAYS` environment variable accepts a comma-separated list of gateway base URLs. On each fetch the processor tries each gateway in order with a per-gateway timeout (`IPFS_GATEWAY_TIMEOUT_MS`, default 30 s). Only when all gateways are exhausted does the job fail. This means a single gateway outage is transparent to the pipeline.

### Recovery flow

When a previously-failing CID is successfully fetched:
1. `IpfsFetchFailureRepository.deleteFailure(cid)` removes the row.
2. The processor publishes `{ type: 'ipfs-fetch-recovered', cid }` to the `se:events` Redis channel.
3. `QueueEventsBus` picks this up and streams it to all connected SSE clients, updating the activity feed on the status page in real time.

---

## 7. In-process Queue Autoscaler

**File:** `src/worker/services/queue-autoscaler.service.ts`

### Why in-process rather than horizontal scaling

Spinning up a new worker container takes 10–30 seconds and requires orchestrator involvement (Kubernetes HPA, ECS desired count, etc.). For short bursts — a registry publishing 200 new topics in one minute — that latency is too high and the overhead too large. The in-process autoscaler adjusts concurrency within the running worker in milliseconds, acting as a first-line smoothing layer.

For sustained multi-hour load, horizontal scaling (more worker containers with `WORKER_QUEUES` partitioning) is still the right answer.

### BullMQ Worker.concurrency property

In BullMQ v5 the `Worker` class exposes `concurrency` as a proper JavaScript getter/setter (verified in `node_modules/bullmq/dist/cjs/classes/worker.js`). Assigning a new value immediately adjusts how many jobs the worker picks up in subsequent polling cycles — no restart needed.

### Scaling rules

The autoscaler runs every 30 seconds per queue:

| Condition | Action |
|-----------|--------|
| `waiting > 100` and `current < maxConcurrency` | `concurrency += 2` (immediate) |
| `waiting < 10` AND `active < concurrency / 2` for **2 consecutive cycles** | `concurrency -= 1` |
| Anything else | No change, reset scale-down counter |

The 2-cycle confirmation for scale-down prevents thrashing when a queue drains briefly between bursts. Scale-up is immediate because leaving 200 jobs waiting while concurrency sits at baseline is worse than a brief overshoot.

### Concurrency bounds

- **Minimum:** the baseline concurrency defined in `bullmq.config.ts` for that queue. The autoscaler never goes below this.
- **Maximum:** `max(baseline × 4, baseline + 4)`, unless overridden via `WORKER_${QUEUE_NAME_UPPER}_MAX_CONCURRENCY` environment variable.

The env var name is derived from the queue's `baseName` using `baseName.replace(/-/g, '_').toUpperCase()`. For example:

| Queue base name | Env var |
|-----------------|---------|
| `mirror-node-topics` | `WORKER_MIRROR_NODE_TOPICS_MAX_CONCURRENCY` |
| `ipfs-files` | `WORKER_IPFS_FILES_MAX_CONCURRENCY` |
| `policy-decode` | `WORKER_POLICY_DECODE_MAX_CONCURRENCY` |

### Leader election

Multiple worker containers share the same Redis. Without coordination they would all try to scale the same queue simultaneously, causing racing writes to `Worker.concurrency`. The autoscaler uses a Redis NX lock:

```
Key:   se:autoscaler:leader:{network}
Value: autoscaler-{pid}-{startTime}
TTL:   30 seconds, renewed every 15 seconds by the holding instance
```

`SET key value EX 30 NX` — only one instance wins. The leader renews every 15 s. If the leader dies the TTL expires after 30 s and another instance takes over. Non-leaders run the leadership renewal loop but skip the scaling loop.

### Optional processor injection

Not every worker container runs every processor (operators can restrict via `WORKER_QUEUES`). Processors for inactive queues are not registered in the NestJS DI container, so injecting them unconditionally would throw at startup. The autoscaler uses `@Optional()` on all processor parameters — NestJS resolves missing optional providers as `undefined` rather than throwing, and the `buildScalingTargets()` method skips any `undefined` processor.

---

## 8. Frontend — Composables

### `useQueueListApi`

`useAsyncData` with a reactive key `() => \`queue-list:${network.value}\`` — re-fetches automatically when the user switches network. Falls back to an empty array on error.

### `useQueueFailedJobsApi`

Key: `` () => `queue-failed:${network}:${baseName}:${offset}` `` — reactive on all three dimensions, so the data refreshes when the drawer opens for a different queue, when the tab changes page offset, or when the network switches.

### `useQueueFailedGroupsApi`

Key: `` () => `queue-failed-groups:${network}:${baseName}` `` — separate from the jobs list because the two tabs display independently.

**Response shape:** the endpoint returns `{ groups: [...] }` when `groupByReason=true`. The composable extracts `res?.groups ?? []`. An early bug returned `res?.items` (the non-grouped shape), causing the by-reason tab to always show empty.

### `useSyncStatusApi`

- Key is reactive (`() => key.value`) so it re-fetches when network changes.
- `available` starts as `ref(true)` and is only set to `false` on a confirmed HTTP 404 (the endpoint does not exist for this network). Transient errors keep `available = true` — the section stays visible with stale/empty data rather than disappearing on any network blip.
- A `watch(opts.network, () => { available.value = true })` resets availability on network switch, so a previous 404 on one network does not hide the section when switching to a configured network.

### `useQueueEventsSse`

**File:** `frontend/composables/useQueueEventsSse.ts`

Browser-only composable (`import.meta.client` guard). Wraps the native `EventSource` API.

- Connects to `${sseApiBaseUrl}/api/v1/${network}/queues/events` — **must bypass the Nitro dev proxy**, which buffers `text/event-stream` responses, breaking SSE. The `sseApiBaseUrl` config value points directly to `http://localhost:3030` (or the externally-reachable API URL in production).
- Handles eight named event types: `counts-changed`, `job-completed`, `job-failed`, `job-active`, `job-waiting`, `job-stalled`, `se-event`, `heartbeat`.
- On `counts-changed`: merges new counts into the `liveCounts` reactive map, keyed by `baseName`.
- On `job-failed`: prepends to both `recentFailures[]` (capped at 200) and `recentEvents[]` (capped at 50). Always passes through immediately — failures are operationally significant and must never be throttled.
- On `se-event`: extracts the inner `payload.type` and surfaces `ipfs-fetch-failed`, `ipfs-fetch-recovered`, and `document-loaded` events to the activity feed immediately.
- `EventSource` auto-reconnects on disconnect — the composable just marks `isConnected = false` on error so the UI can show a polling indicator.

#### job-completed throttle

Without throttling, a queue processing hundreds of jobs per minute produces one feed entry per job, which floods the activity list faster than it can be read. The composable applies a **per-queue 5-second cooldown** using a `Map<queueBase, lastEmitTimestamp>`:

```ts
const COMPLETION_THROTTLE_MS = 5_000;
const lastCompletionTs = new Map<string, number>();

case 'job-completed': {
    const base = (data.queueBase ?? 'unknown') as string;
    const last = lastCompletionTs.get(base) ?? 0;
    if (now - last >= COMPLETION_THROTTLE_MS) {
        lastCompletionTs.set(base, now);
        prepend({ type: 'job-completed', payload: data, ts: now });
    }
    break;
}
```

At most one completion entry per queue every 5 seconds appears in the feed. If a queue completes 500 jobs in 5 seconds, only the first triggers a feed entry — the rest update `liveCounts` via `counts-changed` (which has its own 500 ms debounce server-side). The `lastCompletionTs` map is cleared when the network changes so the first completion on a new network is always shown.

#### Buffer sizes

| Buffer | Cap | Reasoning |
|--------|-----|-----------|
| `recentEvents` | 50 | Enough history to scan at a glance; throttling keeps it from filling instantly |
| `recentFailures` | 200 | Failures are rare but important — a larger history helps incident review |

---

## 9. Frontend — Status Page (status.vue)

### Stat cards (top row)

| Card | Source | Meaning |
|------|--------|---------|
| Data Synced Up To | `syncStatus.lastSyncedAt` | ISO datetime of the most recently indexed HCS message, formatted as `Month DD, YYYY` + time |
| Topics Indexed | `syncStatus.syncedTopics` / `syncStatus.totalTopics` | Topics fully caught up (`hasNext=false`) out of all known topics |
| Messages Processed | `syncStatus.totalMessages` | Sum of all HCS messages across every topic; pending count from `totalWaiting` (queue waiting jobs) |

These replaced the earlier "Total Waiting" and "Total Failed" cards that showed raw queue-depth numbers. The new cards answer the question a non-technical user actually cares about: *how much of Hedera has been indexed?*

### Live vs polling indicator

The SSE connection state drives the `● Live` / `○ Polling` banner. The "last updated Xs ago" counter increments every second using a `setInterval` comparing `Date.now()` against `lastEventAt` (updated on every SSE frame including heartbeats). The 30-second poll fallback (`refreshQueues` interval) ensures the table stays current even if SSE is unavailable.

### Queue table

Counts shown in the table are the **merged** view: SSE `counts-changed` data overlaid on top of the HTTP-fetched baseline. This means the table updates live without full HTTP refetches when jobs transition.

Failed count cells are clickable links that open the failed-jobs drawer for that queue.

### Failed jobs drawer

Slides in from the right. Two tabs:
- **By Reason** — groups all failed jobs by their `failedReason` string, showing count and sample job IDs. Uses `useQueueFailedGroupsApi`.
- **All Failed** — paginated list (50 per page) via `useQueueFailedJobsApi`. Each job shows its error, attempt counters, a collapsible stack trace, and per-job retry controls.

Retry controls require a two-step confirmation to avoid accidental retries. Jobs that have exhausted their 3-retry budget show a "budget exhausted" warning and a "force override" checkbox.

### Sync Health panel

Collapsible section, starts expanded (`syncPanelOpen = ref(true)`). Only rendered when `syncAvailable = true` (hidden only on confirmed 404 — i.e. the endpoint does not exist for this network). Shows:
- Last synced time + lag in seconds (colour-coded: green < 60 s, amber < 300 s, red otherwise).
- Topics table — topic ID, message count, `hasNext` badge, status, last update (relative time).
- Tokens table — token ID, highest serial, type, `hasNext` badge.

### Activity feed

The feed shows the latest 50 events from the SSE stream, newest first, in a fixed-height scrollable container (`max-h-[480px] overflow-y-auto`). There is no pagination.

#### Why no pagination

Pagination was tried but made the feed harder to use: new events arrived on page 0 while the user was reading page 1, making the page count stale. Because `job-completed` events are now throttled to one per queue per 5 seconds, the feed no longer fills faster than it can be read — the latest 50 events cover a meaningful window of time even on busy queues.

#### Filter toggle

A two-button toggle at the top right of the section lets users switch between **All** (default) and **Failures only**. The failures filter shows only `job-failed` and `ipfs-fetch-failed` events. Failure rows are also visually distinguished with a `bg-stat-rose/5` background tint regardless of filter mode.

Each failure row includes a truncated version of the failure reason directly in the feed:

```
09:12:34  Job Failed   mirror-node-topics / 1234 — ECONNREFUSED 127.0.0.1:5551
```

The failures badge on the toggle button shows a live count so users can see at a glance whether new failures have arrived.

#### Buffer full indicator

If `recentEvents` reaches its 50-event cap, a small amber notice appears: *(buffer full — oldest may be lost)*. This makes it visible that the feed is a rolling window, not a complete log.

#### Event types in the feed

| Event type | Source | Badge colour |
|-----------|--------|-------------|
| `job-completed` | BullMQ completed (throttled 1/queue/5s) | Green |
| `job-failed` | BullMQ failed | Red |
| `job-stalled` | BullMQ stalled | Amber |
| `ipfs-fetch-failed` | Worker → Redis `se:events` | Red |
| `ipfs-fetch-recovered` | Worker → Redis `se:events` | Green |
| `document-loaded` | Worker → Redis `se:events` | Blue |

### Pause / Resume

Endpoints exist in the controller code but are **commented out**. The action buttons were removed from the table on the public-facing platform. This functionality is reserved for a future operator admin panel that will require authentication.

---

## 10. SSE Stream — Performance Analysis

### Connection overhead

Each connected browser holds one long-lived HTTP/1.1 connection to the API server. NestJS handles these via its underlying `http.Server` with Node's event-driven I/O — idle connections cost essentially no CPU, only a file descriptor and a few KB of kernel buffer. A typical deployment with 50 simultaneous users on the status page would hold 50 connections.

### Event frequency

Without debouncing, a queue processing 500 jobs per second would emit 500 `completed` events per second per connected client, serialising and sending hundreds of KB/s of JSON. The 500 ms debounce on `counts-changed` collapses that to at most 2 count snapshots per second per queue. Job lifecycle events (failed, stalled) are emitted individually because they are infrequent and operationally significant. On the frontend, the additional 5-second per-queue throttle on `job-completed` feed entries means the UI list never scrolls faster than a human can read, regardless of backend throughput.

### Redis subscriber connection

The bus maintains exactly one dedicated Redis subscriber connection for `se:events`, shared across all SSE clients. The subscriber receives a message and fans it out to all clients in-process via the Node `EventEmitter`. This means N connected clients do not produce N Redis subscriptions — they all share one.

### Heartbeat

A 25-second heartbeat frame is sent to each client. This serves two purposes:
1. Keeps the TCP connection alive through firewalls and load balancers that close idle connections.
2. Drives the "last updated Xs ago" counter on the UI even during genuinely quiet periods.

### Memory per client

Each `streamForNetwork()` call creates one RxJS `merge()` subscription composed of `fromEvent` + `interval`. The `fromEvent` subscription holds a reference to the shared `EventEmitter`; the `interval` is a standard RxJS timer. Memory per client is well under 1 KB. The `EventEmitter.setMaxListeners(200)` call prevents false "possible memory leak" warnings from Node when many clients connect simultaneously.

### What would affect performance

| Scenario | Impact | Mitigation |
|----------|--------|-----------|
| High job throughput (>1000/s per queue) | Many `counts-changed` events debounced away; negligible | 500 ms server-side debounce + 5 s client-side throttle on completions |
| Hundreds of SSE clients | Each client adds one RxJS subscription and one EventEmitter listener | Fine up to ~200 clients (setMaxListeners); beyond that, switch to a dedicated pub/sub fan-out service |
| Redis subscriber disconnects | `se:events` messages are dropped until reconnect; ioredis auto-reconnects | Acceptable — events are ephemeral; the 30-second poll fallback covers gaps |
| Large failed job lists | `getFailed(0, 49)` reads up to 50 job hashes + data from Redis per request | Paginated; no full scan |

---

## 11. Known Constraints and Limits

- **`syncedTopics` count depends on `hasNext` accuracy.** If a topic's `hasNext` flag is stale (e.g. new messages arrived after the last sync), it may count as synced when it isn't. This is a data freshness issue, not a bug in the status page.
- **Total topic count is read without LIMIT.** The aggregate query (`COUNT(*)`) performs a sequential scan if no index covers it. On a table with tens of thousands of topic rows this is still fast (< 10 ms), but should be monitored if the topic count grows into the millions.
- **Autoscaler only controls concurrency, not process count.** For workloads that require parallelism beyond what a single Node event loop can deliver (CPU-bound transforms, memory-intensive parsing), horizontal scaling via additional worker containers remains necessary.
- **Pause/Resume endpoints are disabled.** They exist in the codebase but are commented out. Activating them on a public API without authentication would allow anyone to halt data ingestion. They are re-enabled when the admin panel with role-based access is shipped.
- **SSE does not use HTTP/2 multiplexing in the default NestJS setup.** Each browser tab connecting to `/status` holds a separate TCP connection. In production behind a TLS terminator (nginx, Caddy) that supports HTTP/2, this improves but SSE semantics remain the same.
- **Activity feed is a rolling window, not a log.** The 50-event buffer covers recent activity only. For a full audit trail of job failures, use the Failed Jobs drawer (which reads from Redis) or the `ipfs_fetch_failure` table (which persists across restarts).
