### PR TITLE
refactor: Implement project_mint_link table and update logic to resolve MintToken VC attribution

### DIFF
--- a/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
@@ -263,22 +263,26 @@ export class PgMethodologyRepository extends MethodologyRepository {
                 raw_vc: Record<string, any> | null;
             }> = await this.dataSource.query(
                 `
-                SELECT
-                    COALESCE(tc."tokenId", bv."businessData"->>'tokenId') AS "tokenId",
-                    COALESCE(tc.name,      bv."displayName")              AS name,
-                    COALESCE(tc.symbol,    bv."businessData"->>'symbol')  AS symbol,
-                    tc.type,
-                    tc."totalSupply"                                      AS supply,
-                    bv."createdAt"                                        AS "mintDate",
-                    m.documents                                           AS raw_vc
-                FROM business_view bv
-                LEFT JOIN token_cache tc
-                    ON tc."tokenId" = bv."businessData"->>'tokenId'
-                LEFT JOIN message m
-                    ON m."consensusTimestamp" = bv."sourceTimestamp"
-                WHERE bv."viewType" = 'CREDIT'
-                  AND bv."relatedTopicId" IN (${placeholders})
-                ORDER BY bv."createdAt" ASC
+                SELECT * FROM (
+                    SELECT DISTINCT ON (COALESCE(tc."tokenId", bv."businessData"->>'tokenId'))
+                        COALESCE(tc."tokenId", bv."businessData"->>'tokenId') AS "tokenId",
+                        COALESCE(tc.name,      bv."displayName")              AS name,
+                        COALESCE(tc.symbol,    bv."businessData"->>'symbol')  AS symbol,
+                        tc.type,
+                        tc."totalSupply"                                      AS supply,
+                        bv."createdAt"                                        AS "mintDate",
+                        m.documents                                           AS raw_vc
+                    FROM business_view bv
+                    LEFT JOIN token_cache tc
+                        ON tc."tokenId" = bv."businessData"->>'tokenId'
+                    LEFT JOIN message m
+                        ON m."consensusTimestamp" = bv."sourceTimestamp"
+                    WHERE bv."viewType" = 'CREDIT'
+                      AND bv."relatedTopicId" IN (${placeholders})
+                    ORDER BY COALESCE(tc."tokenId", bv."businessData"->>'tokenId'),
+                             bv."createdAt" DESC
+                ) deduped
+                ORDER BY "mintDate" ASC
                 `,
                 topicIds,
             );

--- a/sustainable-explorer/src/api/repositories/pg-project.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-project.repository.ts
@@ -43,16 +43,17 @@ const REGISTRY_NAME_JOIN = `
 `;
 
 /**
- * LATERAL subquery joined into findAll to count per-project MintToken VCs
- * published back to the project's instance topic by Guardian after each mint.
+ * LATERAL subquery joined into findAll to count per-project mints from the
+ * pre-computed project_mint_link table. Uses idx_pml_project_src so the
+ * lookup is O(log n) per row, and correctly splits grouped projects that
+ * share one instance topic.
  */
 const ISSUANCE_COUNT_JOIN = `
     LEFT JOIN LATERAL (
-        SELECT COUNT(*)::int AS issuance_count
-        FROM message m
-        WHERE m."topicId" = bv."relatedTopicId"
-          AND m.type = 'VC-Document'
-          AND m.documents -> 'credentialSubject' -> 0 ->> 'type' = 'MintToken'
+        SELECT COUNT(DISTINCT pml.token_id)::int AS issuance_count
+        FROM project_mint_link pml
+        WHERE pml.project_source_timestamp = bv."sourceTimestamp"
+          AND pml.token_id IS NOT NULL
     ) mint ON true
 `;
 
