### PR TITLE
Refactor dashboard color handling and enhance donut chart functionality

### DIFF
--- a/sustainable-explorer/frontend/composables/useDashboard.ts
+++ b/sustainable-explorer/frontend/composables/useDashboard.ts
@@ -271,17 +271,6 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
         totalCredits: projects.value.reduce((sum, p) => sum + p.credits, 0),
     }));
 
-    // Sector breakdown for pie charts
-    const sectorColors: Record<string, string> = {
-        'Energy Industries': 'hsl(142, 76%, 36%)',
-        'Energy Demand': 'hsl(197, 37%, 24%)',
-        'Forestry and Land Use': 'hsl(47, 96%, 53%)',
-        'Waste Handling and Disposal': 'hsl(349, 89%, 60%)',
-        'Agriculture': 'hsl(262, 83%, 58%)',
-        'Coastal and Marine': 'hsl(199, 89%, 48%)',
-        'Water Supply': 'hsl(217, 71%, 53%)',
-    };
-
     const sectorBreakdown = computed(() => {
         const groups: Record<string, { projectCount: number; creditCount: number }> = {};
         for (const p of filteredProjects.value) {
@@ -296,18 +285,9 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
                 label,
                 projectCount: data.projectCount,
                 creditCount: data.creditCount,
-                color: sectorColors[label] || 'hsl(220, 13%, 69%)',
             }))
             .sort((a, b) => b.projectCount - a.projectCount);
     });
-
-    // Registry breakdown for pie charts
-    const registryColors: Record<string, string> = {
-        'Verra': 'hsl(142, 76%, 36%)',
-        'Gold Standard': 'hsl(47, 96%, 53%)',
-        'CAR': 'hsl(349, 89%, 60%)',
-        'ACR': 'hsl(262, 83%, 58%)',
-    };
 
     const registryBreakdown = computed(() => {
         const groups: Record<string, { projectCount: number; creditCount: number }> = {};
@@ -323,7 +303,6 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
                 label,
                 projectCount: data.projectCount,
                 creditCount: data.creditCount,
-                color: registryColors[label] || 'hsl(220, 13%, 69%)',
             }))
             .sort((a, b) => b.projectCount - a.projectCount);
     });

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -103,6 +103,7 @@
     "sectorRegistryBreakdownSub": "Distribution of projects and issuances by sector and registry",
     "bySector": "By Sector",
     "byRegistry": "By Registry",
+    "otherCategory": "Other",
     "projectsToggle": "Projects",
     "issuancesToggle": "Issuances",
     "topRegistries": "Top Registries",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -102,6 +102,7 @@
     "sectorRegistryBreakdownTooltip": "Distribución de proyectos y emisiones por sector y registro. Alterna entre conteo de proyectos y volumen de emisiones. Refleja los filtros actuales de desarrollador/registro.",
     "sectorRegistryBreakdownSub": "Distribución de proyectos y emisiones por sector y registro",
     "bySector": "Por sector",
+    "otherCategory": "Otros",
     "byRegistry": "Por registro",
     "projectsToggle": "Proyectos",
     "issuancesToggle": "Emisiones",

--- a/sustainable-explorer/frontend/lib/chart-colors.ts
+++ b/sustainable-explorer/frontend/lib/chart-colors.ts
@@ -1,0 +1,85 @@
+/**
+ * 15 evenly spaced hues plus neutral for aggregated "Other".
+ * Colors are assigned with equal spacing on the donut (largest slice first):
+ * slice i → palette slot floor(i × 15 ÷ n), then a seeded rotation so
+ * first/last neighbors on the ring are always far apart in hue (fixes
+ * two-greens when n is small).
+ */
+export const DONUT_OTHER_COLOR = 'hsl(218, 14%, 48%)';
+
+/** ~24° hue steps, higher saturation for on-screen vibrancy. */
+const DONUT_PALETTE = [
+    'hsl(352, 88%, 52%)',
+    'hsl(16, 92%, 53%)',
+    'hsl(38, 94%, 52%)',
+    'hsl(58, 91%, 46%)',
+    'hsl(82, 84%, 42%)',
+    'hsl(122, 76%, 42%)',
+    'hsl(152, 82%, 38%)',
+    'hsl(178, 82%, 42%)',
+    'hsl(202, 92%, 48%)',
+    'hsl(222, 88%, 54%)',
+    'hsl(252, 82%, 56%)',
+    'hsl(278, 76%, 54%)',
+    'hsl(304, 82%, 52%)',
+    'hsl(322, 82%, 52%)',
+    'hsl(335, 82%, 53%)',
+] as const;
+
+export const DONUT_TOP_N = 15;
+
+export function stableHash(seed: string): number {
+    let h = 0;
+    for (let i = 0; i < seed.length; i++) {
+        h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0;
+    }
+    return Math.abs(h);
+}
+
+/**
+ * One color per wedge in display order; hues are as evenly spaced around
+ * the circle as the fixed 15-slot palette allows (wraps first↔last cleanly).
+ */
+export function allocateDonutColors(sliceCount: number, seed: string): string[] {
+    if (sliceCount <= 0) return [];
+    const n = sliceCount;
+    const m = DONUT_PALETTE.length;
+    const offset = stableHash(seed) % m;
+    const colors: string[] = [];
+    for (let i = 0; i < n; i++) {
+        const slot = Math.floor((i * m) / n);
+        const idx = (slot + offset) % m;
+        colors.push(DONUT_PALETTE[idx]!);
+    }
+    return colors;
+}
+
+export type DonutMergeBin = {
+    label: string;
+    projectCount: number;
+    creditCount: number;
+};
+
+/** Sort by selected metric descending, keep top DONUT_TOP_N, roll the rest into one row. */
+export function mergeTopBinsWithOther(
+    bins: DonutMergeBin[],
+    mode: 'projects' | 'credits',
+    otherLabel: string,
+): DonutMergeBin[] {
+    if (bins.length === 0) return [];
+    const val = (b: DonutMergeBin) =>
+        mode === 'projects' ? b.projectCount : b.creditCount;
+
+    const sorted = [...bins].sort((a, b) => val(b) - val(a));
+
+    if (sorted.length <= DONUT_TOP_N) return sorted;
+
+    const top = sorted.slice(0, DONUT_TOP_N);
+    const tail = sorted.slice(DONUT_TOP_N);
+    const other: DonutMergeBin = {
+        label: otherLabel,
+        projectCount: tail.reduce((s, b) => s + b.projectCount, 0),
+        creditCount: tail.reduce((s, b) => s + b.creditCount, 0),
+    };
+    return [...top, other];
+}

