### PR TITLE
fix: source issuance data from MintToken VCs instead of business_view CREDIT

### DIFF
--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -516,7 +516,7 @@
                     "project": "Project",
                     "country": "Country",
                     "registry": "Registry",
-                    "credits": "Credits",
+                    "issuances": "Issuances",
                     "status": "Status"
                 },
                 "noProjects": "No projects found under this policy."

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -511,7 +511,7 @@
                     "project": "Proyecto",
                     "country": "País",
                     "registry": "Registro",
-                    "credits": "Créditos",
+                    "issuances": "Emisiones",
                     "status": "Estado"
                 },
                 "noProjects": "No se encontraron proyectos bajo esta política."

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -1525,7 +1525,7 @@ const lifecycleSummary = computed(() => {
                 <th class="text-left py-2.5 px-5 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('methodologies.detail.linkedProjects.columns.project') }}</th>
                 <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('methodologies.detail.linkedProjects.columns.country') }}</th>
                 <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('methodologies.detail.linkedProjects.columns.registry') }}</th>
-                <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('methodologies.detail.linkedProjects.columns.credits') }}</th>
+                <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('methodologies.detail.linkedProjects.columns.issuances') }}</th>
                 <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ $t('methodologies.detail.linkedProjects.columns.status') }}</th>
               </tr>
             </thead>