@@ -193,41 +194,39 @@ export class PgProjectRepository extends ProjectRepository {
         const policyTopicId = (row.businessData as Record<string, any> | null)?.['policyTopicId'] as string | null;
         const instanceTopicId = row.relatedTopicId;
 
-        // Step 1 — try per-project attribution via MintToken VCs published back to
-        // the project's instance topic by Guardian after each mint event.
-        // Each MintToken VC has: { type: "MintToken", tokenId, amount, date }
+        // Step 1 — per-project mint attribution via project_mint_link.
+        // The linker pre-resolves each MintToken to its specific project by
+        // walking options.relationships, so this query is correct even for
+        // grouped projects that share one instance topic.
         let issuances: IssuanceRow[] = [];
         let totalIssued = 0;
         let totalRetired = 0;
 
         const mintTokenRows: Array<{
             token_id: string | null;
-            amount: string | null;
-            mint_date: string | null;
+            amount: number | null;
+            mint_date: Date | null;
             documents: Record<string, any> | null;
-        }> = instanceTopicId
-            ? await this.dataSource.query(
-                `SELECT
-                    m.documents -> 'credentialSubject' -> 0 ->> 'tokenId' AS token_id,
-                    m.documents -> 'credentialSubject' -> 0 ->> 'amount'  AS amount,
-                    m.documents -> 'credentialSubject' -> 0 ->> 'date'    AS mint_date,
-                    m.documents
-                 FROM message m
-                 WHERE m."topicId" = $1
-                   AND m.type = 'VC-Document'
-                   AND m.documents -> 'credentialSubject' -> 0 ->> 'type' = 'MintToken'
-                 ORDER BY m."consensusTimestamp" ASC`,
-                [instanceTopicId],
-            )
-            : [];
+        }> = await this.dataSource.query(
+            `SELECT
+                pml.token_id,
+                pml.amount,
+                pml.mint_date,
+                m.documents
+             FROM project_mint_link pml
+             JOIN message m ON m."consensusTimestamp" = pml.mint_consensus_timestamp
+             WHERE pml.project_source_timestamp = $1
+             ORDER BY pml.mint_date ASC NULLS LAST`,
+            [row.sourceTimestamp],
+        );
 
         if (mintTokenRows.length > 0) {
             // Aggregate minted amount per token; keep last MintToken VC as raw data
-            const mintsByToken = new Map<string, { total: number; mintDate: string | null; rawVc: Record<string, any> | null }>();
+            const mintsByToken = new Map<string, { total: number; mintDate: Date | null; rawVc: Record<string, any> | null }>();
             for (const r of mintTokenRows) {
                 if (!r.token_id) continue;
                 const existing = mintsByToken.get(r.token_id) ?? { total: 0, mintDate: r.mint_date, rawVc: r.documents };
-                existing.total += parseInt(r.amount ?? '0', 10);
+                existing.total += r.amount != null ? Number(r.amount) : 0;
                 existing.rawVc = r.documents;
                 mintsByToken.set(r.token_id, existing);
             }
@@ -256,7 +255,7 @@ export class PgProjectRepository extends ProjectRepository {
                     type: meta?.type ?? null,
                     supply: data.total,
                     mintDate: data.mintDate
-                        ? new Date(data.mintDate).toISOString().split('T')[0]
+                        ? data.mintDate.toISOString().split('T')[0]
                         : null,
                     rawVc: data.rawVc,
                 };

--- a/sustainable-explorer/src/shared/database/schema-bootstrap.ts
+++ b/sustainable-explorer/src/shared/database/schema-bootstrap.ts
@@ -149,4 +149,31 @@ export async function bootstrapSchema(dataSource: DataSource): Promise<void> {
           AND documents IS NOT NULL
           AND (documents->'credentialSubject'->0->>'type') = 'MintToken'
     `);
+
+    // Pre-computed MintToken → project attribution table.
+    // Eliminates the grouped-project double-counting bug where a topic-scope
+    // join would assign every MintToken in a shared instance topic to all
+    // projects in that topic. The linker walks options.relationships to
+    // resolve each mint to its specific project by sourceTimestamp.
+    await dataSource.query(`
+        CREATE TABLE IF NOT EXISTS project_mint_link (
+            mint_consensus_timestamp VARCHAR(30)  PRIMARY KEY,
+            project_source_timestamp VARCHAR(30)  NOT NULL,
+            project_topic_id         VARCHAR(20)  NOT NULL,
+            token_id                 VARCHAR(20),
+            amount                   BIGINT,
+            mint_date                TIMESTAMPTZ,
+            link_method              VARCHAR(20)  NOT NULL DEFAULT 'topic_scope'
+        )
+    `);
+
+    await dataSource.query(`
+        CREATE INDEX IF NOT EXISTS idx_pml_project_src
+            ON project_mint_link (project_source_timestamp)
+    `);
+
+    await dataSource.query(`
+        CREATE INDEX IF NOT EXISTS idx_pml_token_id
+            ON project_mint_link (token_id)
+    `);
 }

--- a/sustainable-explorer/src/shared/materialized-views/methodology-stats.mv.ts
+++ b/sustainable-explorer/src/shared/materialized-views/methodology-stats.mv.ts
@@ -38,32 +38,18 @@ export const MV_METHODOLOGY_STATS_CREATE_SQL = `
               AND p."businessData"->>'instanceTopicId' = mb."relatedTopicId"
         ), 0)::bigint AS instance_project_count,
         COALESCE((
-            SELECT COUNT(*)
-            FROM message m
-            WHERE m."topicId" = mb.policy_topic_id
-              AND m.type = 'Token'
-              AND m.options->>'tokenId' IS NOT NULL
+            SELECT COUNT(DISTINCT bv."businessData"->>'tokenId')
+            FROM business_view bv
+            WHERE bv."viewType" = 'CREDIT'
+              AND bv."relatedTopicId" IN (mb.policy_topic_id, mb."relatedTopicId")
+              AND bv."businessData"->>'tokenId' IS NOT NULL
         ), 0)::bigint AS issuance_count,
