### PR TITLE
fix: unify search and sync filters to URL on methodologies and registries pages

### DIFF
--- a/sustainable-explorer/frontend/components/shared/FilterBar.vue
+++ b/sustainable-explorer/frontend/components/shared/FilterBar.vue
@@ -210,7 +210,7 @@ function getActiveLabel(filter: FilterOption): string {
         return `${t('common.to')} ${formatShortDate(to)}`;
     }
     const active = props.activeFilters[filter.key];
-    if (!active || active === 'all') return filter.label;
+    if (!active || active === 'all') return filter.multiSelect ? filter.label : t('common.all');
     if (filter.multiSelect) {
         const count = active.split(',').length;
         return `${filter.label} (${count})`;
@@ -286,33 +286,49 @@ if (import.meta.client) {
                 <!-- Multi-select dropdown -->
                 <div
                     v-if="openDropdown === filter.key && filter.multiSelect"
-                    :class="[dropdownClass, 'absolute top-full mt-1 z-[9999] min-w-[12rem] max-w-[16rem] max-h-64 overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 shadow-md text-left']"
+                    :class="[dropdownClass, 'absolute top-full mt-1 z-[9999] min-w-[12rem] max-w-[16rem] rounded-md border bg-popover shadow-md text-left']"
                 >
-                    <button
-                        class="flex w-full items-center justify-start text-left rounded-sm px-2.5 py-1.5 text-xs transition-colors hover:bg-accent text-muted-foreground"
-                        @click="emit('filter', filter.key, 'all')"
-                    >
-                        {{ $t('common.clearSelection') }}
-                    </button>
-                    <div class="my-1 border-t" />
-                    <button
-                        v-for="opt in filter.options"
-                        :key="opt.value"
-                        class="flex w-full items-center justify-start text-left gap-2 rounded-sm px-2.5 py-1.5 text-xs transition-colors hover:bg-accent"
-                        :class="isMultiSelected(filter.key, opt.value) ? 'font-medium text-foreground' : 'text-muted-foreground'"
-                        @click.stop="toggleMultiSelect(filter.key, opt.value)"
-                    >
-                        <span
-                            class="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border transition-colors"
-                            :class="isMultiSelected(filter.key, opt.value) ? 'bg-primary border-primary' : 'border-input'"
+                    <!-- Inline search for searchable multi-select dropdowns -->
+                    <div v-if="filter.searchable" class="p-1 border-b border-border">
+                        <div class="relative">
+                            <Search class="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+                            <input
+                                v-model="dropdownSearch[filter.key]"
+                                type="text"
+                                :placeholder="$t('common.searchEllipsis')"
+                                class="h-7 w-full rounded-sm border border-input bg-background pl-6 pr-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                                @click.stop
+                                @keydown.esc.stop="openDropdown = null"
+                            />
+                        </div>
+                    </div>
+                    <div class="p-1 max-h-64 overflow-y-auto overflow-x-hidden">
+                        <button
+                            class="flex w-full items-center justify-start text-left rounded-sm px-2.5 py-1.5 text-xs transition-colors hover:bg-accent text-muted-foreground"
+                            @click="emit('filter', filter.key, 'all')"
                         >
-                            <svg v-if="isMultiSelected(filter.key, opt.value)" class="h-2.5 w-2.5 text-primary-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
-                            </svg>
-                        </span>
-                        <img v-if="opt.icon" :src="opt.icon" :alt="opt.label" class="h-4 w-4 rounded-sm shrink-0" />
-                        <span class="text-left whitespace-normal break-words">{{ opt.label }}</span>
-                    </button>
+                            {{ $t('common.clearSelection') }}
+                        </button>
+                        <div class="my-1 border-t" />
+                        <button
+                            v-for="opt in filteredOptions(filter)"
+                            :key="opt.value"
+                            class="flex w-full items-center justify-start text-left gap-2 rounded-sm px-2.5 py-1.5 text-xs transition-colors hover:bg-accent"
+                            :class="isMultiSelected(filter.key, opt.value) ? 'font-medium text-foreground' : 'text-muted-foreground'"
+                            @click.stop="toggleMultiSelect(filter.key, opt.value)"
+                        >
+                            <span
+                                class="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border transition-colors"
+                                :class="isMultiSelected(filter.key, opt.value) ? 'bg-primary border-primary' : 'border-input'"
+                            >
+                                <svg v-if="isMultiSelected(filter.key, opt.value)" class="h-2.5 w-2.5 text-primary-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
+                                </svg>
+                            </span>
+                            <img v-if="opt.icon" :src="opt.icon" :alt="opt.label" class="h-4 w-4 rounded-sm shrink-0" />
+                            <span class="text-left whitespace-normal break-words">{{ opt.label }}</span>
+                        </button>
+                    </div>
                 </div>
 
                 <!-- Numeric range dropdown -->
@@ -473,7 +489,7 @@ if (import.meta.client) {
                     <!-- Options list -->
                     <div :class="['p-1 overflow-y-auto overflow-x-hidden', filter.searchable ? 'max-h-52' : 'max-h-64']">
                         <button
-                            v-for="opt in [{ value: 'all', label: `${t('common.all')} ${filter.label}` }, ...filteredOptions(filter)]"
+                            v-for="opt in [{ value: 'all', label: t('common.all') }, ...filteredOptions(filter)]"
                             :key="opt.value"
                             class="flex w-full items-center justify-start text-left rounded-sm px-2.5 py-1.5 text-xs transition-colors hover:bg-accent"
                             :class="(activeFilters[filter.key] || 'all') === opt.value ? 'font-medium text-foreground' : 'text-muted-foreground'"

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -244,7 +244,9 @@
         "presets": {
             "goldStandard": "Gold Standard",
             "sdg13": "SDG 13: Climate Action",
-            "vintage2024": "Vintage 2024"
+            "vintage2022": "Vintage 2022",
+            "issuingEnergy": "Issuing Energy",
+            "glycolRecycling": "Glycol Recycling"
         },
         "notFound": "Project not found",
         "details": {
@@ -311,7 +313,7 @@
     "credits": {
         "title": "Issuances",
         "subtitle": "Tokens issued on Hedera",
-        "searchPlaceholder": "Search by name, symbol, token ID...",
+        "searchPlaceholder": "Search issuances...",
         "quickFilters": "Quick filters:",
         "presets": {
             "fungible": "Fungible tokens",
@@ -602,6 +604,7 @@
     "registries": {
         "title": "Registries",
         "subtitle": "Standard Registries operating on the Guardian network",
+        "searchPlaceholder": "Search registries...",
         "noMatch": "No registries match your filters",
         "columns": {
             "name": "Name",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -244,7 +244,9 @@
         "presets": {
             "goldStandard": "Gold Standard",
             "sdg13": "ODS 13: Acción por el clima",
-            "vintage2024": "Añada 2024"
+            "vintage2022": "Añada 2022",
+            "issuingEnergy": "Emitiendo Energía",
+            "glycolRecycling": "Reciclaje de Glicol"
         },
         "notFound": "Proyecto no encontrado",
         "details": {
@@ -306,7 +308,7 @@
     "credits": {
         "title": "Emisiones",
         "subtitle": "Tokens emitidos en Hedera",
-        "searchPlaceholder": "Buscar por nombre, símbolo, ID de token...",
+        "searchPlaceholder": "Buscar emisiones...",
         "quickFilters": "Filtros rápidos:",
         "presets": {
             "fungible": "Tokens fungibles",
@@ -597,6 +599,7 @@
     "registries": {
         "title": "Registros",
         "subtitle": "Registros Estándar que operan en la red de Guardian",
+        "searchPlaceholder": "Buscar registros...",
         "noMatch": "Ningún registro coincide con tus filtros",
         "columns": {
             "name": "Nombre",

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -92,8 +92,8 @@ const visibleFilterOptions = computed(() => ({
 }));
 
 const filters = computed<FilterOption[]>(() => [
-    { key: 'type', label: t('credits.filters.tokenType'), options: visibleFilterOptions.value.types.map(x => ({ value: x, label: x })) },
-    { key: 'registry', label: t('credits.filters.registry'), options: visibleFilterOptions.value.registries.map(r => ({ value: r, label: r })) },
+    { key: 'type', label: t('credits.filters.tokenType'), multiSelect: true, options: visibleFilterOptions.value.types.map(x => ({ value: x, label: x })) },
+    { key: 'registry', label: t('credits.filters.registry'), multiSelect: true, searchable: true, options: visibleFilterOptions.value.registries.map(r => ({ value: r, label: r })) },
     { key: 'supply', label: t('credits.filters.supply'), type: 'numrange', options: [] },
     { key: 'mintDate', label: t('credits.filters.mintDate'), type: 'daterange', options: [] },
 ]);
@@ -168,7 +168,7 @@ const typeColor: Record<string, string> = { Fungible: 'bg-stat-blue/10 text-stat
                     v-for="preset in presets"
                     :key="preset.label"
                     class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                    @click="applyPreset({ search: preset.search, filters: preset.filters } as any)"
+                    @click="applyPreset({ filters: preset.filters })"
                 >
                     {{ preset.label }}
                 </button>

--- a/sustainable-explorer/frontend/pages/methodologies/index.vue
+++ b/sustainable-explorer/frontend/pages/methodologies/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { BookOpen, Copy, Check } from "lucide-vue-next";
-import type { FilterField } from "~/components/shared/DataFilters.vue";
+import { useDebounceFn } from '@vueuse/core';
+import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import type {
   MethodologySortKey,
   MethodologySortDir,
@@ -38,24 +39,46 @@ const columnToApiSort: Record<ColumnKey, MethodologySortKey | null> = {
 
 // Reactive query state
 const route = useRoute();
+const router = useRouter();
 const initialFilters: Record<string, any> = {};
 if (route.query.registryDid && typeof route.query.registryDid === "string") {
   initialFilters.registryDid = route.query.registryDid;
 }
-// Dashboard top-registries row links here with registryName=<display name>
-// so the user lands on the methodologies list pre-filtered to that registry.
 if (route.query.registryName && typeof route.query.registryName === "string") {
   initialFilters.registryName = route.query.registryName;
 }
-if (route.query.name && typeof route.query.name === "string") {
-  initialFilters.name = route.query.name;
+if (route.query.decodeStatus && typeof route.query.decodeStatus === "string") {
+  initialFilters.decodeStatus = route.query.decodeStatus;
 }
 const filters = ref<Record<string, any>>(initialFilters);
 const currentPage = ref(1);
 const pageSize = ref(10);
 
-// Placeholder search ref kept for the composable signature.
-const searchQuery = ref("");
+// Unified search — debounced so each keystroke doesn't fire an API request.
+const localSearch = ref(
+  typeof route.query.search === "string" ? route.query.search :
+  typeof route.query.name === "string" ? route.query.name : ""
+);
+const searchQuery = ref(localSearch.value.trim());
+const debouncedSearch = useDebounceFn((val: string) => {
+  searchQuery.value = val.trim();
+}, 300);
+
+function syncToUrl() {
+  const q: Record<string, string> = { ...(route.query as Record<string, string>) };
+  const search = localSearch.value.trim();
+  if (search) q.search = search; else delete q.search;
+  delete q.name;
+  if (filters.value.registryName) q.registryName = String(filters.value.registryName); else delete q.registryName;
+  if (filters.value.decodeStatus) q.decodeStatus = String(filters.value.decodeStatus); else delete q.decodeStatus;
+  if (filters.value.registryDid) q.registryDid = String(filters.value.registryDid); else delete q.registryDid;
+  router.replace({ query: q });
+}
+
+watch(localSearch, (val) => {
+  debouncedSearch(val);
+  syncToUrl();
+});
 
 // Fetch the registries list once so the registry filter can render as a
 // labeled dropdown (registry name + topic id) rather than a free-text DID.
@@ -64,6 +87,7 @@ const registriesLimit = ref(500);
 const registriesSearch = ref('');
 const registriesSortBy = ref(null);
 const registriesSortDir = ref(null);
+const registriesFilters = ref({ hideEmpty: true });
 const { data: registriesData } = useRegistriesApi({
   page: registriesPage,
   limit: registriesLimit,
@@ -71,76 +95,60 @@ const { data: registriesData } = useRegistriesApi({
   network: computed(() => network.value),
   sortBy: registriesSortBy as any,
   sortDir: registriesSortDir as any,
+  filters: registriesFilters,
 });
 
-const registryDidOptions = computed(() => {
-  // Surface the registry's topic ID (e.g. 0.0.3054097) as the primary label
-  // — that's the "Registry ID" the rest of the UI shows. The registry name
-  // sits in parens for readability. The submitted value is still the DID,
-  // because that's what the methodologies endpoint filters by.
-  // DataFilters auto-prepends an empty `<option value="">{{ placeholder }}</option>`
-  // for select fields, so we don't include the "All" option here.
-  return (registriesData.value?.data ?? [])
-    .filter((r: any) => r.did && r.relatedTopicId)
-    .map((r: any) => ({
-      value: r.did as string,
-      label: r.name
-        ? `${r.relatedTopicId} — ${r.name}`
-        : (r.relatedTopicId as string),
-    }))
-    .sort((a, b) => a.label.localeCompare(b.label));
+const registryNameOptions = computed(() => {
+    // Deduplicate by name — a single registry can appear under multiple DIDs
+    // (policy versions). Using the name as both value and key collapses them.
+    const names = new Set<string>();
+    for (const r of (registriesData.value?.data ?? [])) {
+        if (r.name) names.add(r.name);
+    }
+    return [...names]
+        .sort((a, b) => a.localeCompare(b))
+        .map(n => ({ value: n, label: n }));
 });
 
-const filterFields = computed<FilterField[]>(() => [
-  {
-    key: "name",
-    label: t("methodologies.filters.name"),
-    type: "text",
-    placeholder: t("methodologies.filters.namePlaceholder"),
-    width: "md",
-  },
-  {
-    key: "registryDid",
-    label: t("methodologies.filters.registryId"),
-    type: "select",
-    width: "md",
-    placeholder: t("methodologies.filters.registryAll"),
-    options: registryDidOptions.value,
-  },
-  {
-    key: "registryName",
-    label: t("methodologies.filters.registryName"),
-    type: "text",
-    placeholder: t("methodologies.filters.registryNamePlaceholder"),
-    width: "md",
-  },
-  {
-    key: "id",
-    label: t("methodologies.filters.id"),
-    type: "text",
-    placeholder: "0.0.xxxx",
-    width: "sm",
-  },
-  {
-    key: "description",
-    label: t("methodologies.filters.description"),
-    type: "text",
-    width: "md",
-  },
-  {
-    key: "decodeStatus",
-    label: t("methodologies.filters.decoded"),
-    type: "select",
-    width: "sm",
-    options: [
-      { value: "", label: t("methodologies.filters.decodedAll") },
-      { value: "success", label: t("methodologies.decodeStatus.success") },
-      { value: "failed", label: t("methodologies.decodeStatus.failed") },
-      { value: "pending", label: t("methodologies.decodeStatus.pending") },
-      { value: "unknown", label: t("methodologies.decodeStatus.unknown") },
-    ],
-  },
+const barFilters = computed<FilterOption[]>(() => [
+    {
+        key: 'registryName',
+        label: t('methodologies.filters.registry'),
+        multiSelect: true,
+        searchable: true,
+        options: registryNameOptions.value,
+    },
+    {
+        key: 'decodeStatus',
+        label: t('methodologies.filters.decoded'),
+        options: [
+            { value: 'success', label: t('methodologies.decodeStatus.success') },
+            { value: 'failed', label: t('methodologies.decodeStatus.failed') },
+            { value: 'pending', label: t('methodologies.decodeStatus.pending') },
+            { value: 'unknown', label: t('methodologies.decodeStatus.unknown') },
+        ],
+    },
 ]);
+
+const activeFilterRecord = computed<Record<string, string>>(() => {
+    const r: Record<string, string> = {};
+    if (filters.value.registryName) r.registryName = String(filters.value.registryName);
+    if (filters.value.decodeStatus) r.decodeStatus = String(filters.value.decodeStatus);
+    return r;
+});
+
+function setMethodologyFilter(key: string, value: string) {
+    const next = { ...filters.value };
+    if (!value || value === 'all') delete next[key];
+    else next[key] = value;
+    filters.value = next;
+}
+
+function clearMethodologyFilters() {
+    filters.value = {};
+    localSearch.value = '';
+    searchQuery.value = '';
+}
 
 const sortKey = ref<ColumnKey | null>("createdAt");
 const sortDir = ref<SortDirection>("desc");
@@ -222,6 +230,7 @@ watch(
   filters,
   () => {
     currentPage.value = 1;
+    syncToUrl();
   },
   { deep: true },
 );
@@ -303,7 +312,16 @@ const skeletonRows = computed(() =>
     </div>
 
     <div class="px-6 pb-3">
-      <DataFilters v-model="filters" :fields="filterFields" />
+      <FilterBar
+        v-model="localSearch"
+        :filters="barFilters"
+        :active-filters="activeFilterRecord"
+        :result-count="totalCount"
+        :total-count="statTotal"
+        :search-placeholder="$t('methodologies.searchPlaceholder')"
+        @filter="setMethodologyFilter"
+        @clear="clearMethodologyFilters"
+      />
     </div>
 
     <div class="px-6 pb-6">

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -74,10 +74,18 @@ const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, act
     });
 
 const presets = computed(() => [
-    { label: t('projects.presets.goldStandard'), filters: { registry: 'Gold Standard' } },
-    { label: t('projects.presets.sdg13'), filters: { sdgs: '13' } },
-    { label: t('projects.presets.vintage2024'), filters: { vintage: '2024|2024' } },
+    { label: t('projects.presets.goldStandard'), filters: { registry: 'Gold Standard' } as Record<string, string> },
+    { label: t('projects.presets.sdg13'), filters: { sdgs: '13' } as Record<string, string> },
+    { label: t('projects.presets.vintage2022'), filters: { vintage: '2022|2022' } as Record<string, string> },
+    { label: t('projects.presets.issuingEnergy'), filters: { status: 'Issuing', sector: 'Energy' } as Record<string, string> },
+    { label: t('projects.presets.glycolRecycling'), filters: { sector: 'Glycol Recycling' } as Record<string, string> },
 ]);
+
+function isPresetActive(preset: { filters: Record<string, string> }): boolean {
+    const af = activeFilters.value;
+    const entries = Object.entries(preset.filters);
+    return entries.length > 0 && entries.every(([key, value]) => af[key] === value);
+}
 
 // Summary statistics for filtered results
 const summaryStats = computed(() => {
@@ -97,11 +105,14 @@ const filters = computed<FilterOption[]>(() => [
     {
         key: 'registry',
         label: t('projects.filters.registry'),
+        multiSelect: true,
+        searchable: true,
         options: filterOptions.value.registries.map(r => ({ value: r, label: r })),
     },
     {
         key: 'country',
         label: t('projects.filters.country'),
+        multiSelect: true,
         searchable: true,
         options: countryFilterOptions.value.map(c => ({ value: c, label: c })),
     },
@@ -114,6 +125,7 @@ const filters = computed<FilterOption[]>(() => [
     {
         key: 'sector',
         label: t('projects.filters.sector'),
+        multiSelect: true,
         options: filterOptions.value.sectors.map(s => ({ value: s, label: s })),
     },
     {
@@ -124,6 +136,8 @@ const filters = computed<FilterOption[]>(() => [
     {
         key: 'developer',
         label: t('projects.filters.developer'),
+        multiSelect: true,
+        searchable: true,
         options: filterOptions.value.developers.map(d => ({ value: d, label: d })),
     },
     {
@@ -174,8 +188,13 @@ const statusColor: Record<string, string> = {
                 <button
                     v-for="preset in presets"
                     :key="preset.label"
-                    class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                    @click="applyPreset({ search: preset.search, filters: preset.filters } as any)"
+                    :class="[
+                        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors',
+                        isPresetActive(preset)
+                            ? 'border-primary/50 bg-primary/10 text-primary'
+                            : 'border-primary/25 text-muted-foreground hover:bg-muted hover:text-foreground'
+                    ]"
+                    @click="applyPreset({ filters: preset.filters })"
                 >
                     {{ preset.label }}
                 </button>

--- a/sustainable-explorer/frontend/pages/registries/index.vue
+++ b/sustainable-explorer/frontend/pages/registries/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Building2, Copy, Check, FileJson } from 'lucide-vue-next';
-import type { FilterField } from '~/components/shared/DataFilters.vue';
+import { useDebounceFn } from '@vueuse/core';
+import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import type { RegistrySortKey, RegistrySortDir, RegistryDto } from '~/composables/api/useRegistriesApi';
 import type { SortDirection } from '~/composables/useFilteredPagination';
 
@@ -28,40 +29,94 @@ const columnToApiSort: Record<ColumnKey, RegistrySortKey | null> = {
 
 // Reactive query state
 const route = useRoute();
-// hideEmpty defaults to true so the table mirrors the dashboard stat card,
-// which counts only registries with at least one policy/project/user/issuance.
-// `?hideEmpty=false` in the URL turns it off.
+const router = useRouter();
+// hideEmpty defaults to true so the table mirrors the dashboard stat card.
 const initialFilters: Record<string, any> = {
     hideEmpty: route.query.hideEmpty !== 'false',
 };
+// Keep `?did=` deep-link support (used by ProjectKeyFacts and methodologies page).
 if (route.query.did && typeof route.query.did === 'string') {
     initialFilters.did = route.query.did;
 }
-// Dashboard top-registries row links here with displayName=<name> so the
-// list lands pre-filtered. Also accept the other text filters defined in
-// filterFields for symmetry.
-for (const k of ['displayName', 'id', 'tags', 'geography', 'law'] as const) {
-    if (route.query[k] && typeof route.query[k] === 'string') {
-        initialFilters[k] = route.query[k];
-    }
+if (route.query.sourceTimestamp && typeof route.query.sourceTimestamp === 'string') {
+    const [from, to] = (route.query.sourceTimestamp as string).split('|');
+    if (from || to) initialFilters.sourceTimestamp = { from: from || '', to: to || '' };
 }
 const filters = ref<Record<string, any>>(initialFilters);
 const currentPage = ref(1);
 const pageSize = ref(10);
 
-// Placeholder search ref kept for the composable signature.
-// All text filtering now flows through the `filters` object.
-const searchQuery = ref('');
+// Unified search — debounced so each keystroke doesn't fire an API request.
+// Falls back to old per-field URL params for backward compat.
+const localSearch = ref(
+    typeof route.query.search === 'string' ? route.query.search :
+    (['displayName', 'id', 'tags', 'geography', 'law'] as const)
+        .map(k => route.query[k])
+        .find((v): v is string => typeof v === 'string') ?? ''
+);
+const searchQuery = ref(localSearch.value.trim());
+const debouncedSearch = useDebounceFn((val: string) => {
+    searchQuery.value = val.trim();
+}, 300);
 
-const filterFields = computed<FilterField[]>(() => [
-    { key: 'displayName', label: t('registries.filters.name'), type: 'text', placeholder: t('registries.filters.namePlaceholder'), width: 'md' },
-    { key: 'id', label: t('registries.filters.id'), type: 'text', placeholder: t('registries.filters.idPlaceholder'), width: 'sm' },
-    { key: 'did', label: t('registries.filters.registryDid'), type: 'text', width: 'md' },
-    { key: 'tags', label: t('registries.filters.tags'), type: 'text', width: 'sm' },
-    { key: 'geography', label: t('registries.filters.geography'), type: 'text', width: 'sm' },
-    { key: 'law', label: t('registries.filters.law'), type: 'text', width: 'sm' },
-    { key: 'sourceTimestamp', label: t('registries.filters.createdDate'), type: 'daterange', width: 'md' },
+function syncToUrl() {
+    const q: Record<string, string> = { ...(route.query as Record<string, string>) };
+    const search = localSearch.value.trim();
+    if (search) q.search = search; else delete q.search;
+    for (const k of ['displayName', 'id', 'tags', 'geography', 'law']) delete q[k];
+    const ts = filters.value.sourceTimestamp;
+    if (ts && typeof ts === 'object' && (ts.from || ts.to)) {
+        q.sourceTimestamp = `${ts.from || ''}|${ts.to || ''}`;
+    } else {
+        delete q.sourceTimestamp;
+    }
+    if (filters.value.did) q.did = String(filters.value.did); else delete q.did;
+    router.replace({ query: q });
+}
+
+watch(localSearch, (val) => {
+    debouncedSearch(val);
+    syncToUrl();
+});
+
+const barFilters = computed<FilterOption[]>(() => [
+    {
+        key: 'sourceTimestamp',
+        label: t('registries.filters.createdDate'),
+        type: 'daterange',
+        options: [],
+    },
 ]);
+
+const activeFilterRecord = computed<Record<string, string>>(() => {
+    const r: Record<string, string> = {};
+    const ts = filters.value.sourceTimestamp;
+    if (ts && typeof ts === 'object' && (ts.from || ts.to)) {
+        r.sourceTimestamp = `${ts.from || ''}|${ts.to || ''}`;
+    }
+    return r;
+});
+
+function setRegistryFilter(key: string, value: string) {
+    const next = { ...filters.value };
+    if (!value || value === 'all') {
+        delete next[key];
+    } else if (key === 'sourceTimestamp') {
+        const [from, to] = value.split('|');
+        next[key] = { from: from || '', to: to || '' };
+    } else {
+        next[key] = value;
+    }
+    filters.value = next;
+}
+
+function clearRegistryFilters() {
+    const next: Record<string, any> = { hideEmpty: filters.value.hideEmpty };
+    if (filters.value.did) next.did = filters.value.did;
+    filters.value = next;
+    localSearch.value = '';
+    searchQuery.value = '';
+}
 
 const sortKey = ref<ColumnKey | null>('createdAt');
 const sortDir = ref<SortDirection>('desc');
@@ -114,6 +169,7 @@ watch(
     filters,
     () => {
         currentPage.value = 1;
+        syncToUrl();
     },
     { deep: true },
 );
@@ -195,7 +251,16 @@ function viewRegistry(r: RegistryDto) {
         </div>
 
         <div class="px-6 pb-3">
-            <DataFilters v-model="filters" :fields="filterFields" />
+            <FilterBar
+                v-model="localSearch"
+                :filters="barFilters"
+                :active-filters="activeFilterRecord"
+                :result-count="totalCount"
+                :total-count="totalCount"
+                :search-placeholder="$t('registries.searchPlaceholder')"
+                @filter="setRegistryFilter"
+                @clear="clearRegistryFilters"
+            />
             <label class="mt-2 inline-flex items-center gap-2 text-xs text-muted-foreground select-none cursor-pointer">
                 <input
                     type="checkbox"

--- a/sustainable-explorer/src/api/repositories/pg-registry.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-registry.repository.ts
@@ -103,6 +103,17 @@ export class PgRegistryRepository extends RegistryRepository {
                 bv."searchVector" @@ plainto_tsquery('english', ${tsParam})
                 OR bv."displayName" ILIKE ${likeParam}
                 OR bv."registryDid" ILIKE ${likeParam}
+                OR bv."relatedTopicId" ILIKE ${likeParam}
+                OR bv."businessData"->>'geography' ILIKE ${likeParam}
+                OR bv."businessData"->'options'->>'geography' ILIKE ${likeParam}
+                OR bv."businessData"->'options'->'attributes'->>'geography' ILIKE ${likeParam}
+                OR bv."businessData"->'options'->'attributes'->>'Country' ILIKE ${likeParam}
+                OR bv."businessData"->>'law' ILIKE ${likeParam}
+                OR bv."businessData"->'options'->>'law' ILIKE ${likeParam}
+                OR bv."businessData"->'options'->'attributes'->>'law' ILIKE ${likeParam}
+                OR bv."businessData"->>'tags' ILIKE ${likeParam}
+                OR bv."businessData"->'options'->>'tags' ILIKE ${likeParam}
+                OR bv."businessData"->'options'->'attributes'->>'tags' ILIKE ${likeParam}
                 OR similarity(COALESCE(bv."displayName", ''), ${simParam}) > 0.3
             )`);
 

--- a/sustainable-explorer/src/api/repositories/query-builder.ts
+++ b/sustainable-explorer/src/api/repositories/query-builder.ts
@@ -160,13 +160,30 @@ export class QueryBuilder {
      */
     private buildOperatorClause(sql: string, op: FilterOperator, value: unknown): string | null {
         switch (op) {
-            case 'eq':
+            case 'eq': {
+                if (typeof value === 'string' && value.includes(',')) {
+                    const parts = value.split(',').map(s => s.trim()).filter(Boolean);
+                    if (parts.length > 1) {
+                        this.params.push(parts);
+                        return `${sql} = ANY($${this.paramIdx++}::text[])`;
+                    }
+                }
                 this.params.push(value);
                 return `${sql} = $${this.paramIdx++}`;
+            }
 
-            case 'ilike':
-                this.params.push(`%${String(value)}%`);
+            case 'ilike': {
+                const parts = String(value).split(',').map(s => s.trim()).filter(Boolean);
+                if (parts.length > 1) {
+                    const clauses = parts.map(p => {
+                        this.params.push(`%${p}%`);
+                        return `${sql} ILIKE $${this.paramIdx++}`;
+                    });
+                    return `(${clauses.join(' OR ')})`;
+                }
+                this.params.push(`%${parts[0] ?? String(value)}%`);
                 return `${sql} ILIKE $${this.paramIdx++}`;
+            }
 
             case 'in':
                 if (!Array.isArray(value) || value.length === 0) return null;


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-83

Replace multi-field DataFilters with a single FilterBar search input on the methodologies and registries pages. All active filters and search terms are now reflected in the URL via router.replace so they are shareable and survive page refresh.

Extend registry full-text search to cover all businessData JSONB fallback paths for geography, law, and tags (top-level, options.*, attributes.*, attributes.Country) so searching "Switzerland" correctly matches registries that store country in nested attribute paths.

Enhance QueryBuilder eq/ilike operators to handle comma-separated multi-select values, and fix FilterBar single-select default label to show "All" instead of "All [label]".