### PR TITLE
fix: source issuance supply from MintToken VCs and clean up UI label/presets

### DIFF
--- a/sustainable-explorer/frontend/components/project/IssuancesTable.vue
+++ b/sustainable-explorer/frontend/components/project/IssuancesTable.vue
@@ -45,7 +45,7 @@ const linkedCredits = computed<Credit[]>(() => {
                         <th class="text-left py-2.5 px-5 text-xs font-medium text-muted-foreground uppercase tracking-wider">Token</th>
                         <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Token ID</th>
                         <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Type</th>
-                        <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Supply</th>
+                        <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('credits.columns.supply') }}</th>
                         <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Mint Date</th>
                         <th class="text-center py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">
                             <span class="inline-flex items-center gap-1">Raw Data <InfoTooltip text="Raw VC document on the blockchain" /></span>

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -241,12 +241,9 @@
             "sdgs": "SDGs"
         },
         "presets": {
-            "issuingForestry": "Issuing Forestry",
             "goldStandard": "Gold Standard",
             "sdg13": "SDG 13: Climate Action",
-            "underValidation": "Under Validation",
-            "vintage2024": "Vintage 2024",
-            "blueCarbon": "Blue Carbon"
+            "vintage2024": "Vintage 2024"
         },
         "notFound": "Project not found",
         "details": {
@@ -319,9 +316,7 @@
             "fungible": "Fungible tokens",
             "nonFungible": "Non-Fungible (NFTs)",
             "minted2024": "Minted 2024",
-            "minted2025": "Minted 2025",
-            "blueCarbon": "Blue Carbon",
-            "forestry": "Forestry"
+            "minted2025": "Minted 2025"
         },
         "issuancesFound": "{count} issuances found",
         "totalSupply": "Total supply:",
@@ -341,7 +336,7 @@
             "token": "Token",
             "symbol": "Symbol",
             "type": "Type",
-            "supply": "Supply",
+            "supply": "Mint Amount",
             "mintDate": "Mint Date",
             "project": "Project",
             "methodology": "Methodology",
@@ -351,7 +346,7 @@
         "filters": {
             "tokenType": "Token Type",
             "registry": "Registry",
-            "supply": "Supply",
+            "supply": "Mint Amount",
             "mintDate": "Mint Date",
             "hideUnlinked": "Hide issuances with no project link"
         },

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -241,12 +241,9 @@
             "sdgs": "ODS"
         },
         "presets": {
-            "issuingForestry": "Forestal en emisión",
             "goldStandard": "Gold Standard",
             "sdg13": "ODS 13: Acción por el clima",
-            "underValidation": "En validación",
-            "vintage2024": "Añada 2024",
-            "blueCarbon": "Carbono azul"
+            "vintage2024": "Añada 2024"
         },
         "notFound": "Proyecto no encontrado",
         "details": {
@@ -314,9 +311,7 @@
             "fungible": "Tokens fungibles",
             "nonFungible": "No fungibles (NFTs)",
             "minted2024": "Acuñados en 2024",
-            "minted2025": "Acuñados en 2025",
-            "blueCarbon": "Carbono azul",
-            "forestry": "Silvicultura"
+            "minted2025": "Acuñados en 2025"
         },
         "issuancesFound": "{count} emisiones encontradas",
         "totalSupply": "Suministro total:",
@@ -336,7 +331,7 @@
             "token": "Token",
             "symbol": "Símbolo",
             "type": "Tipo",
-            "supply": "Suministro",
+            "supply": "Monto acuñado",
             "mintDate": "Fecha de emisión",
             "project": "Proyecto",
             "methodology": "Metodología",