-        -- Per-version issuances. Each Token-issue message is published in
-        -- the policy topic just BEFORE its version's publish-policy, so we
-        -- attribute each Token to the nearest subsequent publish-policy and
-        -- count those whose instanceTopicId matches this methodology row.
         COALESCE((
-            SELECT COUNT(*)
-            FROM message tok
-            WHERE tok."topicId" = mb.policy_topic_id
-              AND tok.type = 'Token'
-              AND tok.options->>'tokenId' IS NOT NULL
-              AND (
-                  SELECT p.options->>'instanceTopicId'
-                  FROM message p
-                  WHERE p.type = 'Instance-Policy'
-                    AND p.action = 'publish-policy'
-                    AND p."topicId" = tok."topicId"
-                    AND p."consensusTimestamp" > tok."consensusTimestamp"
-                  ORDER BY p."consensusTimestamp" ASC
-                  LIMIT 1
-              ) = mb."relatedTopicId"
+            SELECT COUNT(DISTINCT bv."businessData"->>'tokenId')
+            FROM business_view bv
+            WHERE bv."viewType" = 'CREDIT'
+              AND bv."relatedTopicId" = mb."relatedTopicId"
+              AND bv."businessData"->>'tokenId' IS NOT NULL
         ), 0)::bigint AS instance_issuance_count,
         COALESCE((
             SELECT COUNT(DISTINCT ps."schemaId")

--- a/sustainable-explorer/src/worker/processors/business-view-builder.processor.ts
+++ b/sustainable-explorer/src/worker/processors/business-view-builder.processor.ts
@@ -4,6 +4,7 @@ import { Job } from "bullmq";
 import { DataSource } from "typeorm";
 import Redis from "ioredis";
 import { QUEUE_NAMES } from "@shared/config/bullmq.config";
+import { buildMintProjectLinks } from "../project-mapper/mint-project-linker";
 
 /**
  * Builds METHODOLOGY / REGISTRY / CREDIT rows in business_view from raw
@@ -139,6 +140,8 @@ export class BusinessViewBuilderProcessor extends WorkerHost {
         `);
 
         const totalUpserted = result?.rowCount ?? result?.length ?? 0;
+
+        await buildMintProjectLinks(this.dataSource, this.logger);
 
         await this.redis.publish(
             "se:events",

--- a/sustainable-explorer/src/worker/project-mapper/mint-project-linker.ts
+++ b/sustainable-explorer/src/worker/project-mapper/mint-project-linker.ts
@@ -1,0 +1,162 @@
+import { Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+/**
+ * Resolves each unlinked MintToken VC to its specific project and upserts
+ * the result into project_mint_link.
+ *
+ * Called from BusinessViewBuilderProcessor after registry/methodology/credit
+ * views are built. The function is incremental — only unlinked mints are
+ * processed on each run, so subsequent calls are near-free when no new
+ * MintToken VCs have arrived.
+ *
+ * Resolution strategy:
+ *   1. Walk options.relationships via recursive CTE (up to 15 hops) until an
+ *      ancestor consensusTimestamp matches a business_view PROJECT row.
+ *      Using sourceTimestamp as the project key correctly splits grouped
+ *      projects (multiple project VCs sharing one instance topic).
+ *   2. Topic-scope fallback: only when the instance topic contains exactly
+ *      one project. Grouped topics without a resolved chain are skipped to
+ *      avoid misattribution.
+ */
+export async function buildMintProjectLinks(
+    dataSource: DataSource,
+    logger: Logger,
+): Promise<void> {
+    const unlinked: Array<{
+        consensusTimestamp: string;
+        topicId: string;
+        token_id: string | null;
+        amount: string | null;
+        mint_date: string | null;
+    }> = await dataSource.query(`
+        SELECT
+            m."consensusTimestamp",
+            m."topicId",
+            m.documents->'credentialSubject'->0->>'tokenId' AS token_id,
+            m.documents->'credentialSubject'->0->>'amount'  AS amount,
+            m.documents->'credentialSubject'->0->>'date'    AS mint_date
+        FROM message m
+        WHERE m.type = 'VC-Document'
+          AND m.documents->'credentialSubject'->0->>'type' = 'MintToken'
+          AND NOT EXISTS (
+              SELECT 1 FROM project_mint_link pml
+              WHERE pml.mint_consensus_timestamp = m."consensusTimestamp"
+          )
+        ORDER BY m."consensusTimestamp"
+    `);
+
+    if (unlinked.length === 0) return;
+
+    logger.log(`MintProjectLinker: linking ${unlinked.length} new mint(s)`);
+
+    let linked = 0;
+    let fallback = 0;
+    let skipped = 0;
+
+    for (const mint of unlinked) {
+        // Step 1 — walk options.relationships backwards to find the ancestor
+        // PROJECT row. ORDER BY depth ASC + LIMIT 1 picks the shallowest match,
+        // which is the Project Registration VC closest to the mint in the chain.
+        const chainRows: Array<{
+            project_source_timestamp: string;
+            project_topic_id: string;
+        }> = await dataSource.query(`
+            WITH RECURSIVE rel_chain(ts, depth) AS (
+                SELECT
+                    jsonb_array_elements_text(m.options->'relationships')::varchar AS ts,
+                    1 AS depth
+                FROM message m
+                WHERE m."consensusTimestamp" = $1
+                  AND m.options->'relationships' IS NOT NULL
+                  AND jsonb_typeof(m.options->'relationships') = 'array'
+                  AND jsonb_array_length(m.options->'relationships') > 0
+
+                UNION ALL
+
+                SELECT
+                    jsonb_array_elements_text(p.options->'relationships')::varchar,
+                    rc.depth + 1
+                FROM rel_chain rc
+                JOIN message p ON p."consensusTimestamp" = rc.ts
+                WHERE rc.depth < 15
+                  AND p.options->'relationships' IS NOT NULL
+                  AND p.options->'relationships' != 'null'::jsonb
+                  AND jsonb_typeof(p.options->'relationships') = 'array'
+            )
+            SELECT
+                bv."sourceTimestamp" AS project_source_timestamp,
+                bv."relatedTopicId"  AS project_topic_id
+            FROM rel_chain rc
+            JOIN business_view bv
+                ON bv."sourceTimestamp" = rc.ts
+               AND bv."viewType" = 'PROJECT'
+            ORDER BY rc.depth ASC
+            LIMIT 1
+        `, [mint.consensusTimestamp]);
+
+        let projectSourceTs: string;
+        let projectTopicId: string;
+        let linkMethod: string;
+
+        if (chainRows.length > 0) {
+            projectSourceTs = chainRows[0].project_source_timestamp;
+            projectTopicId = chainRows[0].project_topic_id;
+            linkMethod = 'relationship';
+            linked++;
+        } else {
+            // Step 2 — topic-scope fallback: safe only for unambiguous single-project topics.
+            const fallbackRows: Array<{ sourceTimestamp: string; relatedTopicId: string }> =
+                await dataSource.query(`
+                    SELECT "sourceTimestamp", "relatedTopicId"
+                    FROM business_view
+                    WHERE "viewType" = 'PROJECT'
+                      AND "relatedTopicId" = $1
+                `, [mint.topicId]);
+
+            if (fallbackRows.length !== 1) {
+                if (fallbackRows.length > 1) {
+                    logger.warn(
+                        `MintToken ${mint.consensusTimestamp}: grouped topic ${mint.topicId} — ` +
+                        `chain unresolved, skipping to avoid misattribution`,
+                    );
+                }
+                skipped++;
+                continue;
+            }
+
+            projectSourceTs = fallbackRows[0].sourceTimestamp;
+            projectTopicId = fallbackRows[0].relatedTopicId;
+            linkMethod = 'topic_scope';
+            fallback++;
+        }
+
+        // amount arrives as a JSONB string; parseFloat handles decimal values
+        // (e.g. "250.5") before rounding to fit the BIGINT column.
+        const amount = mint.amount != null ? Math.round(parseFloat(mint.amount)) : null;
+        const mintDate = mint.mint_date ? new Date(mint.mint_date) : null;
+
+        await dataSource.query(`
+            INSERT INTO project_mint_link (
+                mint_consensus_timestamp,
+                project_source_timestamp,
+                project_topic_id,
+                token_id,
+                amount,
+                mint_date,
+                link_method
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (mint_consensus_timestamp) DO UPDATE SET
+                project_source_timestamp = EXCLUDED.project_source_timestamp,
+                project_topic_id         = EXCLUDED.project_topic_id,
+                token_id                 = EXCLUDED.token_id,
+                amount                   = EXCLUDED.amount,
+                mint_date                = EXCLUDED.mint_date,
+                link_method              = EXCLUDED.link_method
+        `, [mint.consensusTimestamp, projectSourceTs, projectTopicId, mint.token_id, amount, mintDate, linkMethod]);
+    }
+
+    logger.log(
+        `MintProjectLinker: ${linked} via relationship, ${fallback} via topic-scope, ${skipped} skipped`,
+    );
+}


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-49

- Added a pre-computed mint-to-project attribution table that resolves each MintToken VC to its specific project by walking the Guardian VC relationship chain. This fixes incorrect issuance counts for grouped projects (multiple projects sharing one Guardian instance topic), where previously all mints in a shared topic were counted for every project in it.
 - Hooked the attribution linker into the business-view rebuild pipeline so it runs incrementally after each sync cycle — only unlinked mints are processed, making repeated runs near-free.
 - Switched the project list and detail endpoints to read from the pre-computed attribution table instead of scanning raw messages by topic, giving correct per-project counts and amounts regardless of topic sharing.
 - Fixed the methodology detail page showing the same token multiple times (once per policy version). The same token is now deduplicated at the SQL level so each distinct token appears once with its latest metadata.
 - Aligned the methodology list issuance count with the detail page by switching from counting raw Token messages (which counted version announcements) to counting distinct token IDs from CREDIT rows, consistent with the deduplication applied on the detail page.