### PR TITLE
feat: Implement dashboard mint statistics feature with API integration and caching

### DIFF
--- a/sustainable-explorer/frontend/composables/useDashboard.ts
+++ b/sustainable-explorer/frontend/composables/useDashboard.ts
@@ -13,6 +13,7 @@ const CODE_TO_COUNTRY: Record<string, string> = Object.fromEntries(
 
 export function useDashboard(filters?: Ref<{ developer?: string; registry?: string }>) {
     const { projects, pending } = useProjects();
+    const { mintStats, buildMintSeries, mintedBySector, mintedByRegistry } = useMintStats(filters);
     const { t } = useI18n();
 
     // Reverse-geocode projects whose country field was empty or unrecognized
@@ -226,38 +227,8 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
             .sort((a, b) => b.projects - a.projects);
     });
 
-    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const quarterNames = ['Q1', 'Q2', 'Q3', 'Q4'];
-
-    // Build issuance time series from filtered projects using createdAt + credits
     function buildIssuanceSeries(period: 'monthly' | 'quarterly' | 'yearly'): { label: string; value: number }[] {
-        const map: Record<string, { sortKey: string; label: string; value: number }> = {};
-
-        for (const p of filteredProjects.value) {
-            if (!p.createdAt) continue;
-            const d = new Date(p.createdAt);
-            if (isNaN(d.getTime())) continue;
-            const val = p.credits / 1_000_000;
-            let sortKey: string;
-            let label: string;
-            if (period === 'yearly') {
-                sortKey = String(d.getFullYear());
-                label = sortKey;
-            } else if (period === 'quarterly') {
-                const q = Math.floor(d.getMonth() / 3);
-                sortKey = `${d.getFullYear()}-Q${q}`;
-                label = `${quarterNames[q]} '${String(d.getFullYear()).slice(2)}`;
-            } else {
-                sortKey = `${d.getFullYear()}-${String(d.getMonth()).padStart(2, '0')}`;
-                label = `${monthNames[d.getMonth()]} '${String(d.getFullYear()).slice(2)}`;
-            }
-            if (!map[sortKey]) map[sortKey] = { sortKey, label, value: 0 };
-            map[sortKey].value += val;
-        }
-
-        return Object.values(map)
-            .sort((a, b) => a.sortKey.localeCompare(b.sortKey))
-            .map(e => ({ label: e.label, value: Math.max(Math.round(e.value * 10) / 10, 0.1) }));
+        return buildMintSeries(period);
     }
 
     // No retirement data source — always returns empty