@@ -346,7 +341,7 @@
         "filters": {
             "tokenType": "Tipo de token",
             "registry": "Registro",
-            "supply": "Suministro",
+            "supply": "Monto acuñado",
             "mintDate": "Fecha de emisión",
             "hideUnlinked": "Ocultar emisiones sin proyecto vinculado"
         },

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -80,8 +80,6 @@ const presets = computed(() => [
     { label: t('credits.presets.nonFungible'), filters: { type: 'Non-Fungible' } },
     { label: t('credits.presets.minted2024'), filters: { mintDate: '2024-01-01|2024-12-31' } },
     { label: t('credits.presets.minted2025'), filters: { mintDate: '2025-01-01|2025-12-31' } },
-    { label: t('credits.presets.blueCarbon'), search: 'Blue Carbon' },
-    { label: t('credits.presets.forestry'), search: 'Forestry' },
 ]);
 
 const skeletonRows = computed(() => Array.from({ length: pageSize.value }, (_, i) => i));

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -1753,7 +1753,7 @@ const lifecycleSummary = computed(() => {
                   <th class="text-left py-2.5 px-5 text-xs font-medium text-muted-foreground uppercase tracking-wider">Token</th>
                   <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Token ID</th>
                   <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Type</th>
-                  <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Supply</th>
+                  <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('credits.columns.supply') }}</th>
                   <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Mint Date</th>
                   <th class="text-center py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Raw Data</th>
                 </tr>

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -67,12 +67,9 @@ const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, act
     });
 
 const presets = computed(() => [
-    { label: t('projects.presets.issuingForestry'), filters: { status: 'Issuing', sector: 'Forestry and Land Use' } },
     { label: t('projects.presets.goldStandard'), filters: { registry: 'Gold Standard' } },
     { label: t('projects.presets.sdg13'), filters: { sdgs: '13' } },
-    { label: t('projects.presets.underValidation'), filters: { status: 'Under Validation' } },
     { label: t('projects.presets.vintage2024'), filters: { vintage: '2024|2024' } },
-    { label: t('projects.presets.blueCarbon'), search: 'Blue Carbon' },
 ]);
 
 // Summary statistics for filtered results

--- a/sustainable-explorer/src/api/repositories/pg-credit.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-credit.repository.ts
@@ -9,66 +9,57 @@ interface RawRow {
     symbol: string | null;
     /** Raw type from token_cache: 'FUNGIBLE_COMMON' | 'NON_FUNGIBLE_UNIQUE' | null */
     raw_type: string | null;
-    /** Fallback token type from businessData->options->tokenType */
+    /** Fallback token type from businessData->options->tokenType (findRaw only) */
     options_token_type: string | null;
     total_supply: string | null;
     registryDid: string | null;
     registry_name: string | null;
     mint_date: Date | null;
-    businessData: Record<string, any> | null;
     project_id: string | null;
     project_name: string | null;
     methodology_id: string | null;
     methodology_name: string | null;
 }
 
+// credentialSubject[0] tokenId path — used in SELECT, WHERE, GROUP BY, and ORDER BY
+const TOKEN_ID_EXPR = `(m.documents->'credentialSubject'->0->>'tokenId')`;
+
 /**
- * LATERAL subquery joined into findAll to look up the publishing registry's
- * display name. Uses LATERAL so we can ORDER BY + LIMIT 1 to handle the (rare)
- * case of multiple REGISTRY rows for one DID.
+ * Base FROM clause: every MintToken VC in the message table, LEFT JOINed with
+ * project_mint_link (pre-computed per-project attribution) and token_cache.
+ * Rows where pml.* is NULL are unattributed mints — still included so the
+ * table is complete regardless of worker attribution state.
  */
