### PR TITLE
fix: remove redundant issuance subtitle from analytics section

### DIFF
--- a/sustainable-explorer/frontend/components/project/ProjectKeyFacts.vue
+++ b/sustainable-explorer/frontend/components/project/ProjectKeyFacts.vue
@@ -51,9 +51,9 @@ function tip(iwaPaths: string): string {
                 Key Facts
             </h2>
         </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-px bg-border">
+        <div class="grid grid-cols-1 sm:grid-cols-2">
             <!-- Methodology -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b sm:border-r">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Methodology
                     <InfoTooltip :text="tip('QualityStandard.name')" />
@@ -69,7 +69,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Registry -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Registry
                     <InfoTooltip :text="tip('OriginationProcessAgreement.name')" />
@@ -85,7 +85,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Developer -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b sm:border-r">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Developer
                     <InfoTooltip :text="tip('ActivityImpactModule.developers')" />
@@ -94,7 +94,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Country -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Country
                     <InfoTooltip :text="tip('ActivityImpactModule.country')" />
@@ -109,7 +109,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Status -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b sm:border-r">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Status
                     <InfoTooltip :text="tip('ActivityImpactModule.validations')" />
@@ -118,7 +118,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Sector -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Sector
                     <InfoTooltip :text="tip('ActivityImpactModule.projectScope')" />
@@ -127,7 +127,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Sectoral Scope -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b sm:border-r">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Sectoral Scope
                     <InfoTooltip :text="tip('ActivityImpactModule.projectType')" />
@@ -136,7 +136,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Category -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Category
                     <InfoTooltip :text="tip('ActivityImpactModule.classificationCategory')" />
@@ -145,7 +145,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Crediting Period -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b sm:border-r">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Crediting Period
                     <InfoTooltip :text="tip('ImpactClaim.startDate,ImpactClaim.endDate')" />
@@ -158,7 +158,7 @@ function tip(iwaPaths: string): string {
             </div>
 
             <!-- Vintage -->
-            <div class="bg-card px-5 py-4">
+            <div class="bg-card px-5 py-4 border-b">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Vintage
                     <InfoTooltip :text="tip('ActivityImpactModule.firstYearIssuance')" />
@@ -166,7 +166,7 @@ function tip(iwaPaths: string): string {
                 <div class="text-sm font-medium text-foreground">{{ project.vintage || '—' }}</div>
             </div>
 
-            <!-- Total Credits -->
+            <!-- Total Credits — last row, no border-b -->
             <div class="bg-card px-5 py-4 sm:col-span-2">
                 <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                     Total Credits

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -2025,7 +2025,6 @@ const issuanceTrendTotal = computed(() =>
             <div class="text-2xl font-bold text-foreground tabular-nums">
               {{ formatCredits(methodology.stats.issuanceCount) }}
             </div>
-            <div class="text-xs text-muted-foreground mt-1">{{ $t('methodologies.detail.analytics.issuancesSub') }}</div>
           </div>
         </div>
 


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-102

_Requirement 1 & 2 has been fixed before with the previous task changes_

**Requirement 01 – Correct Credit Amount Calculation**

This has been fixed now, instead of showing entire token supply, it shows the actual amount of credits minted for the project

**Requirement 02 – Rename the “Credit” Column and extract the correct minted amount**

Instead of showing the Credit or minted amount, we are showing Issuances now since that’s the basic relation, and also when we click on that project we can view the mint amount and all, with all linked issuance details


**Requirement 03 – Rename the “Credit” Column and extract the correct minted amount**

This has been removed now