@@ -327,13 +298,11 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
     // that exist but haven't produced any projects yet.
     const stats = computed(() => {
         const set = filteredProjects.value;
-        let totalCredits = 0;
         const uniqueRegistries = new Set<string>();
         const uniqueMethodologies = new Set<string>();
         for (const p of set) {
             if (p.registry) uniqueRegistries.add(p.registry);
             if (p.methodologyId) uniqueMethodologies.add(p.methodologyId);
-            totalCredits += p.credits;
         }
         return {
             registries: hasActiveFilter.value
@@ -343,49 +312,63 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
                 ? uniqueMethodologies.size
                 : methodologyTotal.value,
             projects: set.length,
-            totalCredits,
+            totalCredits: mintStats.value.totalMinted,
         };
     });
 
     const sectorBreakdown = computed(() => {
-        const groups: Record<string, { projectCount: number; creditCount: number }> = {};
+        // Count projects per sector from the local project list.
+        const projectCounts = new Map<string, number>();
         for (const p of filteredProjects.value) {
-            const sectorKey = p.sector || SectorType.Undefined;
-            if (!groups[sectorKey]) {
-                groups[sectorKey] = { projectCount: 0, creditCount: 0 };
-            }
-            groups[sectorKey].projectCount++;
-            groups[sectorKey].creditCount += p.credits;
+            const key = p.sector || SectorType.Undefined;
+            projectCounts.set(key, (projectCounts.get(key) ?? 0) + 1);
         }
-        return Object.entries(groups)
-            .map(([label, data]) => ({
-                label,
-                projectCount: data.projectCount,
-                creditCount: data.creditCount,
-            }))
-            .sort((a, b) => {
-                if (a.label === SectorType.Undefined) return 1;
-                if (b.label === SectorType.Undefined) return -1;
-                return b.projectCount - a.projectCount;
-            });
+
+        // Drive the row list from the API mint data so every sector with real
+        // minted volume is represented, regardless of whether its label matches
+        // a project in filteredProjects. Without this, sectors whose label only
+        // exists in mintedBySector (not in filteredProjects) are silently dropped
+        // and their amounts never appear in the chart total.
+        const seen = new Set<string>();
+        const rows: { label: string; projectCount: number; creditCount: number }[] = [];
+
+        for (const { label, amount } of mintStats.value.bySector) {
+            const key = label || SectorType.Undefined;
+            seen.add(key);
+            rows.push({ label: key, projectCount: projectCounts.get(key) ?? 0, creditCount: amount });
+        }
+
+        // Add sectors that have projects but no mints.
+        for (const [label, count] of projectCounts) {
+            if (!seen.has(label)) rows.push({ label, projectCount: count, creditCount: 0 });
+        }
+
+        return rows.sort((a, b) => {
+            if (a.label === SectorType.Undefined) return 1;
+            if (b.label === SectorType.Undefined) return -1;
+            return b.projectCount - a.projectCount;
+        });
     });
 
     const registryBreakdown = computed(() => {
-        const groups: Record<string, { projectCount: number; creditCount: number }> = {};
+        const projectCounts = new Map<string, number>();
         for (const p of filteredProjects.value) {
-            if (!groups[p.registry]) {
-                groups[p.registry] = { projectCount: 0, creditCount: 0 };
-            }
-            groups[p.registry].projectCount++;
-            groups[p.registry].creditCount += p.credits;
+            if (p.registry) projectCounts.set(p.registry, (projectCounts.get(p.registry) ?? 0) + 1);
         }
-        return Object.entries(groups)
-            .map(([label, data]) => ({
-                label,
-                projectCount: data.projectCount,
-                creditCount: data.creditCount,
-            }))
-            .sort((a, b) => b.projectCount - a.projectCount);
+
+        const seen = new Set<string>();
+        const rows: { label: string; projectCount: number; creditCount: number }[] = [];
+
+        for (const { label, amount } of mintStats.value.byRegistry) {
+            seen.add(label);
+            rows.push({ label, projectCount: projectCounts.get(label) ?? 0, creditCount: amount });
+        }
+
+        for (const [label, count] of projectCounts) {
+            if (!seen.has(label)) rows.push({ label, projectCount: count, creditCount: 0 });
+        }
+
+        return rows.sort((a, b) => b.projectCount - a.projectCount);
     });
 
     // Country detail for the side panel

--- a/sustainable-explorer/frontend/composables/useMintStats.ts
+++ b/sustainable-explorer/frontend/composables/useMintStats.ts
@@ -1,0 +1,99 @@
+import type { DashboardMintStatsDto } from '~/types/dashboard';
+
+const EMPTY: DashboardMintStatsDto = {
+    totalMinted: 0,
+    mintSeries: [],
+    bySector: [],
+    byRegistry: [],
+};
+
+export function useMintStats(filters?: Ref<{ registry?: string; developer?: string }>) {
+    const { network } = useNetwork();
+    const config = useRuntimeConfig();
+    const baseURL = import.meta.server
+        ? (config.apiBaseUrl as string)
+        : (config.public.apiBaseUrl as string);
+
+    const query = computed(() => {
+        const f = filters?.value ?? {};
+        const q: Record<string, string> = {};
+        if (f.registry && f.registry !== 'All Registries') q.registry = f.registry;
+        if (f.developer && f.developer !== 'All Developers') q.developer = f.developer;
+        return q;
+    });
+
+    const key = computed(() =>
+        `mint-stats:${network.value}:${query.value.registry ?? ''}:${query.value.developer ?? ''}`,
+    );
+
+    const { data, pending } = useAsyncData<DashboardMintStatsDto>(
+        key.value,
+        () => $fetch<DashboardMintStatsDto>(
+            `/api/v1/${network.value}/dashboard/mint-stats`,
+            { baseURL, query: query.value },
+        ).catch(() => EMPTY),
+        {
+            watch: [network, query],
+            default: () => EMPTY,
+        },
+    );
+
+    const mintStats = computed<DashboardMintStatsDto>(() => data.value ?? EMPTY);
+
+    // Build a time-bucketed series (monthly → quarterly → yearly) from the
+    // monthly series returned by the API, matching useDashboard's period API.
+    function buildMintSeries(period: 'monthly' | 'quarterly' | 'yearly'): { label: string; value: number }[] {
+        const monthly = mintStats.value.mintSeries;
+        if (monthly.length === 0) return [];
+
+        const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        const quarterNames = ['Q1', 'Q2', 'Q3', 'Q4'];
+
+        const buckets = new Map<string, { sortKey: string; label: string; value: number }>();
+
+        for (const entry of monthly) {
+            const d = new Date(entry.month);
+            if (isNaN(d.getTime())) continue;
+            const val = entry.amount / 1_000_000;
+            let sortKey: string;
+            let label: string;
+
+            if (period === 'yearly') {
+                sortKey = String(d.getFullYear());
+                label = sortKey;
+            } else if (period === 'quarterly') {
+                const q = Math.floor(d.getMonth() / 3);
+                sortKey = `${d.getFullYear()}-Q${q}`;
+                label = `${quarterNames[q]} '${String(d.getFullYear()).slice(2)}`;
+            } else {
+                sortKey = entry.month.slice(0, 7);
+                label = `${monthNames[d.getMonth()]} '${String(d.getFullYear()).slice(2)}`;
+            }
+
+            if (!buckets.has(sortKey)) buckets.set(sortKey, { sortKey, label, value: 0 });
+            buckets.get(sortKey)!.value += val;
+        }
+
+        return [...buckets.values()]
+            .sort((a, b) => a.sortKey.localeCompare(b.sortKey))
+            .map(e => ({ label: e.label, value: e.value }));
+    }
+
+    // Quick lookup: minted amount by sector label
+    const mintedBySector = computed(() =>
+        new Map(mintStats.value.bySector.map(e => [e.label, e.amount])),
+    );
+
+    // Quick lookup: minted amount by registry label
+    const mintedByRegistry = computed(() =>
+        new Map(mintStats.value.byRegistry.map(e => [e.label, e.amount])),
+    );
+
+    return {
+        mintStats,
+        mintPending: pending,
+        buildMintSeries,
+        mintedBySector,
+        mintedByRegistry,
+    };
+}

