### PR TITLE
feat: enhance map configurations with minZoom and maxBounds settings and fixed country filter while navigating from dashboard

### DIFF
--- a/sustainable-explorer/frontend/assets/css/main.css
+++ b/sustainable-explorer/frontend/assets/css/main.css
@@ -130,3 +130,6 @@ pre {
         scroll-behavior: auto !important;
     }
 }
+
+/* Match CartoDB light_all tile background so no-tile areas blend seamlessly */
+.leaflet-container { background: #d4dadc !important; }

--- a/sustainable-explorer/frontend/components/registry/RegistryProjectsMap.client.vue
+++ b/sustainable-explorer/frontend/components/registry/RegistryProjectsMap.client.vue
@@ -44,6 +44,9 @@ onMounted(async () => {
         center: [20, 0],
         zoomControl: true,
         scrollWheelZoom: false,
+        minZoom: 2,
+        maxBounds: [[-90, -180], [90, 180]],
+        maxBoundsViscosity: 1.0,
     });
 
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {

--- a/sustainable-explorer/frontend/components/shared/ProjectLocationMap.client.vue
+++ b/sustainable-explorer/frontend/components/shared/ProjectLocationMap.client.vue
@@ -17,8 +17,11 @@ onMounted(() => {
     map = L.map(mapContainer.value, {
         center: [props.lat, props.lng],
         zoom: 8,
+        minZoom: 2,
         zoomControl: true,
         scrollWheelZoom: true,
+        maxBounds: [[-90, -180], [90, 180]],
+        maxBoundsViscosity: 1.0,
     });
 
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {

--- a/sustainable-explorer/frontend/components/shared/ProjectMap.client.vue
+++ b/sustainable-explorer/frontend/components/shared/ProjectMap.client.vue
@@ -62,6 +62,8 @@ async function initMap() {
         scrollWheelZoom: true,
         minZoom: 2,
         maxZoom: 10,
+        maxBounds: [[-90, -180], [90, 180]],
+        maxBoundsViscosity: 1.0,
     });
 
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png', {

--- a/sustainable-explorer/frontend/pages/index.vue
+++ b/sustainable-explorer/frontend/pages/index.vue
@@ -230,7 +230,7 @@ function onCountryClick(code: string) {
 // circuits on c.code !== 'UNK' before invoking navigate().
 function countryRouteFor(c: { name: string; code: string }) {
     if (c.code === 'UNK') return { path: '/projects' };
-    return { path: '/projects', query: { country: c.name } };
+    return { path: '/projects', query: { countryCode: c.code } };
 }
 
 // Sector legend → projects page filtered by sector. Untranslated label is

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -9,6 +9,7 @@ import { getMethodologyLongName } from '~/lib/methodologies';
 import type { Project } from '~/types/models';
 
 const { t } = useI18n();
+const route = useRoute();
 const { projects, total, filterOptions } = useProjects();
 const { selectedEntries, canAdd, isSelected, toggleProject, removeProject, clearAll, goToCompare } = useProjectComparison();
 const { resolvedCode, resolvedName } = useGeocodedCountries(projects);
@@ -58,13 +59,31 @@ const allProjects = computed(() => projects.value.map(p => ({
     methodologyLong: getMethodologyLongName(p.methodologyId, p.methodology),
 })));
 
-const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters, applyPreset } =
+const { searchQuery, currentPage, paginated: _paginated, filtered: _filtered, totalPages: _totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters, applyPreset } =
     useFilteredPagination(allProjects, {
         searchFields: ['name', 'country', 'methodology', 'registry', 'sector', 'sectoralScope', 'developer'],
         pageSize: 10,
         defaultSort: { key: 'createdAt', dir: 'desc' },
         arrayFields: ['sdgs'],
+        excludeFromQuery: ['countryCode'],
     });
+
+// When navigating from the dashboard country table, ?countryCode=UGA is used
+// so the filter matches projects via geocoding (resolvedCode) rather than exact
+// raw country string equality — fixing the Uganda 3-vs-1 discrepancy.
+const countryCodeFilter = computed(() => (route.query.countryCode as string) || null);
+
+const filtered = computed(() => {
+    if (!countryCodeFilter.value) return _filtered.value;
+    return _filtered.value.filter(p => resolvedCode(p) === countryCodeFilter.value);
+});
+
+const totalPages = computed(() => Math.max(1, Math.ceil(filtered.value.length / pageSize.value)));
+
+const paginated = computed(() => {
+    const start = (currentPage.value - 1) * pageSize.value;
+    return filtered.value.slice(start, start + pageSize.value);
+});
 
 const presets = computed(() => [
     { label: t('projects.presets.issuingForestry'), filters: { status: 'Issuing', sector: 'Forestry and Land Use' } },


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-56
- Maps — All three Leaflet maps (ProjectLocationMap, ProjectMap, RegistryProjectsMap) now have a minimum zoom limit and hard pan boundaries, so users can't scroll into the empty gray space beyond the world edges. The background color of that empty area also now matches the map tiles seamlessly.

- Dashboard → Projects navigation — Clicking a country row in the dashboard's Project Distribution table now correctly filters the projects page using the same country-resolution logic as the dashboard (including GPS-geocoded projects), fixing the mismatch where Uganda showed 3 projects on the dashboard but only 1 after clicking through.