--- a/sustainable-explorer/frontend/pages/index.vue
+++ b/sustainable-explorer/frontend/pages/index.vue
@@ -22,6 +22,11 @@ import {
     Flame,
 } from 'lucide-vue-next';
 import { formatCredits } from '~/lib/format';
+import {
+    allocateDonutColors,
+    DONUT_OTHER_COLOR,
+    mergeTopBinsWithOther,
+} from '~/lib/chart-colors';
 
 const { t } = useI18n();
 
@@ -89,8 +94,52 @@ const retirementSeriesTotal = computed(() =>
     Math.round(retirementSeriesData.value.reduce((s, d) => s + d.value, 0) * 10) / 10,
 );
 
+function buildDonutRows(
+    bins: { label: string; projectCount: number; creditCount: number }[],
+    mode: 'projects' | 'credits',
+    seedPrefix: string,
+) {
+    if (bins.length === 0) return [];
+    const merged = mergeTopBinsWithOther(bins, mode, t('dashboard.otherCategory'));
+    const hasOtherAggregate = bins.length > 15;
+    const mainSliceCount = hasOtherAggregate ? 15 : merged.length;
+    const val = (b: (typeof merged)[number]) =>
+        mode === 'projects' ? b.projectCount : b.creditCount;
+    const seed = `${seedPrefix}|${mode}|${merged.map(b => `${b.label}:${val(b)}`).join('|')}`;
+    const colors = allocateDonutColors(mainSliceCount, seed);
+    if (hasOtherAggregate) colors.push(DONUT_OTHER_COLOR);
+    return merged.map((b, i) => ({
+        ...b,
+        color: colors[i]!,
+    }));
+}
+
+const sectorDonutRows = computed(() =>
+    buildDonutRows(
+        sectorBreakdown.value.map(({ label, projectCount, creditCount }) => ({
+            label,
+            projectCount,
+            creditCount,
+        })),
+        chartMode.value,
+        'sector',
+    ),
+);
+
+const registryDonutRows = computed(() =>
+    buildDonutRows(
+        registryBreakdown.value.map(({ label, projectCount, creditCount }) => ({
+            label,
+            projectCount,
+            creditCount,
+        })),
+        chartMode.value,
+        'registry',
+    ),
+);
+
 const sectorChartSegments = computed(() =>
-    sectorBreakdown.value.map(s => ({
+    sectorDonutRows.value.map(s => ({
         label: s.label,
         value: chartMode.value === 'projects' ? s.projectCount : s.creditCount,
         color: s.color,
@@ -98,7 +147,7 @@ const sectorChartSegments = computed(() =>
 );
 
 const registryChartSegments = computed(() =>
-    registryBreakdown.value.map(s => ({
+    registryDonutRows.value.map(s => ({
         label: s.label,
         value: chartMode.value === 'projects' ? s.projectCount : s.creditCount,
         color: s.color,
@@ -565,7 +614,7 @@ const filteredStats = computed(() => {
                         <div class="flex items-start gap-5">
                             <DonutChart :segments="sectorChartSegments" :size="140" />
                             <div class="space-y-2 flex-1 min-w-0 pt-1">
-                                <div v-for="s in sectorBreakdown" :key="s.label" class="flex items-center gap-2">
+                                <div v-for="s in sectorDonutRows" :key="s.label" class="flex items-center gap-2">
                                     <span class="h-2.5 w-2.5 shrink-0 rounded-full" :style="{ backgroundColor: s.color }" />
                                     <span class="text-xs text-muted-foreground truncate flex-1">{{ s.label }}</span>
                                     <span class="text-xs font-medium text-foreground tabular-nums shrink-0">
@@ -585,7 +634,7 @@ const filteredStats = computed(() => {
                         <div class="flex items-start gap-5">
                             <DonutChart :segments="registryChartSegments" :size="140" />
                             <div class="space-y-2 flex-1 min-w-0 pt-1">
-                                <div v-for="s in registryBreakdown" :key="s.label" class="flex items-center gap-2">
+                                <div v-for="s in registryDonutRows" :key="s.label" class="flex items-center gap-2">
                                     <span class="h-2.5 w-2.5 shrink-0 rounded-full" :style="{ backgroundColor: s.color }" />
                                     <span class="text-xs text-muted-foreground truncate flex-1">{{ s.label }}</span>
                                     <span class="text-xs font-medium text-foreground tabular-nums shrink-0">


### PR DESCRIPTION
- Replace fixed sector/registry color maps with a 15-slot palette and seeded rotation  
- Keep top 15 buckets by projects/credits; merge remainder into localized “Other”  
- Assign hues with equal angular spacing so last/first donut neighbors stay distinct
- Bump saturation/lightness for clearer, more vibrant wedges  
- Wire legends and charts from shared donut row helpers in `index.vue`; add `dashboard.otherCategory` (en/es)