### PR TITLE
feat: Enhance project details with HashScan links and improve layout for better readability

### DIFF
--- a/sustainable-explorer/frontend/components/project/HederaReferences.vue
+++ b/sustainable-explorer/frontend/components/project/HederaReferences.vue
@@ -3,6 +3,8 @@ import { Shield, CheckCircle2, ExternalLink, Copy, Check } from 'lucide-vue-next
 import type { Project } from '~/types/models';
 import { formatDate } from '~/lib/format';
 
+const { t } = useI18n();
+
 const props = defineProps<{
     project: Project;
     network: string;
@@ -58,11 +60,10 @@ async function copyToClipboard(text: string) {
                 <!-- Instance Topic ID -->
                 <div class="bg-card px-5 py-4">
                     <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">Instance Topic ID</div>
-                    <div class="group flex items-center gap-2">
+                    <div class="flex items-center gap-2 flex-wrap">
                         <code class="text-sm font-mono text-foreground">{{ project.topicId ?? '—' }}</code>
                         <button
                             v-if="project.topicId"
-                            class="opacity-0 group-hover:opacity-100 transition-opacity"
                             title="Copy"
                             @click="copyToClipboard(project.topicId)"
                         >
@@ -74,10 +75,10 @@ async function copyToClipboard(text: string) {
                             :href="hashscanTopicUrl"
                             target="_blank"
                             rel="noopener noreferrer"
-                            class="opacity-0 group-hover:opacity-100 transition-opacity"
-                            title="View on HashScan"
+                            class="inline-flex items-center gap-1 text-xs text-primary hover:underline"
                         >
-                            <ExternalLink class="h-3.5 w-3.5 text-primary" />
+                            <ExternalLink class="h-3 w-3" />
+                            {{ t('common.viewOnHashScan') }}
                         </a>
                     </div>
                 </div>
@@ -85,11 +86,10 @@ async function copyToClipboard(text: string) {
                 <!-- Policy Topic ID -->
                 <div class="bg-card px-5 py-4">
                     <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">Policy Topic ID</div>
-                    <div class="group flex items-center gap-2">
+                    <div class="flex items-center gap-2 flex-wrap">
                         <code class="text-sm font-mono text-foreground">{{ project.policyTopicId ?? '—' }}</code>
                         <button
                             v-if="project.policyTopicId"
-                            class="opacity-0 group-hover:opacity-100 transition-opacity"
                             title="Copy"
                             @click="copyToClipboard(project.policyTopicId)"
                         >
@@ -101,10 +101,10 @@ async function copyToClipboard(text: string) {
                             :href="hashscanPolicyUrl"
                             target="_blank"
                             rel="noopener noreferrer"
-                            class="opacity-0 group-hover:opacity-100 transition-opacity"
-                            title="View on HashScan"
+                            class="inline-flex items-center gap-1 text-xs text-primary hover:underline"
                         >
-                            <ExternalLink class="h-3.5 w-3.5 text-primary" />
+                            <ExternalLink class="h-3 w-3" />
+                            {{ t('common.viewOnHashScan') }}
                         </a>
                     </div>
                 </div>
@@ -118,11 +118,11 @@ async function copyToClipboard(text: string) {
                 <!-- Registry DID -->
                 <div class="bg-card px-5 py-4">
                     <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">Registry DID</div>
-                    <div class="group flex items-start gap-2">
+                    <div class="flex items-start gap-2">
                         <code class="text-xs font-mono text-muted-foreground break-all flex-1">{{ project.registryDid ?? '—' }}</code>
                         <button
                             v-if="project.registryDid"
-                            class="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-0.5"
+                            class="shrink-0 mt-0.5"
                             title="Copy"
                             @click="copyToClipboard(project.registryDid)"
                         >
@@ -131,30 +131,6 @@ async function copyToClipboard(text: string) {
                         </button>
                     </div>
                 </div>
-            </div>
-
-            <!-- External links -->
-            <div class="flex flex-wrap items-center gap-4">
-                <a
-                    v-if="hashscanTopicUrl"
-                    :href="hashscanTopicUrl"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center gap-2 text-sm text-primary hover:underline font-medium"
-                >
-                    <ExternalLink class="h-4 w-4" />
-                    View Instance Topic on HashScan
-                </a>
-                <a
-                    v-if="hashscanPolicyUrl"
-                    :href="hashscanPolicyUrl"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center gap-2 text-sm text-primary hover:underline font-medium"
-                >
-                    <ExternalLink class="h-4 w-4" />
-                    View Policy Topic on HashScan
-                </a>
             </div>
         </div>
     </div>

--- a/sustainable-explorer/frontend/components/project/ProjectKeyFacts.vue
+++ b/sustainable-explorer/frontend/components/project/ProjectKeyFacts.vue
@@ -59,11 +59,11 @@ const creditingPeriodEnd = computed(() => {
                 <NuxtLink
                     v-if="project.registry && project.registryDid"
                     :to="`/registries?did=${encodeURIComponent(project.registryDid)}`"
-                    class="text-sm font-medium text-foreground hover:text-primary hover:underline transition-colors"
+                    class="text-sm font-medium text-foreground hover:text-primary hover:underline transition-colors break-all"
                 >
                     {{ project.registry }}
                 </NuxtLink>
-                <div v-else class="text-sm font-medium text-foreground">{{ project.registry || '—' }}</div>
+                <div v-else class="text-sm font-medium text-foreground break-all">{{ project.registry || '—' }}</div>
             </div>
 
             <!-- Developer -->

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -28,6 +28,7 @@
     "download": "Download",
     "close": "Close",
     "viewOnExplorer": "View on Explorer",
+    "viewOnHashScan": "View on HashScan",
     "viewRawData": "View Raw Data",
     "lines": "lines",
     "mdash": "—",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -28,6 +28,7 @@
     "download": "Descargar",
     "close": "Cerrar",
     "viewOnExplorer": "Ver en el explorador",
+    "viewOnHashScan": "Ver en HashScan",
     "viewRawData": "Ver datos brutos",
     "lines": "líneas",
     "mdash": "—",

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -260,27 +260,11 @@ const statusColor: Record<string, string> = {
                                 <span v-else class="text-xs">—</span>
                             </td>
                             <td class="py-3 px-4 text-muted-foreground text-xs break-words">{{ p.registry }}</td>
-                            <td class="py-3 px-4 overflow-hidden">
-                                <div class="group relative">
-                                    <span class="block text-xs bg-muted rounded px-1.5 py-0.5 cursor-default truncate">{{ p.methodology }}</span>
-                                    <div class="pointer-events-none absolute bottom-full left-0 mb-2 opacity-0 group-hover:opacity-100 transition-opacity z-[100] w-80">
-                                        <div class="whitespace-normal rounded-md bg-foreground px-2.5 py-1.5 text-[11px] text-background shadow-lg leading-snug">
-                                            {{ p.methodologyLong }}
-                                        </div>
-                                        <div class="ml-3 h-0 w-0 border-x-[5px] border-x-transparent border-t-[5px] border-t-foreground" />
-                                    </div>
-                                </div>
+                            <td class="py-3 px-4">
+                                <span class="block text-xs bg-muted rounded px-1.5 py-0.5 cursor-default truncate">{{ p.methodology }}</span>
                             </td>
-                            <td class="py-3 px-4 overflow-hidden">
-                                <div class="group relative">
-                                    <span class="block text-xs text-muted-foreground cursor-default truncate">{{ p.sector }}</span>
-                                    <div class="pointer-events-none absolute bottom-full left-0 mb-2 opacity-0 group-hover:opacity-100 transition-opacity z-[100] max-w-xs">
-                                        <div class="whitespace-normal rounded-md bg-foreground px-2.5 py-1.5 text-[11px] text-background shadow-lg leading-snug">
-                                            {{ $t('projects.sectoralScope', { scope: p.sectoralScope }) }}
-                                        </div>
-                                        <div class="ml-3 h-0 w-0 border-x-[5px] border-x-transparent border-t-[5px] border-t-foreground" />
-                                    </div>
-                                </div>
+                            <td class="py-3 px-4">
+                                <span class="block text-xs text-muted-foreground cursor-default truncate">{{ p.sector }}</span>
                             </td>
                             <td class="py-3 px-4 text-right tabular-nums font-medium">{{ p.issuanceCount ?? 0 }}</td>
                             <td class="py-3 px-4 text-right tabular-nums text-muted-foreground">{{ p.transferredFormatted }}</td>


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-56

 - Truncate registry field with native title tooltip in project details
 - Remove methodology/sector tooltip overlays in projects table (shadow bleed bug)
 - Add copy buttons to all IDs in Hedera On-Chain References section
 - Move HashScan links inline next to topic IDs; remove standalone external links row