### PR TITLE
fix: fix Top Registries table layout and align issuances data source

### DIFF
--- a/sustainable-explorer/frontend/composables/useDashboard.ts
+++ b/sustainable-explorer/frontend/composables/useDashboard.ts
@@ -206,15 +206,14 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
 
     // Registries derived from filtered projects
     const registries = computed(() => {
-        const orgMap: Record<string, { name: string; policies: Set<string>; projects: number; credits: number }> = {};
+        const orgMap: Record<string, { name: string; policies: Set<string>; projects: number }> = {};
 
         for (const p of filteredProjects.value) {
             if (!orgMap[p.registry]) {
-                orgMap[p.registry] = { name: p.registry, policies: new Set(), projects: 0, credits: 0 };
+                orgMap[p.registry] = { name: p.registry, policies: new Set(), projects: 0 };
             }
             orgMap[p.registry].policies.add(p.methodologyId);
             orgMap[p.registry].projects++;
-            orgMap[p.registry].credits += p.credits;
         }
 
         return Object.entries(orgMap)
@@ -222,7 +221,7 @@ export function useDashboard(filters?: Ref<{ developer?: string; registry?: stri
                 name: key,
                 policies: data.policies.size,
                 projects: data.projects,
-                credits: formatCredits(data.credits),
+                credits: formatCredits(mintedByRegistry.value.get(key) ?? 0),
             }))
             .sort((a, b) => b.projects - a.projects);
     });

--- a/sustainable-explorer/frontend/pages/index.vue
+++ b/sustainable-explorer/frontend/pages/index.vue
@@ -691,13 +691,13 @@ const filteredStats = computed(() => {
                     <div class="px-6 pb-6">
                         <div class="rounded-xl border bg-card overflow-hidden">
                             <div class="overflow-x-auto">
-                            <table class="w-full text-sm min-w-[420px]">
+                            <table class="w-full text-sm table-fixed min-w-[420px]">
                                 <thead>
                                     <tr class="border-b bg-muted/30">
                                         <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider whitespace-nowrap">{{ $t('dashboard.name') }}</th>
-                                        <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider whitespace-nowrap">{{ $t('dashboard.policies') }}</th>
-                                        <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider whitespace-nowrap">{{ $t('dashboard.projectsCol') }}</th>
-                                        <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider whitespace-nowrap">{{ $t('dashboard.issuancesCol') }}</th>
+                                        <th class="w-20 text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider whitespace-nowrap">{{ $t('dashboard.policies') }}</th>
+                                        <th class="w-20 text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider whitespace-nowrap">{{ $t('dashboard.projectsCol') }}</th>
+                                        <th class="w-28 text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider whitespace-nowrap">{{ $t('dashboard.issuancesCol') }}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="divide-y">
@@ -713,7 +713,7 @@ const filteredStats = computed(() => {
                                             @click="navigate()"
                                         >
                                             <td class="py-2.5 px-4">
-                                                <span class="font-medium text-foreground">{{ org.name }}</span>
+                                                <span class="font-medium text-foreground break-all">{{ org.name }}</span>
                                             </td>
                                             <td class="py-2.5 px-4 text-right tabular-nums">
                                                 <NuxtLink


### PR DESCRIPTION
### Fix Top Registries table layout and align issuances data source - https://xeptagon.atlassian.net/browse/SE-77

  - Use table-fixed layout with fixed column widths (w-20/w-28) so numeric
    columns are always visible without horizontal scrolling
  - Add break-all to registry name cells to wrap long strings like DID identifiers
  - Source issuances from mintedByRegistry (mint-stats API), matching the By Registry donut chart
    
    
<img width="777" height="707" alt="image" src="https://github.com/user-attachments/assets/f6f31e27-2fc8-4739-b5cd-bf962742c6f9" />