-const REGISTRY_NAME_JOIN = `
-    LEFT JOIN LATERAL (
-        SELECT "displayName" AS registry_name
-        FROM business_view
-        WHERE "viewType" = 'REGISTRY'
-          AND "registryDid" = bv."registryDid"
-        ORDER BY "createdAt" DESC NULLS LAST
-        LIMIT 1
-    ) reg ON true
+const MINT_FROM = `
+    message m
+    LEFT JOIN project_mint_link pml
+           ON pml.mint_consensus_timestamp = m."consensusTimestamp"
+    LEFT JOIN token_cache tc
+           ON tc."tokenId" = ${TOKEN_ID_EXPR}
 `;
 
 /**
- * Resolves the linked project for a credit via project_mint_link — the same
- * table used by the project detail page, ensuring consistent attribution.
+ * LATERAL: resolve project metadata from the pre-attributed project_mint_link
+ * row. Returns NULL for all fields when pml.project_key is NULL.
  */
-const PROJECT_LINK_JOIN = `
+const PROJECT_JOIN = `
     LEFT JOIN LATERAL (
         SELECT
-            bv_proj."projectKey"                    AS project_id,
-            bv_proj."displayName"                   AS project_name,
-            bv_proj."relatedTopicId"                AS proj_topic_id,
-            bv_proj."businessData"->>'methodology'  AS proj_methodology_name
-        FROM project_mint_link pml
-        JOIN business_view bv_proj
-            ON bv_proj."viewType" = 'PROJECT'
-           AND bv_proj."projectKey" = pml.project_key
-        WHERE pml.token_id = COALESCE(bv."businessData"->>'tokenId', tc."tokenId")
-        ORDER BY pml.mint_date DESC NULLS LAST
+            bv_proj."projectKey"                   AS project_id,
+            bv_proj."displayName"                  AS project_name,
+            bv_proj."relatedTopicId"               AS proj_topic_id,
+            bv_proj."businessData"->>'methodology' AS proj_methodology_name,
+            bv_proj."registryDid"                  AS registry_did
+        FROM business_view bv_proj
+        WHERE bv_proj."viewType"   = 'PROJECT'
+          AND bv_proj."projectKey" = pml.project_key
         LIMIT 1
     ) proj ON true
 `;
 
 /**
- * Resolves the linked methodology independently of the project link.
- *
- * Primary path:   project's relatedTopicId (= instanceTopicId) when a project
- *                 was resolved — most accurate since it comes from the known chain.
- * Fallback path:  credit's own relatedTopicId (= the topic where the Token
- *                 message was posted, which is the instance topic in Guardian).
- *
- * Uses idx_business_view_methodology_topic for an O(log n) lookup.
- * Shows a methodology even when no project could be resolved.
+ * LATERAL: resolve methodology from the project's instance topic.
+ * Returns NULL when no project was resolved (unattributed mints).
  */
 const METHODOLOGY_JOIN = `
     LEFT JOIN LATERAL (
@@ -76,21 +67,57 @@ const METHODOLOGY_JOIN = `
             bv_meth."sourceTimestamp" AS methodology_id,
             bv_meth."displayName"     AS methodology_name
         FROM business_view bv_meth
