### PR TITLE
feat: add project comparison functionality with UI updates and localization

### DIFF
--- a/sustainable-explorer/frontend/composables/useProjectComparison.ts
+++ b/sustainable-explorer/frontend/composables/useProjectComparison.ts
@@ -1,0 +1,52 @@
+interface ComparisonEntry {
+    id: string;
+    name: string;
+}
+
+// Module-level singleton — shared across all component instances
+const selectedEntries = ref<ComparisonEntry[]>([]);
+
+export function useProjectComparison() {
+    const router = useRouter();
+
+    const selectedIds = computed(() => selectedEntries.value.map(e => e.id));
+    const canAdd = computed(() => selectedEntries.value.length < 4);
+
+    function isSelected(id: string): boolean {
+        return selectedEntries.value.some(e => e.id === id);
+    }
+
+    function toggleProject(id: string, name: string) {
+        const idx = selectedEntries.value.findIndex(e => e.id === id);
+        if (idx >= 0) {
+            selectedEntries.value.splice(idx, 1);
+        } else if (selectedEntries.value.length < 4) {
+            selectedEntries.value.push({ id, name });
+        }
+    }
+
+    function removeProject(id: string) {
+        const idx = selectedEntries.value.findIndex(e => e.id === id);
+        if (idx >= 0) selectedEntries.value.splice(idx, 1);
+    }
+
+    function clearAll() {
+        selectedEntries.value = [];
+    }
+
+    function goToCompare() {
+        if (selectedEntries.value.length < 2) return;
+        router.push(`/projects/compare?ids=${selectedIds.value.join(',')}`);
+    }
+
+    return {
+        selectedIds,
+        selectedEntries: computed(() => selectedEntries.value),
+        canAdd,
+        isSelected,
+        toggleProject,
+        removeProject,
+        clearAll,
+        goToCompare,
+    };
+}

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -198,6 +198,27 @@
       "vintage": "Vintage",
       "created": "Created",
       "creditingPeriod": "Crediting Period"