@@ -1553,7 +1553,7 @@ const lifecycleSummary = computed(() => {
                   {{ p.registry || '—' }}
                 </td>
                 <td class="py-3 px-4 text-right tabular-nums text-sm font-medium text-foreground">
-                  {{ p.credits != null ? p.credits.toLocaleString() : '—' }}
+                  {{ p.issuanceCount != null ? p.issuanceCount.toLocaleString() : '—' }}
                 </td>
                 <td class="py-3 px-4">
                   <span

--- a/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
@@ -246,60 +246,76 @@ export class PgMethodologyRepository extends MethodologyRepository {
 
         const row = rawRows[0];
 
-        // Resolve the topic IDs to look up CREDIT rows.
-        // businessData.policyTopicId is the Guardian policy topic; relatedTopicId is the
-        // instance topic stored on the business_view row. We union both and deduplicate
-        // so that credits linked to either topic are captured.
-        const policyTopicId = (row.businessData as Record<string, any> | null)?.['topicId'] as string | null;
         const instanceTopicId = row.relatedTopicId;
-        const topicIds = [...new Set([policyTopicId, instanceTopicId].filter((t): t is string => !!t))];
 
+        // Fetch MintToken VCs for all projects under this methodology instance via
+        // project_mint_link. We join through business_view PROJECT rows whose
+        // businessData->>'instanceTopicId' matches this methodology's relatedTopicId
+        // (the same condition mv_methodology_stats uses for instance_project_count),
+        // then pull each project's attributed mints. This keeps supply figures
+        // consistent with the project detail view and the credits list page.
         let issuances: IssuanceRow[] = [];
-        if (topicIds.length > 0) {
-            const placeholders = topicIds.map((_, i) => `$${i + 1}`).join(', ');
-            const creditRows: Array<{
-                tokenId: string | null;
-                name: string | null;
-                symbol: string | null;
-                type: string | null;
-                supply: string | null;
-                mintDate: Date | null;
-                raw_vc: Record<string, any> | null;
+        if (instanceTopicId) {
+            const mintRows: Array<{
+                token_id: string | null;
+                amount: number | null;
+                mint_date: Date | null;
+                documents: Record<string, any> | null;
             }> = await this.dataSource.query(
-                `
-                SELECT * FROM (
-                    SELECT DISTINCT ON (COALESCE(tc."tokenId", bv."businessData"->>'tokenId'))
-                        COALESCE(tc."tokenId", bv."businessData"->>'tokenId') AS "tokenId",
-                        COALESCE(tc.name,      bv."displayName")              AS name,
-                        COALESCE(tc.symbol,    bv."businessData"->>'symbol')  AS symbol,
-                        tc.type,
-                        tc."totalSupply"                                      AS supply,
-                        bv."createdAt"                                        AS "mintDate",
-                        m.documents                                           AS raw_vc
-                    FROM business_view bv
-                    LEFT JOIN token_cache tc
-                        ON tc."tokenId" = bv."businessData"->>'tokenId'
-                    LEFT JOIN message m
-                        ON m."consensusTimestamp" = bv."sourceTimestamp"
-                    WHERE bv."viewType" = 'CREDIT'
-                      AND bv."relatedTopicId" IN (${placeholders})
-                    ORDER BY COALESCE(tc."tokenId", bv."businessData"->>'tokenId'),
-                             bv."createdAt" DESC
-                ) deduped
-                ORDER BY "mintDate" ASC
-                `,
-                topicIds,
+                `SELECT
+                    pml.token_id,
+                    pml.amount,
+                    pml.mint_date,
+                    m.documents
+                 FROM project_mint_link pml
+                 JOIN business_view proj
+                     ON proj."projectKey" = pml.project_key
+                    AND proj."viewType" = 'PROJECT'
+                    AND proj."businessData"->>'instanceTopicId' = $1
+                 JOIN message m ON m."consensusTimestamp" = pml.mint_consensus_timestamp
+                 WHERE pml.token_id IS NOT NULL
+                 ORDER BY pml.mint_date ASC NULLS LAST`,
+                [instanceTopicId],
             );
 
-            issuances = creditRows.map(r => ({
-                tokenId: r.tokenId ?? '',
-                name: r.name ?? null,
-                symbol: r.symbol ?? null,
-                type: r.type ?? null,
-                supply: r.supply != null ? parseFloat(r.supply) : 0,
-                mintDate: r.mintDate ? r.mintDate.toISOString().split('T')[0] : null,
-                rawVc: r.raw_vc ?? null,
-            }));
+            if (mintRows.length > 0) {
+                // Aggregate minted amount per token; keep last MintToken VC as rawVc
+                const mintsByToken = new Map<string, { total: number; mintDate: Date | null; rawVc: Record<string, any> | null }>();
+                for (const r of mintRows) {
+                    if (!r.token_id) continue;
+                    const existing = mintsByToken.get(r.token_id) ?? { total: 0, mintDate: r.mint_date, rawVc: r.documents };
+                    existing.total += r.amount != null ? Number(r.amount) : 0;
+                    existing.rawVc = r.documents;
+                    mintsByToken.set(r.token_id, existing);
+                }
+
+                const distinctTokenIds = Array.from(mintsByToken.keys());
+                const tokenMeta: Array<{
+                    tokenId: string;
+                    name: string | null;
+                    symbol: string | null;
+                    type: string | null;
+                }> = await this.dataSource.query(
+                    `SELECT "tokenId", name, symbol, type
+                     FROM token_cache
+                     WHERE "tokenId" = ANY($1::varchar[])`,
+                    [distinctTokenIds],
+                );
+                const metaMap = new Map(tokenMeta.map(t => [t.tokenId, t]));
+
+                issuances = [...mintsByToken.entries()].map(([tokenId, data]) => {
+                    const meta = metaMap.get(tokenId);
+                    return {
+                        tokenId,
+                        name: meta?.name ?? null,
+                        symbol: meta?.symbol ?? null,
+                        type: meta?.type ?? null,
+                        supply: data.total,
+                        mintDate: data.mintDate ? data.mintDate.toISOString().split('T')[0] : null,
+                        rawVc: data.rawVc,
+                    };
+                });
+            }
         }
 
         // Aggregate lifecycle stats for NFT tokens: total minted (all serials) and

--- a/sustainable-explorer/src/api/repositories/pg-project.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-project.repository.ts
@@ -290,6 +290,24 @@ export class PgProjectRepository extends ProjectRepository {
             // instance topic only. We intentionally exclude policyTopicId here because
             // multiple projects share the same policy topic; including it would return
             // credits belonging to sibling projects under the same Guardian policy.
+            //
+            // Guard: only use this fallback when this is the sole PROJECT in the topic.
+            // For grouped topics (multiple projects sharing one instance topic) the
+            // linker skips unresolvable mints to avoid misattribution — the fallback
+            // must apply the same rule, otherwise it cross-attributes every sibling's
+            // credits to this project. Mirrors mint-project-linker.ts fallback guard.
+            const siblingCountRows: Array<{ count: string }> = await this.dataSource.query(
+                `SELECT COUNT(*)::text AS count
+                 FROM business_view
+                 WHERE "viewType" = 'PROJECT'
+                   AND "relatedTopicId" = $1`,
+                [instanceTopicId],
+            );
+            const siblingCount = parseInt(siblingCountRows[0]?.count ?? '0', 10);
+
+            if (siblingCount > 1) {
+                // Shared topic — cannot safely attribute credits to this project alone.
+            } else {
             const creditRows: Array<{
                 tokenId: string | null;
                 name: string | null;
@@ -347,6 +365,7 @@ export class PgProjectRepository extends ProjectRepository {
             for (const i of issuances) {
                 if (i.type !== 'NON_FUNGIBLE_UNIQUE') totalIssued += i.supply;
             }
+            } // end else (siblingCount === 1)
         }
 
         const totalActive = totalIssued - totalRetired;

--- a/sustainable-explorer/src/shared/materialized-views/methodology-stats.mv.ts
+++ b/sustainable-explorer/src/shared/materialized-views/methodology-stats.mv.ts
@@ -38,18 +38,25 @@ export const MV_METHODOLOGY_STATS_CREATE_SQL = `
               AND p."businessData"->>'instanceTopicId' = mb."relatedTopicId"
         ), 0)::bigint AS instance_project_count,
         COALESCE((
-            SELECT COUNT(DISTINCT bv."businessData"->>'tokenId')
-            FROM business_view bv
-            WHERE bv."viewType" = 'CREDIT'
-              AND bv."relatedTopicId" IN (mb.policy_topic_id, mb."relatedTopicId")
-              AND bv."businessData"->>'tokenId' IS NOT NULL
+            SELECT COUNT(DISTINCT pml.token_id)
+            FROM project_mint_link pml
+            JOIN business_view proj
+                ON proj."projectKey" = pml.project_key
+               AND proj."viewType" = 'PROJECT'
+               AND (
+                   proj."businessData"->>'instanceTopicId' = mb."relatedTopicId"
+                   OR proj."businessData"->>'policyTopicId' = mb.policy_topic_id
+               )
+            WHERE pml.token_id IS NOT NULL
         ), 0)::bigint AS issuance_count,
         COALESCE((
-            SELECT COUNT(DISTINCT bv."businessData"->>'tokenId')
-            FROM business_view bv
-            WHERE bv."viewType" = 'CREDIT'
-              AND bv."relatedTopicId" = mb."relatedTopicId"
-              AND bv."businessData"->>'tokenId' IS NOT NULL
+            SELECT COUNT(DISTINCT pml.token_id)
+            FROM project_mint_link pml
+            JOIN business_view proj
+                ON proj."projectKey" = pml.project_key
+               AND proj."viewType" = 'PROJECT'
+               AND proj."businessData"->>'instanceTopicId' = mb."relatedTopicId"
+            WHERE pml.token_id IS NOT NULL
         ), 0)::bigint AS instance_issuance_count,
         COALESCE((
             SELECT COUNT(DISTINCT entry_iri)


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-70

Fixes incorrect linked issuances in both the project and methodology detail views. The root cause was that both views queried business_view CREDIT (Hedera Token messages) while the credits list page and all other stats already used MintToken VCs via project_mint_link. For projects sharing a topic, the business_view CREDIT fallback had no guard and would cross-attribute sibling credits — fixed by adding a sibling-count check. For methodology, the business_view CREDIT query was replaced entirely with a project_mint_link join through the methodology's projects. The mv_methodology_stats issuance counts were updated to match the same source.

Instead of CREDITS column replaced it with issuance count column in linked projects section