### PR TITLE
fix: expand country code mappings to fix missing flags for all supported countries

### DIFF
--- a/sustainable-explorer/frontend/components/shared/CountryFlag.vue
+++ b/sustainable-explorer/frontend/components/shared/CountryFlag.vue
@@ -14,17 +14,73 @@ const cls = sizeClass[props.size || 'md'];
 
 // Convert 3-letter (ISO 3166-1 alpha-3) to 2-letter (alpha-2) for the CDN
 const alpha3to2: Record<string, string> = {
-    KEN: 'ke', BRA: 'br', RWA: 'rw', IDN: 'id', IND: 'in', COL: 'co',
-    MOZ: 'mz', UGA: 'ug', NPL: 'np', VNM: 'vn', MEX: 'mx', GHA: 'gh',
-    ETH: 'et', COD: 'cd', KHM: 'kh', MWI: 'mw', ISL: 'is', ISR: 'il',
-    PER: 'pe',
-    BGD: 'bd', CHE: 'ch', GBR: 'gb', USA: 'us', FRA: 'fr', DEU: 'de',
-    AUS: 'au', CAN: 'ca', ZAF: 'za', NGA: 'ng', TZA: 'tz', MMR: 'mm',
-    THA: 'th', PHL: 'ph', LKA: 'lk', PAK: 'pk', AFG: 'af', ARG: 'ar',
-    CHL: 'cl', ECU: 'ec', BOL: 'bo', PRY: 'py', URY: 'uy', VEN: 've',
-    CRI: 'cr', PAN: 'pa', GTM: 'gt', HND: 'hn', SLV: 'sv', NIC: 'ni',
-    DOM: 'do', HTI: 'ht', CUB: 'cu', JAM: 'jm', TTO: 'tt', BLZ: 'bz',
-    CHN: 'cn', JPN: 'jp', KOR: 'kr', TWN: 'tw', MYS: 'my', SGP: 'sg',
+    // A
+    AFG: 'af', ALB: 'al', DZA: 'dz', AND: 'ad', AGO: 'ao', ATG: 'ag',
+    ARG: 'ar', ARM: 'am', AUS: 'au', AUT: 'at', AZE: 'az',
+    // B
+    BHS: 'bs', BHR: 'bh', BGD: 'bd', BRB: 'bb', BLR: 'by', BEL: 'be',
+    BLZ: 'bz', BEN: 'bj', BTN: 'bt', BOL: 'bo', BIH: 'ba', BWA: 'bw',
+    BRA: 'br', BRN: 'bn', BGR: 'bg', BFA: 'bf', BDI: 'bi',
+    // C
+    CPV: 'cv', KHM: 'kh', CMR: 'cm', CAN: 'ca', CAF: 'cf', TCD: 'td',
+    CHL: 'cl', CHN: 'cn', COL: 'co', COM: 'km', COG: 'cg', CIV: 'ci',
+    HRV: 'hr', CUB: 'cu', CYP: 'cy', CZE: 'cz',
+    // D
+    DNK: 'dk', DJI: 'dj', DMA: 'dm', DOM: 'do', COD: 'cd',
+    // E
+    ECU: 'ec', EGY: 'eg', SLV: 'sv', GNQ: 'gq', ERI: 'er', EST: 'ee',
+    SWZ: 'sz', ETH: 'et',
+    // F
+    FJI: 'fj', FIN: 'fi', FRA: 'fr',
+    // G
+    GAB: 'ga', GMB: 'gm', GEO: 'ge', DEU: 'de', GHA: 'gh', GRC: 'gr',
+    GRD: 'gd', GTM: 'gt', GIN: 'gn', GNB: 'gw', GUY: 'gy',
+    // H
+    HTI: 'ht', HND: 'hn', HUN: 'hu',
+    // I
+    ISL: 'is', IND: 'in', IDN: 'id', IRN: 'ir', IRQ: 'iq', IRL: 'ie',
+    ISR: 'il', ITA: 'it',
+    // J
+    JAM: 'jm', JPN: 'jp', JOR: 'jo',
+    // K
+    KAZ: 'kz', KEN: 'ke', KIR: 'ki', KWT: 'kw', KGZ: 'kg',
+    // L
+    LAO: 'la', LVA: 'lv', LBN: 'lb', LSO: 'ls', LBR: 'lr', LBY: 'ly',
+    LIE: 'li', LTU: 'lt', LUX: 'lu',
+    // M
+    MDG: 'mg', MWI: 'mw', MYS: 'my', MDV: 'mv', MLI: 'ml', MLT: 'mt',
+    MHL: 'mh', MRT: 'mr', MUS: 'mu', MEX: 'mx', FSM: 'fm', MDA: 'md',
+    MCO: 'mc', MNG: 'mn', MNE: 'me', MAR: 'ma', MOZ: 'mz', MMR: 'mm',
+    // N
+    NAM: 'na', NRU: 'nr', NPL: 'np', NLD: 'nl', NZL: 'nz', NIC: 'ni',
+    NER: 'ne', NGA: 'ng', PRK: 'kp', MKD: 'mk', NOR: 'no',
+    // O
+    OMN: 'om',
+    // P
+    PAK: 'pk', PLW: 'pw', PSE: 'ps', PAN: 'pa', PNG: 'pg', PRY: 'py',
+    PER: 'pe', PHL: 'ph', POL: 'pl', PRT: 'pt',
+    // Q
+    QAT: 'qa',
+    // R
+    ROU: 'ro', RUS: 'ru', RWA: 'rw',
+    // S
+    KNA: 'kn', LCA: 'lc', VCT: 'vc', WSM: 'ws', SMR: 'sm', STP: 'st',
+    SAU: 'sa', SEN: 'sn', SRB: 'rs', SYC: 'sc', SLE: 'sl', SGP: 'sg',
+    SVK: 'sk', SVN: 'si', SLB: 'sb', SOM: 'so', ZAF: 'za', KOR: 'kr',
+    SSD: 'ss', ESP: 'es', LKA: 'lk', SDN: 'sd', SUR: 'sr', SWE: 'se',
+    CHE: 'ch', SYR: 'sy',
+    // T
+    TWN: 'tw', TJK: 'tj', TZA: 'tz', THA: 'th', TLS: 'tl', TGO: 'tg',
+    TON: 'to', TTO: 'tt', TUN: 'tn', TUR: 'tr', TKM: 'tm', TUV: 'tv',
+    // U
+    UGA: 'ug', UKR: 'ua', ARE: 'ae', GBR: 'gb', USA: 'us', URY: 'uy',
+    UZB: 'uz',
+    // V
+    VUT: 'vu', VAT: 'va', VEN: 've', VNM: 'vn',
+    // Y
+    YEM: 'ye',
+    // Z
+    ZMB: 'zm', ZWE: 'zw',
 };
 
 // 'UNK' indicates an unknown / unrecognized country. Without this guard the