-        WHERE bv_meth."viewType" = 'METHODOLOGY'
-          AND bv_meth."relatedTopicId" = COALESCE(proj.proj_topic_id, bv."relatedTopicId")
+        WHERE bv_meth."viewType"       = 'METHODOLOGY'
+          AND bv_meth."relatedTopicId" = proj.proj_topic_id
         ORDER BY bv_meth."createdAt" DESC NULLS LAST
         LIMIT 1
     ) meth ON true
 `;
 
 /**
+ * LATERAL: resolve registry display name from the project's registryDid.
+ * Returns NULL when no project was resolved (unattributed mints).
+ */
+const REGISTRY_JOIN = `
+    LEFT JOIN LATERAL (
+        SELECT bv_reg."displayName" AS registry_name
+        FROM business_view bv_reg
+        WHERE bv_reg."viewType"    = 'REGISTRY'
+          AND bv_reg."registryDid" = proj.registry_did
+        ORDER BY bv_reg."createdAt" DESC NULLS LAST
+        LIMIT 1
+    ) reg ON true
+`;
+
+/**
+ * GROUP BY: one output row per (tokenId, project_key) pair.
+ * Metadata columns (tc.*, proj.*, meth.*, reg.*) are functionally determined
+ * by these two keys but must be listed explicitly for PostgreSQL.
+ */
+const GROUP_BY = `
+    GROUP BY
+        ${TOKEN_ID_EXPR},
+        pml.project_key,
+        tc.name, tc.symbol, tc.type,
+        proj.project_id, proj.project_name, proj.proj_topic_id,
+        proj.proj_methodology_name, proj.registry_did,
+        meth.methodology_id, meth.methodology_name,
+        reg.registry_name
+`;
+
+/**
  * PostgreSQL implementation of the CreditRepository.
  *
- * Generic filter and sort logic is delegated to QueryBuilder + the field
- * schema (CREDIT_FIELD_SCHEMA). Adding a new filterable/sortable column only
- * requires updating the schema — no SQL changes needed here.
+ * findAll() is sourced from MintToken VC documents (message table) joined with
+ * project_mint_link for per-project attribution. Supply figures are
+ * SUM(credentialSubject[0].amount) — the actual minted amounts — consistent
+ * with what the project and methodology detail pages show.
  *
- * Special operations (full-text + fuzzy search) remain explicit.
+ * Unattributed mints (not yet resolved by the worker) are included as rows
+ * with null project / methodology / registry fields.
+ *
+ * findRaw() is unchanged — it reads business_view CREDIT rows for the header
+ * and the message table for the raw mint events.
  */
 export class PgCreditRepository extends CreditRepository {
     constructor(private readonly dataSource: DataSource) {
@@ -102,152 +129,123 @@ export class PgCreditRepository extends CreditRepository {
         const offset = (page - 1) * limit;
 
         const builder = new QueryBuilder(CREDIT_FIELD_SCHEMA);
-        // viewType = 'CREDIT' is enforced inside CREDIT_BASE (the deduplicating
-        // subquery), so it must not be repeated in the outer WHERE clause.
 
-        // Generic filters
+        // Base: only MintToken VC documents with a resolvable tokenId
+        builder.addClause(`m.type = 'VC-Document'`);
+        builder.addClause(`m.documents IS NOT NULL`);
+        builder.addClause(`(m.documents->'credentialSubject'->0->>'type') LIKE 'MintToken%'`);
+        builder.addClause(`${TOKEN_ID_EXPR} IS NOT NULL`);
+
+        // Generic schema-driven filters
         builder.addFilters({
             registryDid: query.registryDid,
-            registry: query.registry,
-            tokenId: query.tokenId,
+            registry:    query.registry,
+            tokenId:     query.tokenId,
         });
 
-        // projectKey filter: restricts to credits that have ANY mint attributed to
-        // the requested project. Uses an EXISTS subquery against project_mint_link
-        // directly so it is self-contained and does not depend on which project
-        // "wins" in the LATERAL display join (which picks the most-recent mint).
+        // projectKey: restrict to mints attributed to this specific project
         if (query.projectKey) {
             const param = builder.nextParam(query.projectKey);
-            builder.addClause(`EXISTS (
-                SELECT 1 FROM project_mint_link pml_f
-                WHERE pml_f.token_id = bv."businessData"->>'tokenId'
-                  AND pml_f.project_key = ${param}
-            )`);
+            builder.addClause(`pml.project_key = ${param}`);
         }
 
-        // methodologyId filter: restricts to credits whose resolved methodology matches
-        // the given sourceTimestamp. Checks both the credit's own relatedTopicId and
-        // the relatedTopicId of any project linked via project_mint_link.
+        // methodologyId: restrict to mints whose resolved methodology matches
         if (query.methodologyId) {
             const param = builder.nextParam(query.methodologyId);
-            builder.addClause(`EXISTS (
-                SELECT 1 FROM business_view bv_meth_f
-                WHERE bv_meth_f."viewType" = 'METHODOLOGY'
-                  AND bv_meth_f."sourceTimestamp" = ${param}
-                  AND (
-                      bv_meth_f."relatedTopicId" IN (
-                          SELECT bv_proj."relatedTopicId"
-                          FROM project_mint_link pml
-                          JOIN business_view bv_proj
-                              ON bv_proj."projectKey" = pml.project_key
-                             AND bv_proj."viewType" = 'PROJECT'
-                          WHERE pml.token_id = bv."businessData"->>'tokenId'
-                      )
-                      OR bv_meth_f."relatedTopicId" = bv."relatedTopicId"
-                  )
-            )`);
+            builder.addClause(`meth.methodology_id = ${param}`);
         }
 
-        // type filter: accept display form ('Fungible'/'Non-Fungible') and map to
-        // token_cache raw values before filtering.
+        // type: map display form to token_cache raw values
         if (query.type) {
             const normalised = query.type.toLowerCase();
             if (normalised === 'fungible') {
-                builder.addClause(`(
-                    tc.type = 'FUNGIBLE_COMMON'
-                    OR (tc.type IS NULL AND LOWER(bv."businessData"->'options'->>'tokenType') = 'fungible')
-                )`);
+                builder.addClause(`tc.type = 'FUNGIBLE_COMMON'`);
             } else if (normalised === 'non-fungible') {
-                builder.addClause(`(
-                    tc.type = 'NON_FUNGIBLE_UNIQUE'
-                    OR (tc.type IS NULL AND LOWER(bv."businessData"->'options'->>'tokenType') = 'non-fungible')
-                )`);
+                builder.addClause(`tc.type = 'NON_FUNGIBLE_UNIQUE'`);
             }
         }
 
-        // Full-text + fuzzy search across name, symbol, tokenId, registry name
+        // Full-text + fuzzy search across token name, symbol, id, and registry
         let rankExpr = '0';
         if (search) {
             const term = search.trim();
-            const tsParam = builder.nextParam(term);
             const likeParam = builder.nextParam(`%${term}%`);
-            const simParam = builder.nextParam(term);
+            const simParam  = builder.nextParam(term);
 
             builder.addClause(`(
-                bv."searchVector" @@ plainto_tsquery('english', ${tsParam})
-                OR COALESCE(tc.name, bv."displayName") ILIKE ${likeParam}
+                tc.name ILIKE ${likeParam}
                 OR tc.symbol ILIKE ${likeParam}
-                OR COALESCE(tc."tokenId", bv."businessData"->>'tokenId') ILIKE ${likeParam}
+                OR ${TOKEN_ID_EXPR} ILIKE ${likeParam}
                 OR reg.registry_name ILIKE ${likeParam}
-                OR similarity(COALESCE(COALESCE(tc.name, bv."displayName"), ''), ${simParam}) > 0.3
+                OR similarity(COALESCE(tc.name, ''), ${simParam}) > 0.3
             )`);
 
-            rankExpr = `
-                ts_rank(bv."searchVector", plainto_tsquery('english', ${tsParam}))
-                + COALESCE(similarity(COALESCE(tc.name, bv."displayName"), ${simParam}), 0)
-            `;
+            rankExpr = `COALESCE(similarity(COALESCE(tc.name, ''), ${simParam}), 0)`;
         }
 
         const orderBy = search
-            ? `search_rank DESC, bv."createdAt" DESC`
+            ? `search_rank DESC, mint_date DESC NULLS LAST`
             : builder.buildOrderBy({
                 sortBy,
                 sortDir,
-                defaultExpr: 'bv."createdAt" DESC NULLS LAST',
+                defaultExpr: 'mint_date DESC NULLS LAST',
             });
 
         const whereSql = builder.getWhereClause();
-        const params = builder.getParams();
+        const params   = builder.getParams();
 
-        const limitParam = builder.nextParam(limit);
+        const limitParam  = builder.nextParam(limit);
         const offsetParam = builder.nextParam(offset);
 
-        // One CREDIT row per token (latest mint). business_view can have multiple
-        // CREDIT rows for the same token (one per mint event); DISTINCT ON collapses
-        // them so the issuance count matches COUNT(DISTINCT token_id) on the project.
-        const CREDIT_BASE = `(
-            SELECT DISTINCT ON ("businessData"->>'tokenId') *
-            FROM business_view
-            WHERE "viewType" = 'CREDIT'
-            ORDER BY "businessData"->>'tokenId', "sourceTimestamp" DESC NULLS LAST
-        ) bv`;
-
+        // Supply = SUM of credentialSubject[0].amount from MintToken VCs.
+        // For attributed mints pml.amount is the pre-parsed BIGINT; for
+        // unattributed mints it falls back to the raw JSONB string cast.
         const rowsSql = `
             SELECT