--- a/sustainable-explorer/frontend/types/dashboard.ts
+++ b/sustainable-explorer/frontend/types/dashboard.ts
@@ -1,0 +1,16 @@
+export interface MintSeriesEntry {
+    month: string;
+    amount: number;
+}
+
+export interface MintBreakdownEntry {
+    label: string;
+    amount: number;
+}
+
+export interface DashboardMintStatsDto {
+    totalMinted: number;
+    mintSeries: MintSeriesEntry[];
+    bySector: MintBreakdownEntry[];
+    byRegistry: MintBreakdownEntry[];
+}

--- a/sustainable-explorer/src/api/api.module.ts
+++ b/sustainable-explorer/src/api/api.module.ts
@@ -15,6 +15,7 @@ import { CreditsController } from './controllers/credits.controller';
 import { QueueStatusController } from './controllers/queue-status.controller';
 import { SdgsController } from './controllers/sdgs.controller';
 import { DevelopersController } from './controllers/developers.controller';
+import { DashboardController } from './controllers/dashboard.controller';
 
 // Services
 import { RegistriesService } from './services/registries.service';
@@ -26,6 +27,7 @@ import { ProjectsService } from './services/project.service';
 import { CreditsService } from './services/credits.service';
 import { SdgsService } from './services/sdgs.service';
 import { DevelopersService } from './services/developers.service';
+import { DashboardService } from './services/dashboard.service';
 
 // Queue management
 import { QueueRegistry } from './queues/queue.registry';
@@ -48,6 +50,7 @@ import { QueueEventsBus } from './queues/queue-events-bus.service';
         QueueStatusController,
         SdgsController,
         DevelopersController,
+        DashboardController,
     ],
     providers: [
         NetworkDataSourceRegistry,
@@ -60,6 +63,7 @@ import { QueueEventsBus } from './queues/queue-events-bus.service';
         CreditsService,
         SdgsService,
         DevelopersService,
+        DashboardService,
         QueueRegistry,
         QueueEventsBus,
     ],

--- a/sustainable-explorer/src/api/controllers/dashboard.controller.ts
+++ b/sustainable-explorer/src/api/controllers/dashboard.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { DashboardService } from '../services/dashboard.service';
+import { DashboardMintStatsQueryDto, DashboardMintStatsDto } from '../dto/dashboard.dto';
+
+@ApiTags('dashboard')
+@Controller('api/v1/:network/dashboard')
+export class DashboardController {
+    constructor(private readonly dashboardService: DashboardService) {}
+
+    @Get('mint-stats')
+    @ApiOperation({
+        summary: 'Dashboard mint statistics',
+        description:
+            'Returns total minted amount, monthly issuance series, and sector/registry breakdowns ' +
+            'sourced from project_mint_link — actual on-chain MintToken amounts connected to projects. ' +
+            'Results are cached for 60 seconds.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'] })
+    @ApiResponse({ status: 200, type: DashboardMintStatsDto })
+    async getMintStats(
+        @Param('network') network: string,
+        @Query() query: DashboardMintStatsQueryDto,
+    ): Promise<DashboardMintStatsDto> {
+        return this.dashboardService.getMintStats(network, {
+            registry: query.registry,
+            developer: query.developer,
+        });
+    }
+}