--- a/sustainable-explorer/frontend/composables/useProjects.ts
+++ b/sustainable-explorer/frontend/composables/useProjects.ts
@@ -2,23 +2,97 @@ import type { Project, ProjectIssuance, LinkedSchema, LinkedVc } from '~/types/m
 
 // country display name → ISO 3166-1 alpha-3 for CountryFlag component
 export const COUNTRY_ALPHA3: Record<string, string> = {
-    'Afghanistan': 'AFG', 'Albania': 'ALB', 'Algeria': 'DZA', 'Angola': 'AGO',
-    'Argentina': 'ARG', 'Australia': 'AUS', 'Austria': 'AUT', 'Bangladesh': 'BGD',
-    'Bolivia': 'BOL', 'Brazil': 'BRA', 'Cambodia': 'KHM', 'Canada': 'CAN',
-    'Chile': 'CHL', 'China': 'CHN', 'Colombia': 'COL', 'Congo': 'COD',
-    'Costa Rica': 'CRI', 'Cuba': 'CUB', 'DR Congo': 'COD', 'Ecuador': 'ECU',
-    'El Salvador': 'SLV', 'Ethiopia': 'ETH', 'France': 'FRA', 'Germany': 'DEU',
-    'Ghana': 'GHA', 'Guatemala': 'GTM', 'Haiti': 'HTI', 'Honduras': 'HND',
-    'Iceland': 'ISL', 'India': 'IND', 'Indonesia': 'IDN', 'Israel': 'ISR', 'Jamaica': 'JAM',
-    'Japan': 'JPN', 'Kenya': 'KEN', 'Malawi': 'MWI', 'Malaysia': 'MYS',
-    'Mexico': 'MEX', 'Mozambique': 'MOZ', 'Myanmar': 'MMR', 'Nepal': 'NPL',
-    'Nicaragua': 'NIC', 'Nigeria': 'NGA', 'Pakistan': 'PAK', 'Panama': 'PAN',
-    'Paraguay': 'PRY', 'Peru': 'PER', 'Philippines': 'PHL', 'Rwanda': 'RWA',
-    'Singapore': 'SGP', 'South Africa': 'ZAF', 'South Korea': 'KOR',
-    'Sri Lanka': 'LKA', 'Switzerland': 'CHE', 'Taiwan': 'TWN', 'Tanzania': 'TZA',
-    'Thailand': 'THA', 'Trinidad and Tobago': 'TTO', 'Uganda': 'UGA',
-    'United Kingdom': 'GBR', 'United States': 'USA', 'Uruguay': 'URY',
-    'Venezuela': 'VEN', 'Vietnam': 'VNM',
+    // A
+    'Afghanistan': 'AFG', 'Albania': 'ALB', 'Algeria': 'DZA', 'Andorra': 'AND',
+    'Angola': 'AGO', 'Antigua and Barbuda': 'ATG', 'Argentina': 'ARG', 'Armenia': 'ARM',
+    'Australia': 'AUS', 'Austria': 'AUT', 'Azerbaijan': 'AZE',
+    // B
+    'Bahamas': 'BHS', 'Bahrain': 'BHR', 'Bangladesh': 'BGD', 'Barbados': 'BRB',
+    'Belarus': 'BLR', 'Belgium': 'BEL', 'Belize': 'BLZ', 'Benin': 'BEN',
+    'Bhutan': 'BTN', 'Bolivia': 'BOL', 'Bosnia and Herzegovina': 'BIH',
+    'Botswana': 'BWA', 'Brazil': 'BRA', 'Brunei': 'BRN', 'Brunei Darussalam': 'BRN',
+    'Bulgaria': 'BGR', 'Burkina Faso': 'BFA', 'Burundi': 'BDI',
+    // C
+    'Cabo Verde': 'CPV', 'Cape Verde': 'CPV', 'Cambodia': 'KHM', 'Cameroon': 'CMR',
+    'Canada': 'CAN', 'Central African Republic': 'CAF', 'Chad': 'TCD',
+    'Chile': 'CHL', 'China': 'CHN', 'Colombia': 'COL', 'Comoros': 'COM',
+    'Congo': 'COG', 'Republic of the Congo': 'COG', 'Costa Rica': 'CRI',
+    'Croatia': 'HRV', 'Cuba': 'CUB', 'Cyprus': 'CYP', 'Czech Republic': 'CZE', 'Czechia': 'CZE',
+    // D
+    'Denmark': 'DNK', 'Djibouti': 'DJI', 'Dominica': 'DMA', 'Dominican Republic': 'DOM',
+    'DR Congo': 'COD', 'Democratic Republic of the Congo': 'COD',
+    // E
+    'Ecuador': 'ECU', 'Egypt': 'EGY', 'El Salvador': 'SLV', 'Equatorial Guinea': 'GNQ',
+    'Eritrea': 'ERI', 'Estonia': 'EST', 'Eswatini': 'SWZ', 'Swaziland': 'SWZ',
+    'Ethiopia': 'ETH',
+    // F
+    'Fiji': 'FJI', 'Finland': 'FIN', 'France': 'FRA',
+    // G
+    'Gabon': 'GAB', 'Gambia': 'GMB', 'Georgia': 'GEO', 'Germany': 'DEU',
+    'Ghana': 'GHA', 'Greece': 'GRC', 'Grenada': 'GRD', 'Guatemala': 'GTM',
+    'Guinea': 'GIN', 'Guinea-Bissau': 'GNB', 'Guyana': 'GUY',
+    // H
+    'Haiti': 'HTI', 'Honduras': 'HND', 'Hungary': 'HUN',
+    // I
+    'Iceland': 'ISL', 'India': 'IND', 'Indonesia': 'IDN', 'Iran': 'IRN',
+    'Iraq': 'IRQ', 'Ireland': 'IRL', 'Israel': 'ISR', 'Italy': 'ITA',
+    'Ivory Coast': 'CIV', "Côte d'Ivoire": 'CIV', 'Cote d\'Ivoire': 'CIV',
+    // J
+    'Jamaica': 'JAM', 'Japan': 'JPN', 'Jordan': 'JOR',
+    // K
+    'Kazakhstan': 'KAZ', 'Kenya': 'KEN', 'Kiribati': 'KIR', 'Kuwait': 'KWT',
+    'Kyrgyzstan': 'KGZ',
+    // L
+    'Laos': 'LAO', 'Lao PDR': 'LAO', "Lao People's Democratic Republic": 'LAO',
+    'Latvia': 'LVA', 'Lebanon': 'LBN', 'Lesotho': 'LSO', 'Liberia': 'LBR',
+    'Libya': 'LBY', 'Liechtenstein': 'LIE', 'Lithuania': 'LTU', 'Luxembourg': 'LUX',
+    // M
+    'Madagascar': 'MDG', 'Malawi': 'MWI', 'Malaysia': 'MYS', 'Maldives': 'MDV',
+    'Mali': 'MLI', 'Malta': 'MLT', 'Marshall Islands': 'MHL', 'Mauritania': 'MRT',
+    'Mauritius': 'MUS', 'Mexico': 'MEX', 'Micronesia': 'FSM', 'Moldova': 'MDA',
+    'Monaco': 'MCO', 'Mongolia': 'MNG', 'Montenegro': 'MNE', 'Morocco': 'MAR',
+    'Mozambique': 'MOZ', 'Myanmar': 'MMR', 'Burma': 'MMR',
+    // N
+    'Namibia': 'NAM', 'Nauru': 'NRU', 'Nepal': 'NPL', 'Netherlands': 'NLD',
+    'New Zealand': 'NZL', 'Nicaragua': 'NIC', 'Niger': 'NER', 'Nigeria': 'NGA',
+    'North Korea': 'PRK', 'North Macedonia': 'MKD', 'Macedonia': 'MKD', 'Norway': 'NOR',
+    // O
+    'Oman': 'OMN',
+    // P
+    'Pakistan': 'PAK', 'Palau': 'PLW', 'Palestine': 'PSE', 'Panama': 'PAN',
+    'Papua New Guinea': 'PNG', 'Paraguay': 'PRY', 'Peru': 'PER', 'Philippines': 'PHL',
+    'Poland': 'POL', 'Portugal': 'PRT',
+    // Q
+    'Qatar': 'QAT',
+    // R
+    'Romania': 'ROU', 'Russia': 'RUS', 'Russian Federation': 'RUS', 'Rwanda': 'RWA',
+    // S
+    'Saint Kitts and Nevis': 'KNA', 'Saint Lucia': 'LCA',
+    'Saint Vincent and the Grenadines': 'VCT', 'Samoa': 'WSM', 'San Marino': 'SMR',
+    'Sao Tome and Principe': 'STP', 'Saudi Arabia': 'SAU', 'Senegal': 'SEN',
+    'Serbia': 'SRB', 'Seychelles': 'SYC', 'Sierra Leone': 'SLE', 'Singapore': 'SGP',
+    'Slovakia': 'SVK', 'Slovenia': 'SVN', 'Solomon Islands': 'SLB', 'Somalia': 'SOM',
+    'South Africa': 'ZAF', 'South Korea': 'KOR', 'Republic of Korea': 'KOR',
+    'South Sudan': 'SSD', 'Spain': 'ESP', 'Sri Lanka': 'LKA', 'Sudan': 'SDN',
+    'Suriname': 'SUR', 'Sweden': 'SWE', 'Switzerland': 'CHE',
+    'Syria': 'SYR', 'Syrian Arab Republic': 'SYR',
+    // T
+    'Taiwan': 'TWN', 'Tajikistan': 'TJK', 'Tanzania': 'TZA',
+    'United Republic of Tanzania': 'TZA', 'Thailand': 'THA',
+    'Timor-Leste': 'TLS', 'East Timor': 'TLS', 'Togo': 'TGO', 'Tonga': 'TON',
+    'Trinidad and Tobago': 'TTO', 'Tunisia': 'TUN', 'Turkey': 'TUR', 'Türkiye': 'TUR',
+    'Turkmenistan': 'TKM', 'Tuvalu': 'TUV',
+    // U
+    'Uganda': 'UGA', 'Ukraine': 'UKR', 'United Arab Emirates': 'ARE', 'UAE': 'ARE',
+    'United Kingdom': 'GBR', 'United States': 'USA', 'United States of America': 'USA',
+    'Uruguay': 'URY', 'Uzbekistan': 'UZB',
+    // V
+    'Vanuatu': 'VUT', 'Vatican City': 'VAT', 'Venezuela': 'VEN',
+    'Vietnam': 'VNM', 'Viet Nam': 'VNM',
+    // Y
+    'Yemen': 'YEM',
+    // Z
+    'Zambia': 'ZMB', 'Zimbabwe': 'ZWE',
 };
 
 function parseSdgs(sdgs: unknown): number[] {


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-60

- COUNTRY_ALPHA3 in useProjects.ts was missing the majority of countries (~60 covered out of ~195), causing any unlisted country (e.g. Zambia, Portugal, Senegal, most of Europe and Africa) to fall back to 'UNK' and render no flag at all.

- alpha3to2 in CountryFlag.vue only had 44 entries and relied on a substring(0, 2) fallback that silently produced wrong flags in many cases — e.g. Senegal (SEN) resolved to se (Sweden), Portugal (PRT) to pr (Puerto Rico), Estonia (EST) to es (Spain).