### PR TITLE
feat: implement dashboard thresholds and display methodology dashboard

### DIFF
--- a/sustainable-explorer/frontend/components/shared/TrendLineChart.vue
+++ b/sustainable-explorer/frontend/components/shared/TrendLineChart.vue
@@ -9,13 +9,17 @@ const props = defineProps<{
 
 const color = props.color || 'hsl(var(--primary))';
 const fillColor = props.fillColor || 'hsl(var(--primary) / 0.1)';
-const unit = props.unit || 'M';
+const unit = computed(() => props.unit ?? 'M');
 
 const chartHeight = 160;
 const chartWidth = 500;
 const padX = 10;
 const padTop = 10;
 const padBottom = 0;
+
+const TOOLTIP_W = 80;
+const TOOLTIP_H = 20;
+const TOOLTIP_PAD = 4; // min distance from viewBox top
 
 const maxVal = computed(() => {
     const vals = props.data.map(d => d.value);
@@ -60,6 +64,20 @@ const areaPath = computed(() => {
 });
 
 const hoveredIndex = ref<number | null>(null);
+
+const hoveredPoint = computed(() =>
+    hoveredIndex.value !== null ? points.value[hoveredIndex.value] ?? null : null,
+);
+
+// Tooltip box — x clamped so it never overflows left/right,
+// y clamped so it never overflows the top of the viewBox.
+const tooltipBox = computed(() => {
+    const pt = hoveredPoint.value;
+    if (!pt) return null;
+    const x = Math.min(Math.max(pt.x - TOOLTIP_W / 2, padX), chartWidth - padX - TOOLTIP_W);
+    const y = Math.max(pt.y - TOOLTIP_H - 12, TOOLTIP_PAD);
+    return { x, y, textX: x + TOOLTIP_W / 2, textY: y + TOOLTIP_H - 6 };
+});
 </script>
 
 <template>
@@ -102,18 +120,8 @@ const hoveredIndex = ref<number | null>(null);
                     stroke-linejoin="round"
                 />
 
-                <!-- Data points + hover zones -->
+                <!-- Dots + x-axis labels + hit areas -->
                 <g v-for="(pt, i) in points" :key="`pt-${i}`">
-                    <!-- Invisible wider hit area -->
-                    <rect
-                        :x="pt.x - (chartWidth / points.length) / 2"
-                        :y="0"
-                        :width="chartWidth / points.length"
-                        :height="chartHeight"
-                        fill="transparent"
-                        @mouseenter="hoveredIndex = i"
-                    />
-
                     <!-- Vertical guide on hover -->
                     <line
                         v-if="hoveredIndex === i"
@@ -138,30 +146,7 @@ const hoveredIndex = ref<number | null>(null);
                         class="transition-all duration-150"
                     />
 
-                    <!-- Value tooltip on hover -->
-                    <g v-if="hoveredIndex === i">
-                        <rect
-                            :x="pt.x - 24"
-                            :y="pt.y - 24"
-                            width="48"
-                            height="18"
-                            rx="4"
-                            fill="hsl(var(--foreground))"
-                            opacity="0.9"
-                        />
-                        <text
-                            :x="pt.x"
-                            :y="pt.y - 13"
-                            text-anchor="middle"
-                            fill="hsl(var(--background))"
-                            font-size="10"
-                            font-weight="600"
-                        >
-                            {{ pt.value }}{{ unit }}
-                        </text>
-                    </g>
-
-                    <!-- X-axis labels -->
+                    <!-- X-axis label -->
                     <text
                         :x="pt.x"
                         :y="chartHeight + 14"
@@ -172,6 +157,38 @@ const hoveredIndex = ref<number | null>(null);
                         :font-weight="hoveredIndex === i ? 600 : 400"
                     >
                         {{ pt.label }}
+                    </text>
+
+                    <!-- Invisible wider hit area (rendered last so it captures events over the dot) -->
+                    <rect
+                        :x="pt.x - (chartWidth / points.length) / 2"
+                        :y="0"
+                        :width="chartWidth / points.length"
+                        :height="chartHeight"
+                        fill="transparent"
+                        @mouseenter="hoveredIndex = i"
+                    />
+                </g>
+
+                <!-- Tooltip overlay — rendered last so it always paints on top -->
+                <g v-if="hoveredPoint && tooltipBox">
+                    <rect
+                        :x="tooltipBox.x"
+                        :y="tooltipBox.y"
+                        :width="TOOLTIP_W"
+                        :height="TOOLTIP_H"
+                        rx="4"
+                        :style="{ fill: 'var(--color-foreground)', opacity: '0.9' }"
+                    />
+                    <text
+                        :x="tooltipBox.textX"
+                        :y="tooltipBox.textY"
+                        text-anchor="middle"
+                        :style="{ fill: 'var(--color-background)' }"
+                        font-size="10"
+                        font-weight="600"
+                    >
+                        {{ hoveredPoint.label }}: {{ hoveredPoint.value !== 0 ? `${hoveredPoint.value}${unit}` : '0' }}
                     </text>
                 </g>
             </svg>

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -546,6 +546,24 @@
                 "trends": "Trends",
                 "trendsComingSoon": "Issuance over time, retirement trend, and geography charts will be available once live VC-Document data is fully synced."
             },
+            "charts": {
+                "geographicDistribution": "Geographic Distribution",
+                "geographicDistributionSub": "Project distribution by country",
+                "noGeographicData": "No geographic data available",
+                "issuanceTrend": "Issuance Trend",
+                "issuanceTrendSub": "Volume ({unit}) by year",
+                "noIssuanceData": "No issuance data available",
+                "issuanceTrendYear": "year",
+                "issuanceTrendYears": "years",
+                "issuanceTrendTotal": "{total}{unit} total",
+                "vintageDistribution": "Vintage Distribution",
+                "vintageDistributionSub": "Project distribution by vintage",
+                "noVintageData": "No vintage data available",
+                "vintageYear": "vintage",
+                "vintageYears": "vintages",
+                "vintageProject": "project",
+                "vintageProjects": "projects"
+            },
             "actions": {
                 "aboutTitle": "About this Methodology",
                 "instancePolicyTopicLabel": "Instance Policy Topic:",

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -546,10 +546,16 @@
                 "trends": "Trends",
                 "trendsComingSoon": "Issuance over time, retirement trend, and geography charts will be available once live VC-Document data is fully synced."
             },
+            "dashboard": {
+                "title": "Methodology Dashboard",
+                "stats": "{projects} projects · {issuances} issuances"
+            },
             "charts": {
                 "geographicDistribution": "Geographic Distribution",
                 "geographicDistributionSub": "Project distribution by country",
                 "noGeographicData": "No geographic data available",
+                "geographicCountry": "country",
+                "geographicCountries": "countries",
                 "issuanceTrend": "Issuance Trend",
                 "issuanceTrendSub": "Volume ({unit}) by year",
                 "noIssuanceData": "No issuance data available",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -541,6 +541,24 @@
                 "trends": "Tendencias",
                 "trendsComingSoon": "Los gráficos de emisiones a lo largo del tiempo, tendencia de retiros y geografía estarán disponibles una vez que los datos de los documentos VC en vivo estén completamente sincronizados."
             },
+            "charts": {
+                "geographicDistribution": "Distribución geográfica",
+                "geographicDistributionSub": "Distribución de proyectos por país",
+                "noGeographicData": "No hay datos geográficos disponibles",
+                "issuanceTrend": "Tendencia de emisiones",
+                "issuanceTrendSub": "Volumen ({unit}) por año",
+                "noIssuanceData": "No hay datos de emisiones disponibles",
+                "issuanceTrendYear": "año",
+                "issuanceTrendYears": "años",
+                "issuanceTrendTotal": "{total}{unit} total",
+                "vintageDistribution": "Distribución por añada",
+                "vintageDistributionSub": "Distribución de proyectos por añada",
+                "noVintageData": "No hay datos de añada disponibles",
+                "vintageYear": "añada",
+                "vintageYears": "añadas",
+                "vintageProject": "proyecto",
+                "vintageProjects": "proyectos"
+            },
             "actions": {
                 "aboutTitle": "Acerca de esta metodología",
                 "instancePolicyTopicLabel": "Tópico de la instancia de política:",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -541,10 +541,16 @@
                 "trends": "Tendencias",
                 "trendsComingSoon": "Los gráficos de emisiones a lo largo del tiempo, tendencia de retiros y geografía estarán disponibles una vez que los datos de los documentos VC en vivo estén completamente sincronizados."
             },
+            "dashboard": {
+                "title": "Panel de metodología",
+                "stats": "{projects} proyectos · {issuances} emisiones"
+            },
             "charts": {
                 "geographicDistribution": "Distribución geográfica",
                 "geographicDistributionSub": "Distribución de proyectos por país",
                 "noGeographicData": "No hay datos geográficos disponibles",
+                "geographicCountry": "país",
+                "geographicCountries": "países",
                 "issuanceTrend": "Tendencia de emisiones",
                 "issuanceTrendSub": "Volumen ({unit}) por año",
                 "noIssuanceData": "No hay datos de emisiones disponibles",

--- a/sustainable-explorer/frontend/lib/methodology-threshold.ts
+++ b/sustainable-explorer/frontend/lib/methodology-threshold.ts
@@ -1,0 +1,8 @@
+export const DASHBOARD_THRESHOLDS = {
+    minProjects: 1,
+    minCredits: 0,
+} as const;
+
+export function meetsDashboardThreshold(projectCount: number, issuanceCount: number): boolean {
+    return projectCount > DASHBOARD_THRESHOLDS.minProjects && issuanceCount > DASHBOARD_THRESHOLDS.minCredits;
+}

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -873,10 +873,10 @@ const issuanceTrendTotal = computed(() =>
         <div class="px-5 py-3.5 border-b bg-muted/30 flex items-center justify-between">
           <h2 class="text-sm font-semibold text-foreground flex items-center gap-2">
             <BarChart3 class="h-4 w-4 text-primary" />
-            Methodology Dashboard
+            {{ $t('methodologies.detail.dashboard.title') }}
           </h2>
           <span class="text-[11px] text-muted-foreground">
-            {{ methodology.stats.projectCount }} projects &middot; {{ methodology.stats.issuanceCount }} issuances
+            {{ $t('methodologies.detail.dashboard.stats', { projects: methodology.stats.projectCount, issuances: methodology.stats.issuanceCount }) }}
           </span>
         </div>
 
@@ -893,7 +893,7 @@ const issuanceTrendTotal = computed(() =>
                 <h3 class="text-sm font-semibold text-foreground">{{ $t('methodologies.detail.charts.geographicDistribution') }}</h3>
                 <p class="text-xs text-muted-foreground mt-0.5">{{ $t('methodologies.detail.charts.geographicDistributionSub') }}</p>
               </div>
-              <span class="text-[11px] text-muted-foreground">{{ geoDistribution.length }} countr{{ geoDistribution.length !== 1 ? 'ies' : 'y' }}</span>
+              <span class="text-[11px] text-muted-foreground">{{ geoDistribution.length }} {{ geoDistribution.length !== 1 ? $t('methodologies.detail.charts.geographicCountries') : $t('methodologies.detail.charts.geographicCountry') }}</span>
             </div>
             <div v-if="geoDistribution.length > 0" class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2.5">
               <div v-for="item in geoDistribution" :key="item.country" class="flex items-center gap-2.5">

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -667,12 +667,25 @@ const issuanceTrend = computed(() => {
     const year = new Date(iss.mintDate).getFullYear().toString();
     byYear[year] = (byYear[year] ?? 0) + iss.supply;
   }
-  const entries = Object.entries(byYear).sort(([a], [b]) => a.localeCompare(b));
-  const maxVal = entries.reduce((m, [, v]) => Math.max(m, v), 0);
+  const years = Object.keys(byYear).sort();
+  if (years.length === 0) return { data: [], unit: '' };
+
+  // Fill every year in the range (including gaps with 0) so the line connects.
+  // When there is only a single year, prepend the previous year at 0 to ensure
+  // at least two points so a line segment can be drawn.
+  const minYear = parseInt(years[0]);
+  const maxYear = parseInt(years[years.length - 1]);
+  const startYear = minYear === maxYear ? minYear - 1 : minYear;
+  const filled: [string, number][] = [];
+  for (let y = startYear; y <= maxYear; y++) {
+    filled.push([String(y), byYear[String(y)] ?? 0]);
+  }
+
+  const maxVal = filled.reduce((m, [, v]) => Math.max(m, v), 0);
   const divisor = maxVal >= 1_000_000 ? 1_000_000 : maxVal >= 1_000 ? 1_000 : 1;
   const unit = maxVal >= 1_000_000 ? 'M' : maxVal >= 1_000 ? 'K' : '';
   return {
-    data: entries.map(([label, value]) => ({ label, value: Math.round((value / divisor) * 10) / 10 })),
+    data: filled.map(([label, value]) => ({ label, value: Math.round((value / divisor) * 10) / 10 })),
     unit,
   };
 });
@@ -684,7 +697,7 @@ const vintageByIssuance = computed(() => {
     const match = raw.match(/\d{4}/);
     if (!match) continue;
     const year = match[0];
-    byVintage[year] = (byVintage[year] ?? 0) + (p.issuanceCount ?? 0);
+    byVintage[year] = (byVintage[year] ?? 0) + 1;
   }
   return Object.entries(byVintage)
     .sort(([a], [b]) => a.localeCompare(b))
@@ -877,8 +890,8 @@ const issuanceTrendTotal = computed(() =>
           <div class="border-b px-5 py-4">
             <div class="flex items-center justify-between mb-4">
               <div>
-                <h3 class="text-sm font-semibold text-foreground">Geographic Distribution</h3>
-                <p class="text-xs text-muted-foreground mt-0.5">Project distribution by country</p>
+                <h3 class="text-sm font-semibold text-foreground">{{ $t('methodologies.detail.charts.geographicDistribution') }}</h3>
+                <p class="text-xs text-muted-foreground mt-0.5">{{ $t('methodologies.detail.charts.geographicDistributionSub') }}</p>
               </div>
               <span class="text-[11px] text-muted-foreground">{{ geoDistribution.length }} countr{{ geoDistribution.length !== 1 ? 'ies' : 'y' }}</span>
             </div>
@@ -897,7 +910,7 @@ const issuanceTrendTotal = computed(() =>
                 <span class="text-xs tabular-nums text-muted-foreground w-4 text-right shrink-0">{{ item.projects }}</span>
               </div>
             </div>
-            <div v-else class="text-xs text-muted-foreground py-2">No geographic data available</div>
+            <div v-else class="text-xs text-muted-foreground py-2">{{ $t('methodologies.detail.charts.noGeographicData') }}</div>
           </div>
 
           <!-- Issuance Trend + Vintage Distribution -->
@@ -906,8 +919,8 @@ const issuanceTrendTotal = computed(() =>
           <div>
             <div class="flex items-center justify-between px-5 py-4">
               <div>
-                <h3 class="text-sm font-semibold text-foreground">Issuance Trend</h3>
-                <p class="text-xs text-muted-foreground mt-0.5">Volume ({{ issuanceTrend.unit || 'units' }}) by year</p>
+                <h3 class="text-sm font-semibold text-foreground">{{ $t('methodologies.detail.charts.issuanceTrend') }}</h3>
+                <p class="text-xs text-muted-foreground mt-0.5">{{ $t('methodologies.detail.charts.issuanceTrendSub', { unit: issuanceTrend.unit || 'units' }) }}</p>
               </div>
             </div>
             <div class="px-5 pb-5">
@@ -917,11 +930,11 @@ const issuanceTrendTotal = computed(() =>
                   :unit="issuanceTrend.unit"
                   color="hsl(142, 76%, 36%)"
                   fill-color="hsl(142, 76%, 36%, 0.08)"
-                  empty-text="No issuance data available"
+                  :empty-text="$t('methodologies.detail.charts.noIssuanceData')"
                 />
                 <div class="flex items-center justify-between mt-4 pt-3 border-t">
-                  <span class="text-xs text-muted-foreground">{{ issuanceTrend.data.length }} year{{ issuanceTrend.data.length !== 1 ? 's' : '' }}</span>
-                  <span class="text-sm font-semibold text-foreground">{{ issuanceTrendTotal }}{{ issuanceTrend.unit }} total</span>
+                  <span class="text-xs text-muted-foreground">{{ issuanceTrend.data.length }} {{ issuanceTrend.data.length !== 1 ? $t('methodologies.detail.charts.issuanceTrendYears') : $t('methodologies.detail.charts.issuanceTrendYear') }}</span>
+                  <span class="text-sm font-semibold text-foreground">{{ $t('methodologies.detail.charts.issuanceTrendTotal', { total: issuanceTrendTotal, unit: issuanceTrend.unit }) }}</span>
                 </div>
               </div>
             </div>
@@ -931,8 +944,8 @@ const issuanceTrendTotal = computed(() =>
           <div>
             <div class="flex items-center justify-between px-5 py-4">
               <div>
-                <h3 class="text-sm font-semibold text-foreground">Vintage Distribution</h3>
-                <p class="text-xs text-muted-foreground mt-0.5">MintToken issuances by vintage year</p>
+                <h3 class="text-sm font-semibold text-foreground">{{ $t('methodologies.detail.charts.vintageDistribution') }}</h3>
+                <p class="text-xs text-muted-foreground mt-0.5">{{ $t('methodologies.detail.charts.vintageDistributionSub') }}</p>
               </div>
             </div>
             <div class="px-5 pb-5">
@@ -952,11 +965,11 @@ const issuanceTrendTotal = computed(() =>
                   </div>
                 </div>
                 <div v-else class="flex items-center justify-center h-48 text-sm text-muted-foreground">
-                  No vintage data available
+                  {{ $t('methodologies.detail.charts.noVintageData') }}
                 </div>
                 <div class="flex items-center justify-between mt-4 pt-3 border-t">
-                  <span class="text-xs text-muted-foreground">{{ vintageByIssuance.length }} vintage{{ vintageByIssuance.length !== 1 ? 's' : '' }}</span>
-                  <span class="text-sm font-semibold text-foreground">{{ vintageTotal }} issuances</span>
+                  <span class="text-xs text-muted-foreground">{{ vintageByIssuance.length }} {{ vintageByIssuance.length !== 1 ? $t('methodologies.detail.charts.vintageYears') : $t('methodologies.detail.charts.vintageYear') }}</span>
+                  <span class="text-sm font-semibold text-foreground">{{ vintageTotal }} {{ vintageTotal !== 1 ? $t('methodologies.detail.charts.vintageProjects') : $t('methodologies.detail.charts.vintageProject') }}</span>
                 </div>
               </div>
             </div>

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -35,6 +35,7 @@ import type {
 } from "~/composables/api/useMethodologiesApi";
 import type { DecodedMethodologyResponse } from "~/composables/api/useDecodedMethodologyApi";
 import { mapApiProject } from "~/composables/useProjects";
+import { meetsDashboardThreshold } from "~/lib/methodology-threshold";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -132,6 +133,12 @@ const publishedAt = computed(() => {
   return new Date(parseFloat(ts) * 1000).toLocaleString();
 });
 
+const showDashboard = computed(() =>
+  methodology.value
+    ? meetsDashboardThreshold(methodology.value.stats.projectCount, methodology.value.stats.issuanceCount)
+    : false,
+);
+
 // Linked Projects: fetch when tab is activated
 const linkedProjects = ref<Record<string, any>[]>([]);
 const linkedProjectsPending = ref(false);
@@ -144,6 +151,22 @@ if (import.meta.client) {
   const config = useRuntimeConfig();
   const baseURL = config.public.apiBaseUrl as string;
 
+  async function loadLinkedProjects(instId: string) {
+    linkedProjectsPending.value = true;
+    try {
+      const res = await $fetch<{ data: Record<string, any>[]; meta: { total: number } }>(
+        `/api/v1/${network.value}/projects`,
+        { baseURL, query: { instanceTopicId: instId, limit: 100, page: 1 } },
+      );
+      linkedProjects.value = res.data ?? [];
+    } catch {
+      linkedProjects.value = [];
+    } finally {
+      linkedProjectsPending.value = false;
+      linkedProjectsLoaded.value = true;
+    }
+  }
+
   // Linked projects scope to this *version* of the methodology — filtered by
   // instanceTopicId (the URL id), not policyTopicId, so v0.1 and v0.2 of the
   // same policy show different project lists.
@@ -153,19 +176,19 @@ if (import.meta.client) {
       if (tab !== 'projects' || !instId) return;
       if (instId === oldInstId && linkedProjectsLoaded.value) return;
       linkedProjectsLoaded.value = false;
-      linkedProjectsPending.value = true;
-      try {
-        const res = await $fetch<{ data: Record<string, any>[]; meta: { total: number } }>(
-          `/api/v1/${network.value}/projects`,
-          { baseURL, query: { instanceTopicId: instId, limit: 100, page: 1 } },
-        );
-        linkedProjects.value = res.data ?? [];
-      } catch {
-        linkedProjects.value = [];
-      } finally {
-        linkedProjectsPending.value = false;
-        linkedProjectsLoaded.value = true;
-      }
+      await loadLinkedProjects(instId);
+    },
+    { immediate: true },
+  );
+
+  // Eagerly load for dashboard section when threshold is met
+  watch(
+    [methodology, id] as const,
+    ([m, instId]) => {
+      if (!m || !instId) return;
+      if (!meetsDashboardThreshold(m.stats.projectCount, m.stats.issuanceCount)) return;
+      if (linkedProjectsLoaded.value) return;
+      loadLinkedProjects(instId);
     },
     { immediate: true },
   );
@@ -596,6 +619,71 @@ const lifecycleSummary = computed(() => {
   const active = methodology.value?.totalActive ?? 0;
   return { totalIssued, totalRetired, active };
 });
+
+// ─── Methodology Dashboard ────────────────────────────────────────────────────
+
+const INVALID_COUNTRY_LOWER = new Set([
+  'not applicable', 'not specified', 'n/a', 'na', 'none', 'not stated',
+  'not available', 'not provided', 'unknown',
+  'point', 'multipoint', 'linestring', 'multilinestring',
+  'polygon', 'multipolygon', 'geometrycollection',
+]);
+
+const geoDistribution = computed(() => {
+  // Subscribe to geocoding cache updates so this recomputes when lat/lng lookups resolve
+  const counts: Record<string, { projects: number; code: string }> = {};
+  for (const p of linkedProjectsMapped.value) {
+    const code = resolvedProjectCode(p);
+    if (code === 'UNK') continue;
+    const name = resolvedProjectName(p);
+    if (!name || INVALID_COUNTRY_LOWER.has(name.toLowerCase())) continue;
+    if (!counts[name]) counts[name] = { projects: 0, code };
+    counts[name].projects++;
+  }
+  return Object.entries(counts)
+    .map(([country, d]) => ({ country, projects: d.projects, code: d.code }))
+    .sort((a, b) => b.projects - a.projects)
+    .slice(0, 8);
+});
+
+const issuanceTrend = computed(() => {
+  const byYear: Record<string, number> = {};
+  for (const iss of (methodology.value?.issuances ?? [])) {
+    if (!iss.mintDate) continue;
+    const year = new Date(iss.mintDate).getFullYear().toString();
+    byYear[year] = (byYear[year] ?? 0) + iss.supply;
+  }
+  const entries = Object.entries(byYear).sort(([a], [b]) => a.localeCompare(b));
+  const maxVal = entries.reduce((m, [, v]) => Math.max(m, v), 0);
+  const divisor = maxVal >= 1_000_000 ? 1_000_000 : maxVal >= 1_000 ? 1_000 : 1;
+  const unit = maxVal >= 1_000_000 ? 'M' : maxVal >= 1_000 ? 'K' : '';
+  return {
+    data: entries.map(([label, value]) => ({ label, value: Math.round((value / divisor) * 10) / 10 })),
+    unit,
+  };
+});
+
+const vintageByIssuance = computed(() => {
+  const byVintage: Record<string, number> = {};
+  for (const p of linkedProjectsMapped.value) {
+    const raw = p.vintage?.trim() || (p.creditingPeriodStart ? String(new Date(p.creditingPeriodStart).getFullYear()) : '');
+    const match = raw.match(/\d{4}/);
+    if (!match) continue;
+    const year = match[0];
+    byVintage[year] = (byVintage[year] ?? 0) + (p.issuanceCount ?? 0);
+  }
+  return Object.entries(byVintage)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([label, value]) => ({ label, value }));
+});
+
+const vintageMax = computed(() => Math.max(...vintageByIssuance.value.map(v => v.value), 0));
+
+const vintageTotal = computed(() => vintageByIssuance.value.reduce((s, v) => s + v.value, 0));
+
+const issuanceTrendTotal = computed(() =>
+  Math.round(issuanceTrend.value.data.reduce((s, d) => s + d.value, 0) * 10) / 10,
+);
 </script>
 
 <template>
@@ -751,6 +839,116 @@ const lifecycleSummary = computed(() => {
             </span>
           </div>
         </div>
+      </div>
+
+      <!-- Methodology Dashboard -->
+      <div v-if="showDashboard" class="rounded-xl border bg-card overflow-hidden">
+        <div class="px-5 py-3.5 border-b bg-muted/30 flex items-center justify-between">
+          <h2 class="text-sm font-semibold text-foreground flex items-center gap-2">
+            <BarChart3 class="h-4 w-4 text-primary" />
+            Methodology Dashboard
+          </h2>
+          <span class="text-[11px] text-muted-foreground">
+            {{ methodology.stats.projectCount }} projects &middot; {{ methodology.stats.issuanceCount }} issuances
+          </span>
+        </div>
+
+        <div v-if="linkedProjectsPending && linkedProjects.length === 0" class="px-5 py-8 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+          <RefreshCw class="h-4 w-4 animate-spin" />
+          Loading dashboard data...
+        </div>
+
+        <div v-else>
+          <!-- Geographic Distribution (full width) -->
+          <div class="border-b px-5 py-4">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-sm font-semibold text-foreground">Geographic Distribution</h3>
+                <p class="text-xs text-muted-foreground mt-0.5">Project distribution by country</p>
+              </div>
+              <span class="text-[11px] text-muted-foreground">{{ geoDistribution.length }} countr{{ geoDistribution.length !== 1 ? 'ies' : 'y' }}</span>
+            </div>
+            <div v-if="geoDistribution.length > 0" class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2.5">
+              <div v-for="item in geoDistribution" :key="item.country" class="flex items-center gap-2.5">
+                <div class="flex items-center gap-1.5 w-32 shrink-0 min-w-0">
+                  <CountryFlag :code="item.code" size="sm" />
+                  <span class="text-xs text-foreground truncate">{{ item.country }}</span>
+                </div>
+                <div class="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+                  <div
+                    class="h-full bg-primary rounded-full transition-all duration-500"
+                    :style="{ width: `${(item.projects / geoDistribution[0].projects) * 100}%` }"
+                  />
+                </div>
+                <span class="text-xs tabular-nums text-muted-foreground w-4 text-right shrink-0">{{ item.projects }}</span>
+              </div>
+            </div>
+            <div v-else class="text-xs text-muted-foreground py-2">No geographic data available</div>
+          </div>
+
+          <!-- Issuance Trend + Vintage Distribution -->
+          <div class="grid grid-cols-1 lg:grid-cols-2 divide-y lg:divide-y-0 lg:divide-x">
+          <!-- Issuance Trend -->
+          <div>
+            <div class="flex items-center justify-between px-5 py-4">
+              <div>
+                <h3 class="text-sm font-semibold text-foreground">Issuance Trend</h3>
+                <p class="text-xs text-muted-foreground mt-0.5">Volume ({{ issuanceTrend.unit || 'units' }}) by year</p>
+              </div>
+            </div>
+            <div class="px-5 pb-5">
+              <div class="rounded-xl border bg-card p-5">
+                <TrendLineChart
+                  :data="issuanceTrend.data"
+                  :unit="issuanceTrend.unit"
+                  color="hsl(142, 76%, 36%)"
+                  fill-color="hsl(142, 76%, 36%, 0.08)"
+                  empty-text="No issuance data available"
+                />
+                <div class="flex items-center justify-between mt-4 pt-3 border-t">
+                  <span class="text-xs text-muted-foreground">{{ issuanceTrend.data.length }} year{{ issuanceTrend.data.length !== 1 ? 's' : '' }}</span>
+                  <span class="text-sm font-semibold text-foreground">{{ issuanceTrendTotal }}{{ issuanceTrend.unit }} total</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Vintage Distribution -->
+          <div>
+            <div class="flex items-center justify-between px-5 py-4">
+              <div>
+                <h3 class="text-sm font-semibold text-foreground">Vintage Distribution</h3>
+                <p class="text-xs text-muted-foreground mt-0.5">MintToken issuances by vintage year</p>
+              </div>
+            </div>
+            <div class="px-5 pb-5">
+              <div class="rounded-xl border bg-card p-5">
+                <div v-if="vintageByIssuance.length > 0" class="flex items-end gap-3 h-48">
+                  <div
+                    v-for="item in vintageByIssuance"
+                    :key="item.label"
+                    class="flex-1 flex flex-col items-center gap-2"
+                  >
+                    <span class="text-[11px] font-medium text-muted-foreground tabular-nums">{{ item.value }}</span>
+                    <div
+                      class="w-full rounded-t-md bg-chart-2/80 hover:bg-chart-2 transition-colors"
+                      :style="{ height: `${vintageMax > 0 ? (item.value / vintageMax) * 140 : 0}px` }"
+                    />
+                    <span class="text-[11px] text-muted-foreground">{{ item.label }}</span>
+                  </div>
+                </div>
+                <div v-else class="flex items-center justify-center h-48 text-sm text-muted-foreground">
+                  No vintage data available
+                </div>
+                <div class="flex items-center justify-between mt-4 pt-3 border-t">
+                  <span class="text-xs text-muted-foreground">{{ vintageByIssuance.length }} vintage{{ vintageByIssuance.length !== 1 ? 's' : '' }}</span>
+                  <span class="text-sm font-semibold text-foreground">{{ vintageTotal }} issuances</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          </div><!-- end Issuance + Vintage grid -->
+        </div><!-- end v-else -->
       </div>
 
       <!-- Tab Navigation -->


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-33

Threshold mechanism — dashboard section only renders when projectCount > 1 and issuanceCount > 0, defined in lib/methodology-threshold.ts with easily adjustable constants.

Entry point from project pages — project detail page links directly to /methodologies/${project.instanceTopicId}.

Dashboard panels:
  - Geographic Distribution — top 8 countries by project count with flags
  - Issuance Trend — line chart of credit volume by year, gaps filled with 0, connected line
  - Vintage Distribution — bar chart of project count per vintage year

<img width="1555" height="676" alt="image" src="https://github.com/user-attachments/assets/7150d01c-9ed4-4205-96c3-a9775f567238" />