### PR TITLE
feat(dashboard): replace fixed entity chart colors with dynamic 15-color palette

### DIFF
--- a/sustainable-explorer/frontend/composables/useDashboard.ts
+++ b/sustainable-explorer/frontend/composables/useDashboard.ts
@@ -1,5 +1,6 @@
 import type { ActivityItem, MapPoint, MapCountry } from '~/types/models';
 import { formatCredits } from '~/lib/format';
+import { allocateDonutColors } from '~/lib/chart-colors';
 
 function relativeTime(dateStr: string): string {
     const now = Date.now();
@@ -354,29 +355,25 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
             totalCredits += p.credits;
         }
 
-        const sectorColorMap: Record<string, string> = {
-            'Renewable Energy': '#1a9850',
-            'Forestry': '#0f6b3a',
-            'Blue Carbon': '#0a97d9',
-            'Energy Efficiency': '#66bd63',
-            'Agriculture': '#d9ef8b',
-            'Water': '#26bde2',
-            'Waste': '#a6d96a',
-        };
-
         const useCredits = totalCredits > 0;
         const denom = useCredits ? totalCredits : (totalProjects || 1);
 
-        const sectors = Object.keys(catCounts)
+        const sectorRows = Object.keys(catCounts)
             .map(label => {
                 const numerator = useCredits ? catCredits[label] : catCounts[label];
                 return {
                     label,
                     value: Math.round((numerator / denom) * 100),
-                    color: sectorColorMap[label] || '#d4d4d8',
                 };
             })
             .sort((a, b) => b.value - a.value);
+
+        const sectorSeed = `country-sectors|${code}|${sectorRows.map(s => `${s.label}:${s.value}`).join('|')}`;
+        const sectorColors = allocateDonutColors(sectorRows.length, sectorSeed);
+        const sectors = sectorRows.map((s, i) => ({
+            ...s,
+            color: sectorColors[i] ?? 'hsl(220, 13%, 75%)',
+        }));
 
         const regCredits: Record<string, number> = {};
         const regCounts: Record<string, number> = {};

--- a/sustainable-explorer/frontend/pages/analytics/index.vue
+++ b/sustainable-explorer/frontend/pages/analytics/index.vue
@@ -2,6 +2,7 @@
 import { BarChart3, TrendingUp, ArrowUpRight, ArrowDownRight } from 'lucide-vue-next';
 import { MOCK_PROJECTS, MOCK_CREDITS } from '~/data';
 import { formatCredits } from '~/lib/format';
+import { allocateDonutColors } from '~/lib/chart-colors';
 
 const { t } = useI18n();
 
@@ -28,18 +29,20 @@ const byMethodology = computed(() => {
         total += p.credits;
     }
 
-    const colors = ['bg-chart-1', 'bg-chart-2', 'bg-chart-3', 'bg-chart-4', 'bg-chart-5'];
-    return Object.entries(catCredits)
+    const rows = Object.entries(catCredits)
         .map(([name, credits]) => ({
             name,
             value: total > 0 ? Math.round((credits / total) * 100) : 0,
         }))
         .sort((a, b) => b.value - a.value)
-        .slice(0, 5)
-        .map((item, idx) => ({
-            ...item,
-            color: colors[idx] || 'bg-chart-5',
-        }));
+        .slice(0, 5);
+
+    const seed = `analytics-methodology|${rows.map(r => `${r.name}:${r.value}`).join('|')}`;
+    const palette = allocateDonutColors(rows.length, seed);
+    return rows.map((item, idx) => ({
+        ...item,
+        accentColor: palette[idx] ?? 'hsl(220, 13%, 75%)',
+    }));
 });
 </script>
 
@@ -82,9 +85,8 @@ const byMethodology = computed(() => {
                             <span class="text-xs text-muted-foreground w-32 shrink-0 text-right">{{ m.name }}</span>
                             <div class="flex-1 h-7 bg-muted/50 rounded-md overflow-hidden">
                                 <div
-                                    :class="m.color"
                                     class="h-full rounded-md transition-all duration-500"
-                                    :style="{ width: `${m.value}%` }"
+                                    :style="{ width: `${m.value}%`, backgroundColor: m.accentColor }"
                                 />
                             </div>
                             <span class="text-xs font-medium text-foreground w-10 text-right tabular-nums">{{ m.value }}%</span>


### PR DESCRIPTION
- Wire dashboard donuts and country-panel sector donut to shared allocator;
  drop hard-coded sector/registry/category hex maps
