### PR TITLE
feat: add searchable country filter to project listings and update localization

### DIFF
--- a/sustainable-explorer/frontend/components/shared/FilterBar.vue
+++ b/sustainable-explorer/frontend/components/shared/FilterBar.vue
@@ -10,6 +10,7 @@ export interface FilterOption {
     label: string;
     options: { value: string; label: string; icon?: string }[];
     multiSelect?: boolean;
+    searchable?: boolean;
     type?: 'select' | 'daterange' | 'yearrange' | 'numrange';
 }
 
@@ -36,6 +37,17 @@ const emit = defineEmits<{
 
 const openDropdown = ref<string | null>(null);
 const dropdownRefs = ref<Record<string, HTMLElement | null>>({});
+const dropdownSearch = ref<Record<string, string>>({});
+
+watch(openDropdown, (_newKey, oldKey) => {
+    if (oldKey) dropdownSearch.value[oldKey] = '';
+});
+
+function filteredOptions(filter: FilterOption): FilterOption['options'] {
+    const q = (dropdownSearch.value[filter.key] ?? '').toLowerCase().trim();
+    if (!q) return filter.options;
+    return filter.options.filter(o => o.label.toLowerCase().includes(q));
+}
 
 function toggleDropdown(key: string) {
     openDropdown.value = openDropdown.value === key ? null : key;
@@ -442,17 +454,34 @@ if (import.meta.client) {
                 <!-- Single-select dropdown -->
                 <div
                     v-else-if="openDropdown === filter.key"
-                    :class="[dropdownClass, 'absolute top-full mt-1 z-[9999] min-w-[10rem] max-w-[16rem] max-h-64 overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 shadow-md text-left']"
+                    :class="[dropdownClass, 'absolute top-full mt-1 z-[9999] min-w-[10rem] max-w-[16rem] rounded-md border bg-popover shadow-md text-left']"
                 >
-                    <button
-                        v-for="opt in [{ value: 'all', label: `${t('common.all')} ${filter.label}` }, ...filter.options]"
-                        :key="opt.value"
-                        class="flex w-full items-center justify-start text-left rounded-sm px-2.5 py-1.5 text-xs transition-colors hover:bg-accent"
-                        :class="(activeFilters[filter.key] || 'all') === opt.value ? 'font-medium text-foreground' : 'text-muted-foreground'"
-                        @click="selectFilter(filter.key, opt.value)"
-                    >
-                        <span class="min-w-0 break-words">{{ opt.label }}</span>
-                    </button>
+                    <!-- Inline search for searchable dropdowns -->
+                    <div v-if="filter.searchable" class="p-1 border-b border-border">
+                        <div class="relative">
+                            <Search class="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+                            <input
+                                v-model="dropdownSearch[filter.key]"
+                                type="text"
+                                :placeholder="$t('common.searchEllipsis')"
+                                class="h-7 w-full rounded-sm border border-input bg-background pl-6 pr-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                                @click.stop
+                                @keydown.esc.stop="openDropdown = null"
+                            />
+                        </div>
+                    </div>
+                    <!-- Options list -->
+                    <div :class="['p-1 overflow-y-auto overflow-x-hidden', filter.searchable ? 'max-h-52' : 'max-h-64']">
+                        <button
+                            v-for="opt in [{ value: 'all', label: `${t('common.all')} ${filter.label}` }, ...filteredOptions(filter)]"
+                            :key="opt.value"
+                            class="flex w-full items-center justify-start text-left rounded-sm px-2.5 py-1.5 text-xs transition-colors hover:bg-accent"
+                            :class="(activeFilters[filter.key] || 'all') === opt.value ? 'font-medium text-foreground' : 'text-muted-foreground'"
+                            @click="selectFilter(filter.key, opt.value)"
+                        >
+                            <span class="min-w-0 break-words">{{ opt.label }}</span>
+                        </button>
+                    </div>
                 </div>
             </Transition>
         </div>

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -234,6 +234,7 @@
         "filters": {
             "status": "Status",
             "registry": "Registry",
+            "country": "Country",
             "vintage": "Vintage",
             "sector": "Sector",
             "sectoralScope": "Sectoral Scope",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -234,6 +234,7 @@
         "filters": {
             "status": "Estado",
             "registry": "Registro",
+            "country": "País",
             "vintage": "Añada",
             "sector": "Sector",
             "sectoralScope": "Alcance sectorial",

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -56,7 +56,14 @@ const allProjects = computed(() => projects.value.map(p => ({
     retired: retiredByProject.value[p.id] || 0,
     retiredFormatted: formatCredits(retiredByProject.value[p.id] || 0),
     methodologyLong: getMethodologyLongName(p.methodologyId, p.methodology),
+    // Override country with the resolved display name so filters and sorting
+    // use the same value that appears in the column (not raw coordinates).
+    country: displayCountry(p) ?? '',
 })));
+
+const countryFilterOptions = computed(() =>
+    [...new Set(allProjects.value.map(p => p.country).filter(Boolean))].sort(),
+);
 
 const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters, applyPreset } =
     useFilteredPagination(allProjects, {
@@ -91,6 +98,12 @@ const filters = computed<FilterOption[]>(() => [
         key: 'registry',
         label: t('projects.filters.registry'),
         options: filterOptions.value.registries.map(r => ({ value: r, label: r })),
+    },
+    {
+        key: 'country',
+        label: t('projects.filters.country'),
+        searchable: true,
+        options: countryFilterOptions.value.map(c => ({ value: c, label: c })),
     },
     {
         key: 'vintage',


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-81


Added a Country dropdown filter to the Projects page with inline search support for when the list is large. The filter options and filtering logic both use the same resolved display names shown in the Country column (e.g. "Uganda" instead of raw coordinates), staying in sync as geocoding results arrive. Filter selection persists across pagination and sorting via the existing URL query param system.