-                COALESCE(tc."tokenId", bv."businessData"->>'tokenId')               AS "tokenId",
-                COALESCE(tc.name,      bv."displayName")                             AS name,
-                COALESCE(tc.symbol,    bv."businessData"->>'symbol')                 AS symbol,
-                tc.type                                                               AS raw_type,
-                bv."businessData"->'options'->>'tokenType'                           AS options_token_type,
-                tc."totalSupply"                                                      AS total_supply,
-                bv."registryDid"                                                      AS "registryDid",
+                ${TOKEN_ID_EXPR}                                                                AS "tokenId",
+                tc.name,
+                tc.symbol,
+                tc.type                                                                         AS raw_type,
+                NULL::text                                                                      AS options_token_type,
+                COALESCE(SUM(COALESCE(pml.amount::numeric,
+                    (m.documents->'credentialSubject'->0->>'amount')::numeric
+                )), 0)                                                                          AS total_supply,
+                proj.registry_did                                                               AS "registryDid",
                 reg.registry_name,
-                to_timestamp(bv."sourceTimestamp"::numeric)::timestamptz             AS mint_date,
-                bv."businessData"                                                     AS "businessData",
-                proj.project_id                                                       AS project_id,
-                proj.project_name                                                     AS project_name,
-                meth.methodology_id                                                   AS methodology_id,
-                COALESCE(meth.methodology_name, proj.proj_methodology_name)          AS methodology_name,
-                ${rankExpr}                                                           AS search_rank
-            FROM ${CREDIT_BASE}
-            LEFT JOIN token_cache tc
-                ON tc."tokenId" = bv."businessData"->>'tokenId'
-            ${REGISTRY_NAME_JOIN}
-            ${PROJECT_LINK_JOIN}
+                MIN(COALESCE(pml.mint_date,
+                    to_timestamp(m."consensusTimestamp"::numeric)
+                ))                                                                              AS mint_date,
+                proj.project_id,
+                proj.project_name,
+                meth.methodology_id,
+                COALESCE(meth.methodology_name, proj.proj_methodology_name)                    AS methodology_name,
+                ${rankExpr}                                                                     AS search_rank
+            FROM ${MINT_FROM}
+            ${PROJECT_JOIN}
             ${METHODOLOGY_JOIN}
