### PR TITLE
feat: show country-center map pin when project coordinates are unavailable

### DIFF
--- a/sustainable-explorer/frontend/components/shared/ProjectLocationMap.client.vue
+++ b/sustainable-explorer/frontend/components/shared/ProjectLocationMap.client.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
     lat: number;
     lng: number;
     name: string;
+    approximate?: boolean;
 }>();
 
 const mapContainer = ref<HTMLElement | null>(null);
@@ -16,7 +17,7 @@ onMounted(() => {
 
     map = L.map(mapContainer.value, {
         center: [props.lat, props.lng],
-        zoom: 8,
+        zoom: props.approximate ? 5 : 8,
         zoomControl: true,
         scrollWheelZoom: true,
     });
@@ -46,5 +47,13 @@ onUnmounted(() => {
 </script>
 
 <template>
-    <div ref="mapContainer" class="h-full w-full rounded-lg" />
+    <div class="relative h-full w-full">
+        <div ref="mapContainer" class="h-full w-full rounded-lg" />
+        <div
+            v-if="approximate"
+            class="absolute bottom-2 left-2 z-[1000] rounded bg-background/80 px-2 py-0.5 text-[10px] text-muted-foreground backdrop-blur-sm"
+        >
+            Approximate location
+        </div>
+    </div>
 </template>

--- a/sustainable-explorer/frontend/composables/useGeocodedCountries.ts
+++ b/sustainable-explorer/frontend/composables/useGeocodedCountries.ts
@@ -1,4 +1,5 @@
 import { COUNTRY_ALPHA3 } from '~/composables/useProjects';
+import { nominatimReverse } from '~/composables/useNominatim';
 import type { Project } from '~/types/models';
 
 // Module-level cache — persists across page navigations within the session.
@@ -15,19 +16,12 @@ async function drainQueue() {
     while (queue.length > 0) {
         const item = queue.shift()!;
         if (cache.has(item.id)) continue;
-        try {
-            const res = await $fetch<any>('https://nominatim.openstreetmap.org/reverse', {
-                params: { lat: item.lat, lon: item.lng, format: 'json', zoom: 3 },
-                headers: { 'Accept-Language': 'en' },
-            });
-            const name: string = res?.address?.country ?? '';
-            const code = COUNTRY_ALPHA3[name] ?? 'UNK';
-            if (code !== 'UNK') {
-                cache.set(item.id, code);
-                if (name) nameCache.set(item.id, name);
-                cacheRef.value++;
-            }
-        } catch { /* ignore */ }
+        const result = await nominatimReverse(item.lat, item.lng, n => COUNTRY_ALPHA3[n] ?? 'UNK');
+        if (result) {
+            cache.set(item.id, result.code);
+            nameCache.set(item.id, result.name);
+            cacheRef.value++;
+        }
         if (queue.length > 0) await new Promise(r => setTimeout(r, 1100));
     }
     queueRunning = false;

--- a/sustainable-explorer/frontend/composables/useNominatim.ts
+++ b/sustainable-explorer/frontend/composables/useNominatim.ts
@@ -1,0 +1,53 @@
+const reverseCache = new Map<string, { name: string; code: string }>();
+const centerCache = new Map<string, { lat: number; lng: number }>();
+
+function getUrls() {
+    const config = useRuntimeConfig();
+    return {
+        reverseUrl: config.public.geocoderUrl as string,
+        searchUrl: config.public.geocoderSearchUrl as string,
+    };
+}
+
+export async function nominatimReverse(
+    lat: number,
+    lng: number,
+    alpha3: (name: string) => string,
+): Promise<{ name: string; code: string } | null> {
+    const key = `${lat.toFixed(4)},${lng.toFixed(4)}`;
+    if (reverseCache.has(key)) return reverseCache.get(key)!;
+    try {
+        const { reverseUrl } = getUrls();
+        const res = await $fetch<any>(reverseUrl, {
+            params: { lat, lon: lng, format: 'json', zoom: 3 },
+            headers: { 'Accept-Language': 'en' },
+        });
+        const name: string = res?.address?.country ?? '';
+        const code = alpha3(name);
+        if (code !== 'UNK') {
+            const result = { name, code };
+            reverseCache.set(key, result);
+            return result;
+        }
+    } catch { /* ignore */ }
+    return null;
+}
+
+export async function nominatimCountryCenter(
+    country: string,
+): Promise<{ lat: number; lng: number } | null> {
+    if (centerCache.has(country)) return centerCache.get(country)!;
+    try {
+        const { searchUrl } = getUrls();
+        const results = await $fetch<Array<{ lat: string; lon: string }>>(searchUrl, {
+            params: { country, format: 'json', limit: 1, featuretype: 'country' },
+            headers: { 'Accept-Language': 'en' },
+        });
+        if (results?.length) {
+            const coords = { lat: parseFloat(results[0].lat), lng: parseFloat(results[0].lon) };
+            centerCache.set(country, coords);
+            return coords;
+        }
+    } catch { /* ignore */ }
+    return null;
+}

--- a/sustainable-explorer/frontend/nuxt.config.ts
+++ b/sustainable-explorer/frontend/nuxt.config.ts
@@ -62,8 +62,9 @@ export default defineNuxtConfig({
             // SSE (EventSource) must bypass the Nitro proxy — connect directly to the API.
             // Override via NUXT_PUBLIC_SSE_API_BASE_URL in production.
             sseApiBaseUrl: process.env.NUXT_PUBLIC_SSE_API_BASE_URL || 'http://localhost:3030',
-            // Reverse-geocoding endpoint. Override via NUXT_PUBLIC_GEOCODER_URL.
+            // Nominatim geocoding endpoints. Override via NUXT_PUBLIC_GEOCODER_URL / NUXT_PUBLIC_GEOCODER_SEARCH_URL.
             geocoderUrl: 'https://nominatim.openstreetmap.org/reverse',
+            geocoderSearchUrl: 'https://nominatim.openstreetmap.org/search',
             // Google Apps Script Web App URL that receives feedback submissions.
             // Leave empty to hide the feedback widget. Set via NUXT_PUBLIC_FEEDBACK_WEBHOOK_URL.
             feedbackWebhookUrl: process.env.NUXT_PUBLIC_FEEDBACK_WEBHOOK_URL || '',

--- a/sustainable-explorer/frontend/pages/projects/[id].vue
+++ b/sustainable-explorer/frontend/pages/projects/[id].vue
@@ -13,6 +13,7 @@ import { getSDG } from '~/lib/sdgs';
 import { getMethodologyName } from '~/lib/methodologies';
 import { useDecodedMethodologyApi } from '~/composables/api/useDecodedMethodologyApi';
 import { COUNTRY_ALPHA3 } from '~/composables/useProjects';
+import { nominatimReverse, nominatimCountryCenter } from '~/composables/useNominatim';
 
 const route = useRoute();
 const { network } = useNetwork();
@@ -26,15 +27,7 @@ const geocodedCountry = ref<{ code: string; name: string } | null>(null);
 watch(project, async (p) => {
     geocodedCountry.value = null;
     if (!p || p.countryCode !== 'UNK' || !p.lat || !p.lng) return;
-    try {
-        const res = await $fetch<any>('https://nominatim.openstreetmap.org/reverse', {
-            params: { lat: p.lat, lon: p.lng, format: 'json', zoom: 3 },
-            headers: { 'Accept-Language': 'en' },
-        });
-        const name: string = res?.address?.country ?? '';
-        const code = COUNTRY_ALPHA3[name] ?? 'UNK';
-        if (code !== 'UNK') geocodedCountry.value = { code, name };
-    } catch { /* ignore — fallback stays UNK */ }
+    geocodedCountry.value = await nominatimReverse(p.lat, p.lng, n => COUNTRY_ALPHA3[n] ?? 'UNK');
 }, { immediate: true });
 
 const INVALID_COUNTRY = new Set([
@@ -513,6 +506,26 @@ watch(methodologyMappingOpen, (open) => {
     }
 });
 
+// ─── Effective map location (falls back to Nominatim country center when no coordinates) ──
+
+const countryCenterCoords = ref<{ lat: number; lng: number } | null>(null);
+
+watch(project, async (p) => {
+    if (!p) return;
+    const hasCoords = p.lat !== 0 || p.lng !== 0;
+    if (hasCoords) { countryCenterCoords.value = null; return; }
+    if (!p.country) return;
+    countryCenterCoords.value = await nominatimCountryCenter(p.country);
+}, { immediate: true });
+
+const effectiveLocation = computed(() => {
+    if (!project.value) return null;
+    const hasCoords = project.value.lat !== 0 || project.value.lng !== 0;
+    if (hasCoords) return { lat: project.value.lat, lng: project.value.lng, approximate: false };
+    if (countryCenterCoords.value) return { ...countryCenterCoords.value, approximate: true };
+    return null;
+});
+
 // ─── Emission data (currently all dashes) ─────────────────────────────────────
 
 const emissions = computed(() => {
@@ -614,12 +627,23 @@ const emissions = computed(() => {
                             Project Location
                         </h2>
                         <p class="text-[11px] text-muted-foreground mt-0.5">
-                            {{ project.lat.toFixed(4) }}, {{ project.lng.toFixed(4) }}<span v-if="displayCountry"> · {{ displayCountry }}</span>
+                            <template v-if="effectiveLocation && !effectiveLocation.approximate">{{ effectiveLocation.lat.toFixed(4) }}, {{ effectiveLocation.lng.toFixed(4) }}</template>
+                            <template v-else-if="effectiveLocation?.approximate">Country-level location</template>
+                            <span v-if="displayCountry"> · {{ displayCountry }}</span>
                         </p>
                     </div>
                     <div class="h-[320px]">
                         <ClientOnly>
-                            <ProjectLocationMap :lat="project.lat" :lng="project.lng" :name="project.name" />
+                            <ProjectLocationMap
+                                v-if="effectiveLocation"
+                                :lat="effectiveLocation.lat"
+                                :lng="effectiveLocation.lng"
+                                :name="project.name"
+                                :approximate="effectiveLocation.approximate"
+                            />
+                            <div v-else class="h-full flex items-center justify-center text-sm text-muted-foreground">
+                                Location data unavailable
+                            </div>
                         </ClientOnly>
                     </div>
                 </div>


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-62

When a project has no coordinates, the project detail map now falls back to the country's geographic center (looked up via Nominatim search) and displays an "Approximate location" label. All Nominatim calls are consolidated into a new useNominatim.ts composable (reading URLs from runtimeConfig.public) used by both the project detail page and useGeocodedCountries, removing the three separate hardcoded URLs.