+    },
+    "compare": {
+      "title": "Compare Projects",
+      "subtitle": "Side-by-side comparison of up to 4 projects",
+      "attribute": "Attribute",
+      "notFound": "Project not found",
+      "needTwo": "Select at least 2 projects to compare.",
+      "credits": "Est. Credits",
+      "totalIssued": "Total Issued",
+      "totalRetired": "Total Retired",
+      "totalActive": "Total Active",
+      "creditingPeriodEnd": "Crediting Period End",
+      "selectToCompare": "Compare",
+      "comparing": "{count} selected",
+      "compareButton": "Compare",
+      "clearAll": "Clear all",
+      "maxSelected": "Max 4 projects",
+      "addToCompare": "Add to comparison",
+      "removeFromCompare": "Remove from comparison",
+      "diff": "diff",
+      "diffLegend": "Highlighted rows differ between projects"
     }
   },
   "credits": {

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -198,6 +198,27 @@
       "vintage": "Añada",
       "created": "Creado",
       "creditingPeriod": "Período de acreditación"
+    },
+    "compare": {
+      "title": "Comparar proyectos",
+      "subtitle": "Comparación lado a lado de hasta 4 proyectos",
+      "attribute": "Atributo",
+      "notFound": "Proyecto no encontrado",
+      "needTwo": "Selecciona al menos 2 proyectos para comparar.",
+      "credits": "Créditos est.",
+      "totalIssued": "Total emitido",
+      "totalRetired": "Total retirado",
+      "totalActive": "Total activo",
+      "creditingPeriodEnd": "Fin del período de acreditación",
+      "selectToCompare": "Comparar",
+      "comparing": "{count} seleccionados",
+      "compareButton": "Comparar",
+      "clearAll": "Limpiar todo",
+      "maxSelected": "Máx. 4 proyectos",
+      "addToCompare": "Añadir a la comparación",
+      "removeFromCompare": "Quitar de la comparación",
+      "diff": "dif.",
+      "diffLegend": "Las filas resaltadas difieren entre proyectos"
     }
   },
   "credits": {

--- a/sustainable-explorer/frontend/pages/projects/compare.vue
+++ b/sustainable-explorer/frontend/pages/projects/compare.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import { ArrowLeft, Columns2, X } from 'lucide-vue-next';
+import { formatCredits } from '~/lib/format';
+import { mapApiProject } from '~/composables/useProjects';
+import type { Project } from '~/types/models';
+
+const route = useRoute();
+const { network } = useNetwork();
+const { t } = useI18n();
+const config = useRuntimeConfig();
+const { clearAll } = useProjectComparison();
+
+const baseURL = import.meta.server
+    ? (config.apiBaseUrl as string)
+    : (config.public.apiBaseUrl as string);
+
+const ids = computed(() => {
+    const raw = (route.query.ids as string) ?? '';
+    return raw.split(',').map(s => s.trim()).filter(Boolean).slice(0, 4);
+});
+
+const { data: rawProjects, pending } = useAsyncData(
+    `compare:${network.value}:${ids.value.join(',')}`,
+    () => Promise.all(
+        ids.value.map(id =>
+            $fetch<Record<string, any>>(`/api/v1/${network.value}/projects/${id}`, { baseURL })
+                .catch(() => null),
+        ),
+    ),
+    { watch: [network] },
+);
+
+const projects = computed<(Project | null)[]>(() =>
+    (rawProjects.value ?? []).map(r => (r ? mapApiProject(r) : null)),
+);
+
+const loadedProjects = computed(() => projects.value.filter((p): p is Project => p !== null));
+
+const statusColor: Record<string, string> = {
+    Registered: 'bg-slate-100 text-slate-600',
+    'Under Validation': 'bg-stat-amber/10 text-stat-amber',
+    Verified: 'bg-stat-blue/10 text-stat-blue',
+    Issuing: 'bg-stat-green/10 text-stat-green',
+    Completed: 'bg-purple-50 text-purple-600',
+};
+
+interface CompareRow {
+    key: string;
+    label: string;
+    render: 'text' | 'status' | 'country' | 'credits' | 'sdgs';
+    getValue?: (p: Project) => string | number;
+}
+
+const COMPARE_ROWS = computed<CompareRow[]>(() => [
+    { key: 'status',            label: t('projects.details.status'),          render: 'status' },
+    { key: 'country',           label: t('projects.details.country'),          render: 'country' },
+    { key: 'registry',          label: t('projects.details.registry'),         render: 'text' },
+    { key: 'methodology',       label: t('projects.details.methodology'),      render: 'text' },
+    { key: 'sector',            label: t('dashboard.sector'),                  render: 'text' },
+    { key: 'vintage',           label: t('projects.filters.vintage'),          render: 'text' },
+    { key: 'developer',         label: t('projects.details.developer'),        render: 'text' },
+    { key: 'credits',           label: t('projects.compare.credits'),          render: 'credits',  getValue: (p) => p.credits },
+    { key: 'totalIssued',       label: t('projects.compare.totalIssued'),      render: 'credits',  getValue: (p) => p.totalIssued ?? 0 },
+    { key: 'totalRetired',      label: t('projects.compare.totalRetired'),     render: 'credits',  getValue: (p) => p.totalRetired ?? 0 },
+    { key: 'totalActive',       label: t('projects.compare.totalActive'),      render: 'credits',  getValue: (p) => p.totalActive ?? 0 },
+    { key: 'issuanceCount',     label: t('projects.columns.issuances'),        render: 'text',     getValue: (p) => p.issuanceCount ?? 0 },
+    { key: 'creditingPeriodEnd', label: t('projects.compare.creditingPeriodEnd'), render: 'text', getValue: (p) => p.creditingPeriodEnd ?? '—' },
+    { key: 'sdgs',              label: t('projects.columns.sdgs'),             render: 'sdgs' },
+]);
+
+function getCellValue(project: Project, row: CompareRow): string | number {
+    if (row.getValue) return row.getValue(project);
+    const val = (project as any)[row.key];
+    if (val === null || val === undefined || val === '') return '—';
+    return String(val);
+}
+
+function isDifferent(row: CompareRow): boolean {
+    if (loadedProjects.value.length < 2) return false;
+    if (row.render === 'sdgs') {
+        const vals = loadedProjects.value.map(p => [...(p.sdgs ?? [])].sort().join(','));
+        return new Set(vals).size > 1;
+    }
+    const vals = loadedProjects.value.map(p => String(getCellValue(p, row)));
+    return new Set(vals).size > 1;
+}
+
+const hasEnoughIds = computed(() => ids.value.length >= 2);
+</script>
+
+<template>
+    <div class="space-y-0">
+        <!-- Header -->
+        <div class="px-6 pt-6 pb-4">
+            <div class="flex items-center gap-3 mb-2">
+                <NuxtLink
+                    to="/projects"
+                    class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                    @click="clearAll"
+                >
+                    <ArrowLeft class="h-4 w-4" />
+                    {{ $t('projects.title') }}
+                </NuxtLink>
+            </div>
+            <h1 class="text-2xl font-bold text-foreground flex items-center gap-2">
+                <Columns2 class="h-6 w-6 text-primary" />
+                {{ $t('projects.compare.title') }}
+            </h1>
+            <p class="text-sm text-muted-foreground mt-1">{{ $t('projects.compare.subtitle') }}</p>
+        </div>
+
+        <!-- Not enough IDs -->
+        <div v-if="!hasEnoughIds" class="px-6 pb-6">
+            <div class="rounded-xl border bg-card px-6 py-10 text-center">
+                <p class="text-sm text-muted-foreground">{{ $t('projects.compare.needTwo') }}</p>
+                <NuxtLink to="/projects" class="mt-3 inline-flex items-center gap-1.5 text-sm text-primary hover:underline">
+                    <ArrowLeft class="h-4 w-4" />
+                    {{ $t('projects.title') }}
+                </NuxtLink>
+            </div>
+        </div>
+
+        <!-- Loading skeleton -->
+        <div v-else-if="pending" class="px-6 pb-6">
+            <div class="rounded-xl border bg-card overflow-hidden">
+                <div class="h-14 bg-muted/30 animate-pulse border-b" />
+                <div v-for="i in 8" :key="i" class="h-12 border-b animate-pulse" :class="i % 2 === 0 ? 'bg-muted/10' : 'bg-card'" />
+            </div>
+        </div>
+
+        <!-- Comparison table -->
+        <div v-else class="px-6 pb-6">
+            <div class="rounded-xl border bg-card overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b bg-muted/30">
+                            <th class="text-left py-3 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider min-w-[160px] sticky left-0 bg-muted/30 z-10">
+                                {{ $t('projects.compare.attribute') }}
+                            </th>
+                            <th
+                                v-for="(project, idx) in projects"
+                                :key="idx"
+                                class="text-left py-3 px-4 min-w-[220px] align-top"
+                            >
+                                <template v-if="project">
+                                    <NuxtLink
+                                        :to="`/projects/${project.id}`"
+                                        class="font-semibold text-foreground hover:text-primary transition-colors normal-case text-sm leading-snug block line-clamp-2"
+                                    >
+                                        {{ project.name }}
+                                    </NuxtLink>
+                                    <div class="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                                        <CountryFlag :code="project.countryCode || 'UNK'" size="sm" />
+                                        <span>{{ project.country || '—' }}</span>
+                                    </div>
+                                </template>
+                                <template v-else>
+                                    <span class="text-muted-foreground normal-case text-sm">{{ $t('projects.compare.notFound') }}</span>
+                                </template>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y">
+                        <tr
+                            v-for="row in COMPARE_ROWS"
+                            :key="row.key"
+                            :class="isDifferent(row) ? 'bg-amber-50/60' : ''"
+                        >
+                            <td class="py-3 px-4 text-xs font-medium text-muted-foreground whitespace-nowrap sticky left-0 z-10" :class="isDifferent(row) ? 'bg-amber-50/60' : 'bg-card'">
+                                {{ row.label }}
+                                <span v-if="isDifferent(row)" class="ml-1.5 inline-flex items-center rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
+                                    {{ $t('projects.compare.diff') }}
+                                </span>
+                            </td>
+                            <td
+                                v-for="(project, idx) in projects"
+                                :key="idx"
+                                class="py-3 px-4"
+                            >
+                                <template v-if="!project">
+                                    <span class="text-muted-foreground">—</span>
+                                </template>
+                                <template v-else-if="row.render === 'status'">
+                                    <span :class="[statusColor[project.status] || 'bg-muted text-muted-foreground', 'text-xs font-medium rounded-full px-2 py-0.5']">
+                                        {{ project.status }}
+                                    </span>
+                                </template>
+                                <template v-else-if="row.render === 'country'">
+                                    <span class="inline-flex items-center gap-1.5">
+                                        <CountryFlag :code="project.countryCode || 'UNK'" size="sm" />
+                                        <span>{{ project.country || '—' }}</span>
+                                    </span>
+                                </template>
+                                <template v-else-if="row.render === 'sdgs'">
+                                    <SdgBadges v-if="project.sdgs && project.sdgs.length > 0" :ids="project.sdgs" :max="6" />
+                                    <span v-else class="text-muted-foreground">—</span>
+                                </template>
+                                <template v-else-if="row.render === 'credits'">
+                                    <span class="tabular-nums font-medium">{{ formatCredits(Number(getCellValue(project, row)) || 0) }}</span>
+                                </template>
+                                <template v-else>
+                                    <span class="text-foreground">{{ getCellValue(project, row) || '—' }}</span>
+                                </template>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Legend -->
+            <div class="mt-3 flex items-center gap-2 text-[11px] text-muted-foreground">
+                <span class="inline-flex items-center gap-1">
+                    <span class="h-3 w-3 rounded-sm bg-amber-100 border border-amber-200" />
+                    {{ $t('projects.compare.diffLegend') }}
+                </span>
+            </div>
+        </div>
+    </div>
+</template>

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { FolderKanban, FileJson, Sparkles } from 'lucide-vue-next';
+import { FolderKanban, FileJson, Sparkles, CheckSquare, Square, X, Columns2 } from 'lucide-vue-next';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import { formatCredits } from '~/lib/format';
 import { SDG_LIST } from '~/lib/sdgs';
@@ -10,6 +10,7 @@ import type { Project } from '~/types/models';
 
 const { t } = useI18n();
 const { projects, total, filterOptions } = useProjects();
+const { selectedEntries, canAdd, isSelected, toggleProject, removeProject, clearAll, goToCompare } = useProjectComparison();
 const { resolvedCode } = useGeocodedCountries(projects);
 
 const INVALID_COUNTRY = new Set([
@@ -182,6 +183,9 @@ const statusColor: Record<string, string> = {
                 <table class="w-full text-sm min-w-[900px]">
                     <thead>
                         <tr class="border-b bg-muted/30">
+                            <th class="text-center py-2.5 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider w-10">
+                                <span class="inline-flex items-center gap-1"><Columns2 class="h-3.5 w-3.5" /></span>
+                            </th>
                             <SortableHeader :label="$t('projects.columns.project')" sort-key="name" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
                             <SortableHeader :label="$t('projects.columns.country')" sort-key="country" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
                             <SortableHeader :label="$t('projects.columns.registry')" sort-key="registry" :active-sort-key="sortKey as string" :sort-dir="sortDir" @sort="toggleSort($event as any)" />
@@ -206,6 +210,22 @@ const statusColor: Record<string, string> = {
                             :key="p.id"
                             class="hover:bg-muted/30 transition-colors cursor-pointer"
                         >
+                            <td class="py-3 px-3 text-center">
+                                <button
+                                    :class="[
+                                        isSelected(p.id)
+                                            ? 'text-primary bg-primary/10 hover:bg-primary/20'
+                                            : (!canAdd ? 'opacity-40 cursor-not-allowed text-muted-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'),
+                                        'inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors',
+                                    ]"
+                                    :title="isSelected(p.id) ? $t('projects.compare.removeFromCompare') : (!canAdd ? $t('projects.compare.maxSelected') : $t('projects.compare.addToCompare'))"
+                                    :disabled="!canAdd && !isSelected(p.id)"
+                                    @click.stop="toggleProject(p.id, p.name)"
+                                >
+                                    <CheckSquare v-if="isSelected(p.id)" class="h-3.5 w-3.5" />
+                                    <Square v-else class="h-3.5 w-3.5" />
+                                </button>
+                            </td>
                             <td class="py-3 px-4">
                                 <NuxtLink :to="`/projects/${p.id}`" class="font-medium text-foreground hover:text-primary transition-colors">{{ p.name }}</NuxtLink>
                             </td>
@@ -266,7 +286,7 @@ const statusColor: Record<string, string> = {
                             </td>
                         </tr>
                         <tr v-if="paginated.length === 0">
-                            <td colspan="11" class="py-12 text-center text-sm text-muted-foreground">{{ $t('projects.noMatch') }}</td>
+                            <td colspan="12" class="py-12 text-center text-sm text-muted-foreground">{{ $t('projects.noMatch') }}</td>
                         </tr>
                     </tbody>
                 </table>
@@ -282,4 +302,66 @@ const statusColor: Record<string, string> = {
 
         <VcJsonViewer :open="vcViewerOpen" :title="vcViewerTitle" :data="vcViewerData" @close="vcViewerOpen = false" />
     </div>
+
+    <!-- Floating comparison bar -->
+    <Teleport to="body">
+        <Transition
+            enter-active-class="transition-all duration-200 ease-out"
+            enter-from-class="opacity-0 translate-y-4"
+            enter-to-class="opacity-100 translate-y-0"
+            leave-active-class="transition-all duration-150 ease-in"
+            leave-from-class="opacity-100 translate-y-0"
+            leave-to-class="opacity-0 translate-y-4"
+        >
+            <div v-if="selectedEntries.length > 0" class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 pointer-events-none">
+                <div class="pointer-events-auto flex items-center gap-3 rounded-xl border bg-card shadow-2xl px-4 py-3 min-w-[340px] max-w-[700px]">
+                    <Columns2 class="h-4 w-4 text-primary shrink-0" />
+                    <span class="text-sm font-medium text-foreground shrink-0">
+                        {{ $t('projects.compare.comparing', { count: selectedEntries.length }) }}
+                    </span>
+
+                    <!-- Project chips -->
+                    <div class="flex items-center gap-1.5 flex-1 flex-wrap min-w-0">
+                        <span
+                            v-for="entry in selectedEntries"
+                            :key="entry.id"
+                            class="inline-flex items-center gap-1 rounded-full bg-primary/10 text-primary px-2.5 py-0.5 text-xs font-medium max-w-[160px]"
+                        >
+                            <span class="truncate">{{ entry.name }}</span>
+                            <button
+                                class="shrink-0 rounded-full hover:bg-primary/20 transition-colors p-0.5"
+                                :title="$t('common.close')"
+                                @click="removeProject(entry.id)"
+                            >
+                                <X class="h-2.5 w-2.5" />
+                            </button>
+                        </span>
+                    </div>
+
+                    <!-- Actions -->
+                    <div class="flex items-center gap-2 shrink-0">
+                        <button
+                            class="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                            @click="clearAll"
+                        >
+                            {{ $t('projects.compare.clearAll') }}
+                        </button>
+                        <button
+                            :disabled="selectedEntries.length < 2"
+                            :class="[
+                                selectedEntries.length >= 2
+                                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                                    : 'bg-muted text-muted-foreground cursor-not-allowed',
+                                'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                            ]"
+                            @click="goToCompare"
+                        >
+                            <Columns2 class="h-3 w-3" />
+                            {{ $t('projects.compare.compareButton') }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Transition>
+    </Teleport>
 </template>


### PR DESCRIPTION
Adds side-by-side comparison of up to 4 projects. Users select projects via a toggle button in the first column of the
projects table — a floating bar appears at the bottom showing selected projects with chips and a "Compare" button. 

Navigates to /projects/compare?ids=... which renders a 14-row attribute table with amber diff highlighting on rows where values differ.