### PR TITLE
fix: adjust Leaflet map settings and override container background for better visibility

### DIFF
--- a/sustainable-explorer/frontend/assets/css/main.css
+++ b/sustainable-explorer/frontend/assets/css/main.css
@@ -130,3 +130,8 @@ pre {
         scroll-behavior: auto !important;
     }
 }
+
+/* Override Leaflet's default #ddd container background to match the CARTO light tile ocean color */
+.leaflet-container {
+    background: #D4DADC !important;
+}

--- a/sustainable-explorer/frontend/components/registry/RegistryProjectsMap.client.vue
+++ b/sustainable-explorer/frontend/components/registry/RegistryProjectsMap.client.vue
@@ -44,6 +44,9 @@ onMounted(async () => {
         center: [20, 0],
         zoomControl: true,
         scrollWheelZoom: false,
+        minZoom: 2,
+        maxBounds: [[-85, -180], [85, 180]],
+        maxBoundsViscosity: 1.0,
     });
 
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
@@ -71,6 +74,7 @@ onUnmounted(() => {
     markerLayer = null;
 });
 </script>
+
 
 <template>
     <div ref="mapContainer" class="h-full w-full rounded-lg" />

--- a/sustainable-explorer/frontend/components/shared/ProjectLocationMap.client.vue
+++ b/sustainable-explorer/frontend/components/shared/ProjectLocationMap.client.vue
@@ -20,6 +20,9 @@ onMounted(() => {
         zoom: props.approximate ? 5 : 8,
         zoomControl: true,
         scrollWheelZoom: true,
+        minZoom: 2,
+        maxBounds: [[-85, -180], [85, 180]],
+        maxBoundsViscosity: 1.0,
     });
 
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
@@ -45,6 +48,7 @@ onUnmounted(() => {
     map = null;
 });
 </script>
+
 
 <template>
     <div class="relative h-full w-full">

--- a/sustainable-explorer/frontend/components/shared/ProjectMap.client.vue
+++ b/sustainable-explorer/frontend/components/shared/ProjectMap.client.vue
@@ -62,6 +62,8 @@ async function initMap() {
         scrollWheelZoom: true,
         minZoom: 2,
         maxZoom: 10,
+        maxBounds: [[-85, -180], [85, 180]],
+        maxBoundsViscosity: 1.0,
     });
 
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png', {
@@ -183,6 +185,7 @@ watch(() => props.points, () => {
     renderPoints();
 }, { deep: true });
 </script>
+
 
 <template>
     <div ref="mapContainer" class="h-full w-full" />

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -74,9 +74,9 @@ const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, act
     });
 
 const presets = computed(() => [
-    { label: t('projects.presets.goldStandard'), filters: { registry: 'Gold Standard' } },
-    { label: t('projects.presets.sdg13'), filters: { sdgs: '13' } },
-    { label: t('projects.presets.vintage2024'), filters: { vintage: '2024|2024' } },
+    { label: t('projects.presets.goldStandard'), filters: { registry: 'Gold Standard' } as Record<string, string> },
+    { label: t('projects.presets.sdg13'), filters: { sdgs: '13' } as Record<string, string> },
+    { label: t('projects.presets.vintage2024'), filters: { vintage: '2024|2024' } as Record<string, string> },
 ]);
 
 // Summary statistics for filtered results
@@ -175,7 +175,7 @@ const statusColor: Record<string, string> = {
                     v-for="preset in presets"
                     :key="preset.label"
                     class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                    @click="applyPreset({ search: preset.search, filters: preset.filters } as any)"
+                    @click="applyPreset({ filters: preset.filters })"
                 >
                     {{ preset.label }}
                 </button>
@@ -277,8 +277,8 @@ const statusColor: Record<string, string> = {
                                 <span v-else class="text-xs">—</span>
                             </td>
                             <td class="py-3 px-4 text-muted-foreground text-xs break-words">{{ p.registry }}</td>
-                            <td class="py-3 px-4">
-                                <span class="block text-xs bg-muted rounded px-1.5 py-0.5 cursor-default truncate">{{ p.methodology }}</span>
+                            <td class="py-3 px-4 max-w-0">
+                                <span class="block text-xs bg-muted rounded px-1.5 py-0.5 cursor-default break-words">{{ p.methodology }}</span>
                             </td>
                             <td class="py-3 px-4">
                                 <span class="block text-xs text-muted-foreground cursor-default truncate">{{ p.sector }}</span>


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-56

Maps — All three Leaflet maps (ProjectLocationMap, ProjectMap, RegistryProjectsMap) now have a minimum zoom limit and hard pan boundaries, so users can't scroll into the empty gray space beyond the world edges. The background color of that empty area also now matches the map tiles seamlessly.