### PR TITLE
fix: Update pageSize in useFilteredPagination for consistency acros components

### DIFF
--- a/sustainable-explorer/frontend/composables/useFilteredPagination.ts
+++ b/sustainable-explorer/frontend/composables/useFilteredPagination.ts
@@ -18,7 +18,7 @@ export function useFilteredPagination<T>(
     const initialQuery = route.query;
     const searchQuery = ref((initialQuery.q as string) || '');
     const currentPage = ref(initialQuery.page ? parseInt(initialQuery.page as string) : 1);
-    const pageSize = opts.pageSize ?? 10;
+    const pageSize = ref(opts.pageSize ?? 10);
     const activeFilters = ref<Record<string, string>>(parseFiltersFromQuery(initialQuery));
     const sortKey = ref<keyof T | null>(
         (initialQuery.sort as keyof T | undefined) ?? opts.defaultSort?.key ?? null,
@@ -139,11 +139,11 @@ export function useFilteredPagination<T>(
         return result;
     });
 
-    const totalPages = computed(() => Math.max(1, Math.ceil(filtered.value.length / pageSize)));
+    const totalPages = computed(() => Math.max(1, Math.ceil(filtered.value.length / pageSize.value)));
 
     const paginated = computed(() => {
-        const start = (currentPage.value - 1) * pageSize;
-        return filtered.value.slice(start, start + pageSize);
+        const start = (currentPage.value - 1) * pageSize.value;
+        return filtered.value.slice(start, start + pageSize.value);
     });
 
     function setFilter(key: string, value: string) {
@@ -180,6 +180,10 @@ export function useFilteredPagination<T>(
 
     watch(currentPage, () => {
         syncToUrl();
+    });
+
+    watch(pageSize, () => {
+        currentPage.value = 1;
     });
 
     return {

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -42,7 +42,7 @@ const allCredits = computed(() => credits.value.map(c => ({
 const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters } =
     useFilteredPagination(allCredits, {
         searchFields: ['name', 'symbol', 'tokenId', 'project', 'registry'],
-        pageSize: 8,
+        pageSize: 10,
         defaultSort: { key: 'supply', dir: 'desc' },
     });
 

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -111,7 +111,7 @@ const typeColor: Record<string, string> = { Fungible: 'bg-stat-blue/10 text-stat
                     </tbody>
                 </table>
             </div>
-            <Pagination v-model:current-page="currentPage" :total-pages="totalPages" :total-items="filtered.length" :page-size="pageSize" />
+            <Pagination v-model:current-page="currentPage" v-model:page-size="pageSize" :total-pages="totalPages" :total-items="filtered.length" />
         </div>
 
         <VcJsonViewer :open="vcViewerOpen" :title="vcViewerTitle" :data="vcViewerData" @close="vcViewerOpen = false" />

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -60,7 +60,7 @@ const allProjects = computed(() => projects.value.map(p => ({
 const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters, applyPreset } =
     useFilteredPagination(allProjects, {
         searchFields: ['name', 'country', 'methodology', 'registry', 'sector', 'sectoralScope'],
-        pageSize: 8,
+        pageSize: 10,
         defaultSort: { key: 'createdAt', dir: 'desc' },
         arrayFields: ['sdgs'],
     });
@@ -311,9 +311,9 @@ const statusColor: Record<string, string> = {
 
             <Pagination
                 v-model:current-page="currentPage"
+                v-model:page-size="pageSize"
                 :total-pages="totalPages"
                 :total-items="filtered.length"
-                :page-size="pageSize"
             />
         </div>
 

--- a/sustainable-explorer/frontend/pages/sdgs.vue
+++ b/sustainable-explorer/frontend/pages/sdgs.vue
@@ -22,7 +22,7 @@ const allSdgs = computed(() => sdgStats.value.map(s => ({
 const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters } =
     useFilteredPagination(allSdgs, {
         searchFields: ['name', 'topMethodology'],
-        pageSize: 17,
+        pageSize: 25,
         defaultSort: { key: 'projects', dir: 'desc' },
     });
 

--- a/sustainable-explorer/frontend/pages/sdgs.vue
+++ b/sustainable-explorer/frontend/pages/sdgs.vue
@@ -22,7 +22,7 @@ const allSdgs = computed(() => sdgStats.value.map(s => ({
 const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters } =
     useFilteredPagination(allSdgs, {
         searchFields: ['name', 'topMethodology'],
-        pageSize: 25,
+        pageSize: 10,
         defaultSort: { key: 'projects', dir: 'desc' },
     });
 
@@ -126,9 +126,9 @@ function sdgIcon(id: number): string {
 
             <Pagination
                 v-model:current-page="currentPage"
+                v-model:page-size="pageSize"
                 :total-pages="totalPages"
                 :total-items="filtered.length"
-                :page-size="pageSize"
             />
         </div>
     </div>


### PR DESCRIPTION
### Pagination rows-per-page not applying (Projects, Credits, SDGs) - https://xeptagon.atlassian.net/browse/SE-55

  **Root cause: Three separate issues compounded:**
  1. useFilteredPagination returned pageSize as a plain number — totalPages and paginated computed properties could
  never react to changes
  2. The Pagination component in projects/index.vue only had a one-way :page-size bind — the update:pageSize event
  emitted by the dropdown was never handled
  3. Default pageSize values (8, 17) were not in the dropdown options [10, 25, 50, 100], causing the select to render
  blank on load

  **Fix:**
  - Converted pageSize to a ref in useFilteredPagination and updated dependent computeds to use .value
  - Added watch(pageSize) to reset currentPage to 1 when page size changes
  - Changed :page-size to v-model:page-size in projects/index.vue so the dropdown selection is written back
  - Aligned default page sizes to valid option values: 8 → 10 (projects, credits), 17 → 10 (SDGs)