--- a/sustainable-explorer/src/api/dto/dashboard.dto.ts
+++ b/sustainable-explorer/src/api/dto/dashboard.dto.ts
@@ -1,0 +1,44 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class DashboardMintStatsQueryDto {
+    @ApiPropertyOptional({ description: 'Filter by registry display name' })
+    @IsOptional()
+    @IsString()
+    registry?: string;
+
+    @ApiPropertyOptional({ description: 'Filter by project developer name' })
+    @IsOptional()
+    @IsString()
+    developer?: string;
+}
+
+export class MintSeriesEntryDto {
+    @ApiProperty({ description: 'Month bucket as ISO date (YYYY-MM-01)' })
+    month: string;
+
+    @ApiProperty({ description: 'Total minted in this month (tCO2e or token units)' })
+    amount: number;
+}
+
+export class MintBreakdownEntryDto {
+    @ApiProperty({ description: 'Sector or registry label' })
+    label: string;
+
+    @ApiProperty({ description: 'Total minted for this label' })
+    amount: number;
+}
+
+export class DashboardMintStatsDto {
+    @ApiProperty({ description: 'Sum of all project_mint_link amounts connected to projects' })
+    totalMinted: number;
+
+    @ApiProperty({ type: [MintSeriesEntryDto], description: 'Monthly minted amounts, sorted ascending' })
+    mintSeries: MintSeriesEntryDto[];
+
+    @ApiProperty({ type: [MintBreakdownEntryDto], description: 'Minted amounts grouped by project sector' })
+    bySector: MintBreakdownEntryDto[];
+
+    @ApiProperty({ type: [MintBreakdownEntryDto], description: 'Minted amounts grouped by registry' })
+    byRegistry: MintBreakdownEntryDto[];
+}

--- a/sustainable-explorer/src/api/repositories/pg-dashboard.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-dashboard.repository.ts
@@ -1,0 +1,79 @@
+import { DataSource } from 'typeorm';
+
+export interface MintAggRow {
+    sector: string;
+    registry: string;
+    month: Date | null;
+    amount: string; // Postgres returns BIGINT as string
+}
+
+export interface DashboardMintQuery {
+    registry?: string;
+    developer?: string;
+}
+
+/**
+ * Single aggregation query against project_mint_link JOIN business_view.
+ *
+ * Groups by (sector, registry, month) in one pass — the caller pivots the
+ * result into totalMinted / mintSeries / bySector / byRegistry without any
+ * extra round trips.
+ *
+ * Performance notes:
+ *  - project_mint_link.project_source_timestamp has idx_pml_project_src —
+ *    the JOIN to business_view hits that index.
+ *  - The LATERAL registry lookup is O(log n) per row.
+ *  - No per-project loop; the DB engine handles the aggregation in one plan.
+ *  - We filter pml.amount > 0 and pml.token_id IS NOT NULL early so the
+ *    aggregation only touches real mint rows.
+ */
+export class PgDashboardRepository {
+    constructor(private readonly dataSource: DataSource) {}
+
+    async getMintAggregations(query: DashboardMintQuery = {}): Promise<MintAggRow[]> {
+        const params: unknown[] = [];
+
+        const conditions: string[] = [
+            `pml.token_id IS NOT NULL`,
+            `pml.amount IS NOT NULL`,
+            `pml.amount > 0`,
+        ];
+
+        if (query.registry) {
+            params.push(query.registry);
+            conditions.push(`reg.registry_name = $${params.length}`);
+        }
+
+        if (query.developer) {
+            params.push(query.developer);
+            conditions.push(`bv."businessData"->>'developer' = $${params.length}`);
+        }
+
+        const where = conditions.join(' AND ');
+
+        const sql = `
+            SELECT
+                COALESCE(bv."businessData"->>'sector', '')                   AS sector,
+                COALESCE(reg.registry_name, bv."registryDid", 'Unknown')     AS registry,
+                DATE_TRUNC('month', pml.mint_date)::date                     AS month,
+                SUM(pml.amount)::bigint                                      AS amount
+            FROM project_mint_link pml
+            JOIN business_view bv
+                ON bv."sourceTimestamp" = pml.project_source_timestamp
+               AND bv."viewType" = 'PROJECT'
+            LEFT JOIN LATERAL (
+                SELECT "displayName" AS registry_name
+                FROM business_view r
+                WHERE r."viewType" = 'REGISTRY'
+                  AND r."registryDid" = bv."registryDid"
+                ORDER BY r."createdAt" DESC NULLS LAST
+                LIMIT 1
+            ) reg ON true
+            WHERE ${where}
+            GROUP BY sector, registry, month
+            ORDER BY month ASC NULLS LAST
+        `;
+
+        return this.dataSource.query(sql, params);
+    }
+}