+            ${REGISTRY_JOIN}
             WHERE ${whereSql}
+            ${GROUP_BY}
             ORDER BY ${orderBy}
             LIMIT ${limitParam} OFFSET ${offsetParam}
         `;
 
+        // Count: number of distinct (tokenId, project_key) groups after filtering.
+        // Uses a simplified GROUP BY — metadata columns are omitted because they
+        // are functionally determined by (tokenId, project_key) and don't affect
+        // the group count.
         const countParams = params.slice(0, params.length - 2);
         const countSql = `
             SELECT COUNT(*)::int AS total
-            FROM ${CREDIT_BASE}
-            LEFT JOIN token_cache tc
-                ON tc."tokenId" = bv."businessData"->>'tokenId'
-            ${REGISTRY_NAME_JOIN}
-            WHERE ${whereSql}
+            FROM (
+                SELECT 1
+                FROM ${MINT_FROM}
+                ${PROJECT_JOIN}
+                ${METHODOLOGY_JOIN}
+                ${REGISTRY_JOIN}
+                WHERE ${whereSql}
+                GROUP BY ${TOKEN_ID_EXPR}, pml.project_key
+            ) cnt
         `;
 
         const [rawRows, countResult]: [RawRow[], Array<{ total: number }>] = await Promise.all([

--- a/sustainable-explorer/src/api/repositories/schemas/credit.schema.ts
+++ b/sustainable-explorer/src/api/repositories/schemas/credit.schema.ts
@@ -1,26 +1,33 @@
 import { FieldSchema } from '../query-builder';
 
 /**
- * Field schema for the Credits endpoint.
+ * Field schema for the Credits/Issuances endpoint.
  *
- * Adding a new filter only requires adding an entry here. The
- * PgCreditRepository's QueryBuilder will pick it up automatically.
+ * Column aliases match the SELECT output of pg-credit.repository.ts findAll(),
+ * which is sourced from MintToken VCs (message table) grouped by
+ * (tokenId, project_key).
  *
- * Notes:
- *   - `bv` is the alias used for `business_view` in the repository's queries.
- *   - `tc` is the alias used for `token_cache` (LEFT JOIN on tokenId).
- *   - `reg.registry_name` comes from a LATERAL join that resolves the
- *     publishing registry's display name.
+ * Table aliases in use:
+ *   m    — message (MintToken VC rows)
+ *   pml  — project_mint_link (pre-computed per-project attribution)
+ *   tc   — token_cache (Mirror Node token metadata)
+ *   proj — LATERAL: resolved project from business_view PROJECT
+ *   meth — LATERAL: resolved methodology from business_view METHODOLOGY
+ *   reg  — LATERAL: resolved registry from business_view REGISTRY
+ *
+ * Aggregate fields (supply, mintDate) use SELECT output aliases so ORDER BY
+ * can reference them by name in a grouped query. They carry no filter operator
+ * since aggregate expressions cannot appear in a WHERE clause.
  */
 export const CREDIT_FIELD_SCHEMA: FieldSchema = {
-    // ── token_cache columns ─────────────────────────────────────────────
+    // ── Token identity ──────────────────────────────────────────────────
     tokenId: {
-        sql: 'tc."tokenId"',
+        sql: `(m.documents->'credentialSubject'->0->>'tokenId')`,
         filter: 'eq',
         sortable: true,
     },
     name: {
-        sql: 'COALESCE(tc.name, bv."displayName")',
+        sql: 'tc.name',
         filter: 'ilike',
         sortable: true,
     },
@@ -31,39 +38,28 @@ export const CREDIT_FIELD_SCHEMA: FieldSchema = {
     },
     type: {
         sql: 'tc.type',
-        filter: 'ilike',
-        sortable: true,
-    },
-    supply: {
-        sql: 'COALESCE(tc."totalSupply", 0)',
         sortable: true,
     },
 
-    // ── Lateral registry join ───────────────────────────────────────────
+    // ── Aggregates (SELECT aliases — sortable only) ─────────────────────
+    supply: {
+        sql: 'total_supply',
+        sortable: true,
+    },
+    mintDate: {
+        sql: 'mint_date',
+        sortable: true,
+    },
+
+    // ── Attribution ─────────────────────────────────────────────────────
     registry: {
         sql: 'reg.registry_name',
         filter: 'ilike',
         sortable: true,
     },
     registryDid: {
-        sql: 'bv."registryDid"',
+        sql: 'proj.registry_did',
         filter: 'eq',
-        sortable: true,
-    },
-
-    // ── Computed date from consensus timestamp ──────────────────────────
-    mintDate: {
-        sql: 'to_timestamp(bv."sourceTimestamp"::numeric)',
-        sortable: true,
-    },
-
-    // ── Audit columns ───────────────────────────────────────────────────
-    createdAt: {
-        sql: 'bv."createdAt"',
-        sortable: true,
-    },
-    updatedAt: {
-        sql: 'bv."updatedAt"',
         sortable: true,
     },
 };


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-84

Backend 

-   Issuance table query was rewritten to source directly from MintToken VC documents (message table + project_mint_link) instead of business_view CREDIT rows.
- Supply is now SUM(credentialSubject[0].amount) from MintToken VCs (actual minted amounts), instead of tc."totalSupply" from Mirror Node — making the credits list consistent with what the project and methodology detail pages show

Frontend 
- "Supply" → "Mint Amount"
- credits/index.vue — removed "Blue Carbon", "Forestry" (Quick filter presets)