--- a/sustainable-explorer/src/api/services/dashboard.service.ts
+++ b/sustainable-explorer/src/api/services/dashboard.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { NetworkDataSourceRegistry } from '../database/network-datasource.registry';
+import { PgDashboardRepository, DashboardMintQuery } from '../repositories/pg-dashboard.repository';
+import { DashboardMintStatsDto } from '../dto/dashboard.dto';
+
+interface CacheEntry {
+    data: DashboardMintStatsDto;
+    expiresAt: number;
+}
+
+@Injectable()
+export class DashboardService {
+    // In-memory cache keyed by "network:registry:developer".
+    // TTL matches MV_REFRESH_INTERVAL so the data is never staler than the
+    // underlying business_view materialized view.
+    private readonly cache = new Map<string, CacheEntry>();
+    private readonly CACHE_TTL_MS = 60_000;
+
+    constructor(private readonly dataSources: NetworkDataSourceRegistry) {}
+
+    async getMintStats(network: string, query: DashboardMintQuery): Promise<DashboardMintStatsDto> {
+        const cacheKey = `${network}:${query.registry ?? ''}:${query.developer ?? ''}`;
+        const cached = this.getFromCache(cacheKey);
+        if (cached) return cached;
+
+        const repo = new PgDashboardRepository(this.dataSources.getDataSource(network));
+        const rows = await repo.getMintAggregations(query);
+
+        const result = this.aggregate(rows);
+        this.setCache(cacheKey, result);
+        return result;
+    }
+
+    private aggregate(rows: Awaited<ReturnType<PgDashboardRepository['getMintAggregations']>>): DashboardMintStatsDto {
+        let totalMinted = 0;
+        const monthMap = new Map<string, number>();
+        const sectorMap = new Map<string, number>();
+        const registryMap = new Map<string, number>();
+
+        for (const row of rows) {
+            const amount = Number(row.amount) || 0;
+            totalMinted += amount;
+
+            // Monthly series — key is ISO month string 'YYYY-MM-01'
+            if (row.month) {
+                const monthKey = row.month instanceof Date
+                    ? row.month.toISOString().slice(0, 7) + '-01'
+                    : String(row.month).slice(0, 7) + '-01';
+                monthMap.set(monthKey, (monthMap.get(monthKey) ?? 0) + amount);
+            }
+
+            // Sector breakdown
+            const sector = row.sector || '';
+            sectorMap.set(sector, (sectorMap.get(sector) ?? 0) + amount);
+
+            // Registry breakdown
+            const registry = row.registry || 'Unknown';
+            registryMap.set(registry, (registryMap.get(registry) ?? 0) + amount);
+        }
+
+        return {
+            totalMinted,
+            mintSeries: [...monthMap.entries()]
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([month, amount]) => ({ month, amount })),
+            bySector: [...sectorMap.entries()]
+                .sort(([, a], [, b]) => b - a)
+                .map(([label, amount]) => ({ label, amount })),
+            byRegistry: [...registryMap.entries()]
+                .sort(([, a], [, b]) => b - a)
+                .map(([label, amount]) => ({ label, amount })),
+        };
+    }
+
+    private getFromCache(key: string): DashboardMintStatsDto | null {
+        const entry = this.cache.get(key);
+        if (!entry) return null;
+        if (Date.now() > entry.expiresAt) {
+            this.cache.delete(key);
+            return null;
+        }
+        return entry.data;
+    }
+
+    private setCache(key: string, data: DashboardMintStatsDto): void {
+        this.cache.set(key, { data, expiresAt: Date.now() + this.CACHE_TTL_MS });
+    }
+}


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-57

- Added GET /api/v1/:network/dashboard/mint-stats endpoint — aggregates project_mint_link by sector, registry, and month
- Dashboard stat card "Total Issuances", issuance trendline, and Sector/Registry breakdown (credits mode) now reflect actual minted token amounts from project_mint_link instead of the estimatedERy field from project registration VCs
- Fixed sector/registry breakdown totals not matching the stat card — breakdown is now driven from the API mint data directly rather than a project-list label lookup that silently dropped unmatched sectors
- Fixed trendline total inflation caused by rounding accumulation