### PR TITLE
feat: Enhance project service with policy graph and VC evidence retrieval

### DIFF
--- a/sustainable-explorer/.claude/AGENT-PROMPT.md
+++ b/sustainable-explorer/.claude/AGENT-PROMPT.md
@@ -1,0 +1,599 @@
+# Sustainable Explorer — Project Mapping & Trust Chain Pipeline Implementation
+
+## Mission
+
+Implement robust project-cycle mapping from Guardian Verifiable Credentials (VCs)
+and a frontend "Project Pipeline & Trust Chain" view showing every document in a
+project's lifecycle with raw VC inspection. This is a re-implementation of work
+previously designed but reverted; the prompt captures every requirement precisely.
+
+---
+
+## Two-Agent System
+
+### Agent 1 — Senior Software Architect (`opus` model)
+Role: owns the design, task breakdown, and review gate. Reads the codebase before
+assigning any task. Reviews EVERY diff the junior produces before it is considered
+done. Maintains `//.claude/architect-memory.md` and `//.claude/DECISIONS.md`.
+Never writes application code directly — only plans, assigns, and reviews.
+
+Architect checklist before approving any junior deliverable:
+- [ ] No unnecessary abstractions beyond the stated requirement
+- [ ] No new dependencies not already in `package.json`
+- [ ] All new NestJS services are `@Injectable()` and registered in `worker.module.ts`
+- [ ] All SQL uses parameterized queries (no string interpolation)
+- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
+- [ ] Existing tests still pass (`npx jest`)
+- [ ] No existing behaviour changed unless explicitly required
+- [ ] Memory files updated
+
+### Agent 2 — Junior Developer (`sonnet` model)
+Role: implements exactly what the architect specifies, in the exact files and
+patterns the architect designates. Maintains `//.claude/dev-memory.md`. Must read
+the relevant source files before editing. Must run `npx tsc --noEmit` and
+`npx jest` after each task and report results to the architect before moving on.
+
+---
+
+## Codebase Context (read before planning anything)
+
+### Stack
+- **Worker** (`src/worker/`): NestJS + BullMQ. Syncs HCS topics, fetches IPFS,
+  decodes policies, maps VCs to project rows.
+- **API** (`src/api/`): NestJS REST. Reads from Postgres `business_view` table.
+- **Frontend** (`frontend/`): Nuxt 3. Project detail page at
+  `frontend/pages/projects/[id].vue`.
+- **Shared** (`src/shared/`): entities, config, `message-parser.ts`.
+- Infra: Postgres (TypeORM synchronize + `src/shared/database/schema-bootstrap.ts`
+  for raw indexes), BullMQ via Redict.
+
+### Key files to read first
+```
+src/worker/services/project-mapper.service.ts       ← entry point for VC → project
+src/worker/project-mapper/                          ← helpers, types, non-project-credential
+src/worker/mapping/policy-pipeline.types.ts         ← PolicyMapping, PolicyMappingEntry
+src/worker/mapping/policy-pipeline.service.ts       ← stamps entries at decode time
+src/worker/worker.module.ts                         ← DI registration
+src/shared/database/schema-bootstrap.ts             ← raw index creation
+src/api/repositories/pg-project.repository.ts       ← findActivity, findById
+frontend/pages/projects/[id].vue                    ← project detail page
+frontend/components/project/                        ← existing project components
+frontend/composables/useProjects.ts                 ← useProjectActivity, mapActivityEvent
+docs/guardian-topic-hierarchy.md                    ← Guardian HCS topic tree structure
+```
+
+### Guardian topic tree (critical for understanding M1)
+```
+Seed Topic
+└── User Topic (one per registry)
+    └── Policy Topic
+        ├── Instance-Policy publish-policy message  ← methodology source
+        └── Instance Policy Topic
+            ├── VCs directly on instance topic (shared-topic policies)
+            └── Dynamic Topic "Project"             ← ONE per project submission
+                └── VCs: INF, PDD, MR, VR, Issuance
+```
+
+### Current project-mapper.service.ts state
+**The primary (first) resolver MUST be the dynamic topic ID (M1).**
+Guardian creates one Dynamic Topic per project submission. Every VC in that
+project's lifecycle (INF, PDD, MR, VR, MintToken) is published on the same
+dynamic topic, so `projectKey = topicId` structurally collapses the full cycle
+into one row — this is the cleanest and most reliable identity.
+
+The current service does NOT implement this. It resolves `projectKey` via:
+1. `cs.ref` chain walk (`resolveProjectKeyViaRef`, 8 hops)  ← currently method 1
+2. `options.relationships` BFS (`resolveProjectKeyViaRelationships`, 24 hops)
+3. Project-schema designation (`isProjectSchemaVc`)
+
+After this implementation the priority order becomes:
+```
+M1  Dynamic topic ID          — PRIMARY (new, must be first)
+M2  cs.ref chain              — secondary (existing, promoted to slot 2)
+M3  Gated relationships BFS  — fallback (existing but made safe)
+M4  Project-schema last resort — discard non-project VCs in classified policies
+```
+
+The resolver chain, circuit breaker, docType field guard, and
+`TopicClassifierService` need to be built from scratch (the
+`src/worker/project-mapper/resolvers/` folder does not exist yet).
+
+### `PolicyMappingEntry` (already has `docType?: string` field)
+```typescript
+// src/worker/mapping/policy-pipeline.types.ts
+export interface PolicyMappingEntry {
+    source: 'schema' | 'policyJson';
+    schemaIri?: string;
+    schemaType?: PolicyMappingSchemaType;
+    fieldPath?: string;
+    isProjectSchema?: boolean;
+    docType?: string;   // ← exists but is NOT stamped yet
+    title: string;
+    description: string;
+    score?: number;
+}
+```
+`src/worker/project-mapper/document-type-classifier.ts` exists and is correct;
+it is NOT wired into `policy-pipeline.service.ts` yet.
+
+---
+
+## Part 1 — Backend: Project-Key Resolution
+
+### Requirement summary
+Collapse every VC in a project's lifecycle (INF, PDD, Validation, Monitoring x N,
+Verification, MintToken) into **one** `business_view` PROJECT row, keyed by a
+stable `projectKey`. Prevent INF and PDD appearing as two separate projects.
+
+**`projectKey` priority (M1 is primary — this is non-negotiable):**
+```
+M1  Dynamic Topic ID   projectKey = topicId of the per-project dynamic topic
+                       Every VC published on that topic maps to the same key.
+                       This is the cleanest dedup — one topic = one project.
+
+M2  cs.ref chain       projectKey = root cs.id reached by following cs.ref hops.
+                       Applies to VCs on shared instance topics carrying cs.ref.
+
+M3  Gated BFS          projectKey = confirmed ancestor cs.id via relationships.
+                       Only accepted when confirmProjectKey() independently
+                       verifies the ancestor (M1/M4/known row). Prevents VVB
+                       mis-attribution.
+
+M4  Project schema     projectKey = own cs.id  (project-schema VCs only).
+                       Non-project-schema VCs in classified policies are REJECTED
+                       (no row seeded) — this is the "discard the rest" rule.
+```
+
+All resolvers share a common interface and base class. A per-strategy circuit
+breaker bounds blast radius when a single strategy's query misbehaves.
+
+---
+
+### R1 — Common resolver interface and base class
+
+**Files to create:**
+- `src/worker/project-mapper/resolvers/resolver.types.ts`
+- `src/worker/project-mapper/resolvers/circuit-breaker.ts`
+- `src/worker/project-mapper/resolvers/base-resolver.ts`
+
+#### `resolver.types.ts`
+```typescript
+import { PolicyMapping } from '../../mapping/policy-pipeline.types';
+
+export interface ResolutionContext {
+    consensusTimestamp: string;
+    topicId: string;
+    csId: string;           // credentialSubject[0].id — always present (callers guard)
+    csRef: string;          // credentialSubject[0].ref, trimmed, '' when absent
+    isProjectSchemaVc: boolean;
+    policyHasProjectSchemaClassification: boolean;
+    policyMapping: PolicyMapping;
+}
+
+export type ResolutionOutcome =
+    | { status: 'resolved'; projectKey: string; method: string }
+    | { status: 'pass' }
+    | { status: 'reject'; reason: string };
+
+export interface ResolvedProjectKey {
+    projectKey: string;
+    method: string;         // logged to debug output for observability
+}
+```
+
+#### `circuit-breaker.ts`
+Single-class circuit breaker with:
+- `threshold` consecutive failures → circuit OPEN
+- `cooldownMs` → HALF-OPEN (log it)
+- Successful half-open probe → CLOSED (log it)
+- Open state returns `fallback` immediately without calling `fn`
+- Use `number | null` (not `0`) as the "closed" sentinel for `openedAt`
+
+#### `base-resolver.ts`
+Abstract `@Injectable()` class holding ALL shared DB graph helpers that strategies
+reuse. Strategies extend it and implement only `resolve(ctx)`. Methods to include:
+- `resolveViaRef(startTs, startCsId)` — 8-hop cs.ref chain walk
+- `resolveViaRelationships(startTs, startCsId)` — 24-hop BFS with self-ref guard
+- `isCsIdReferencedByOtherVcs(csId, selfTs)`
+- `isCsIdOnProjectSchema(csId, policyMapping)` — returns `true` when no schemas
+  are classified (permissive fallback)
+- `isKnownProjectRow(projectKey)` — checks `business_view WHERE viewType='PROJECT'`
+- `confirmProjectKey(csId, policyMapping)` — used by M3; returns confirmed key or
+  null (checks: dynamic project topic → topic-keyed; project schema → cs.id-keyed;
+  known PROJECT row → cs.id-keyed)
+- `projectSchemaUuids(policyMapping)` — Set of designated project schema UUIDs
+
+Constructor: `(dataSource: DataSource, topicClassifier: TopicClassifierService)`.
+Each subclass passes these up via `super(dataSource, topicClassifier)`.
+
+---
+
+### R2 — Topic classifier service
+
+**File:** `src/worker/project-mapper/topic-classifier.ts`
+
+```typescript
+export type TopicKind = 'dynamic-project' | 'instance' | 'other';
+export interface TopicClassification {
+    kind: TopicKind;
+    name: string | null;
+    instancePolicyTopicId: string | null;
+}
+
+@Injectable()
+export class TopicClassifierService {
+    // in-process Map cache keyed by topicId
+    // Only cache definitive results (kind !== 'other' || instancePolicyTopicId !== null)
+    // because 'other' with null instancePolicyTopicId can be a temporary miss
+    // due to ingest ordering
+    async classifyTopic(dataSource: DataSource, topicId: string): Promise<TopicClassification>
+}
+```
+
+Classification logic:
+1. Query `message WHERE type='Topic' AND topicId=$1 AND options->>'parentId' IS NOT NULL`
+   to get `{ parentId, name }`.
+2. Check if topicId itself is an instance-policy topic (Instance-Policy message
+   references it) → kind `'instance'`.
+3. If it has a parent AND `name` matches `/project/i` AND parent chain reaches an
+   instance-policy topic → kind `'dynamic-project'`.
+4. Otherwise → kind `'other'`.
+
+---
+
+### R3 — Four resolver strategies (M1 → M4)
+
+Each is a small `@Injectable()` extending `BaseProjectKeyResolver`.
+
+#### M1 — `dynamic-topic.resolver.ts`
+`method = 'topic'`
+- Call `topicClassifier.classifyTopic`. If `kind !== 'dynamic-project'` → `pass()`.
+- If kind is `'dynamic-project'` → `resolved(topicId)`.
+- **No over-merge guard.** Guardian creates one dynamic topic per project
+  submission; multiple same-project registrations sharing that topic are the
+  very thing this resolver is meant to collapse. Removing the guard is deliberate.
+
+#### M2 — `cs-ref.resolver.ts`
+`method = 'csRef'`
+- If `ctx.csRef` is empty → `pass()`.
+- Walk via `resolveViaRef`. For classified policies where this VC is not itself the
+  project schema, verify the chain terminus is on a project schema →
+  if not, `reject('cs.ref resolves to non-project-schema VC')`.
+
+#### M3 — `relationships.resolver.ts`
+`method = 'relationships'`
+- If `ctx.isProjectSchemaVc` → `pass()` (project schema VCs ARE the root; M4 keys them).
+- Walk via `resolveViaRelationships`. If nothing walked → `pass()`.
+- Call `confirmProjectKey` on the candidate. If not confirmed → `pass()` (do NOT
+  reject; ungated relationships walk can mis-key, so silently pass to M4).
+
+#### M4 — `project-schema.resolver.ts`
+`method = 'projectSchema'`
+- If `ctx.isProjectSchemaVc` → `resolved(ctx.csId)`.
+- Else if `policyHasProjectSchemaClassification` → `reject('not the project schema, no cs.ref/ancestor')`.
+- Else → `pass()` (unclassified policy — let the chain end; VC is skipped).
+
+---
+
+### R4 — Resolver chain orchestrator
+
+**File:** `src/worker/project-mapper/resolvers/resolver-chain.service.ts`
+
+`@Injectable()` class. Constructor receives `(m1, m2, m3, m4)` as the four
+strategy instances. Maintains one `CircuitBreaker` per strategy
+(`threshold=5, cooldownMs=30_000`). `resolve(ctx)` runs M1→M4:
+- First `resolved` → returns `ResolvedProjectKey`, short-circuits.
+- `reject` → returns `null` (VC skipped), short-circuits.
+- Strategy throws → breaker absorbs it as `pass`, logs the error, chain continues.
+- All `pass` → returns `null`.
+
+---
+
+### R5 — Wire docType into the policy pipeline
+
+**File:** `src/worker/mapping/policy-pipeline.service.ts`
+
+In `execute()`:
+1. After `flattenAll(schemas, schemaTypes)`, build `docTypeBySchema: Map<string, DocumentType>`
+   by calling the existing `classifyDocumentType(schema.name, schema.id, fieldDefMap)`
+   from `document-type-classifier.ts` for each schema.
+2. Pass `docTypeBySchema` into `attachSchemaMappings()` and stamp each
+   `PolicyMappingEntry.docType = docTypeBySchema.get(schemaIri) ?? 'unknown'`.
+
+`DocumentType` union type must be exported from
+`src/worker/project-mapper/types.ts`:
+```typescript
+export type DocumentType =
+    | 'pdd' | 'monitoringReport' | 'validationReport'
+    | 'verificationReport' | 'registration' | 'unknown';
+```
+
+---
+
+### R6 — Rewrite `project-mapper.service.ts` to use the chain
+
+Replace the existing multi-branch `projectKey` resolution block with a call to
+`resolverChain.resolve(ctx)`. Key constraints:
+
+```typescript
+// Constructor: inject the chain instead of individual helpers
+constructor(
+    private readonly dataSource: DataSource,
+    private readonly reverseGeoService: ReverseGeoService,
+    private readonly resolverChain: ProjectKeyResolverChain,
+) {}
+```
+
+**docType field guard** — add this constant at module scope (not inside the class):
+```typescript
+const DATE_ONLY_FIELD_KEYS = new Set<string>([
+    'vintageRaw', 'creditingPeriod', 'creditingPeriodStart', 'creditingPeriodEnd',
+]);
+```
+
+In the extraction loop, before reading each field:
+```typescript
+if (vcDocType === 'validationReport') break;                          // contributes nothing
+if (isDateOnlySource && !DATE_ONLY_FIELD_KEYS.has(field.key)) continue; // only dates/credits
+```
+
+**Credit guard**: validation reports also skip `ER_y` credit extraction.
+
+**Debug log**: include `via=${resolvedProject.method}` in the final debug line.
+
+**Remove** all private methods that moved into `BaseProjectKeyResolver`:
+`resolveProjectKeyViaRef`, `resolveProjectKeyViaRelationships`,
+`isCsIdReferencedByOtherVcs`, `isCsIdOnProjectSchema`,
+`findCanonicalProjectSchemaCsIdInTopic`, `isDownstreamTopic`, and the
+`DOWNSTREAM_TOPIC_NAMES` static set.
+
+**Keep**: `docTypeForSchema()`, `queryPolicyByPolicyId()`,
+`findPolicyVersionByTopicWalk()`, the orphan-cleanup DELETE, the full upsert SQL.
+
+---
+
+### R7 — Register all new services in `worker.module.ts`
+
+Add to `providers[]`:
+```typescript
+TopicClassifierService,
+DynamicTopicResolver,
+CsRefResolver,
+RelationshipsResolver,
+ProjectSchemaResolver,
+ProjectKeyResolverChain,
+```
+`ProjectMapperService` already present — just update its injected dependencies
+by adding `ProjectKeyResolverChain` to its constructor parameters.
+
+---
+
+### R8 — GIN index for `linkedVcs` containment queries
+
+**File:** `src/shared/database/schema-bootstrap.ts`
+
+Add at the end of `bootstrapSchema()`:
+```sql
+CREATE INDEX IF NOT EXISTS idx_business_view_linked_vcs
+ON business_view USING GIN (("businessData" -> 'linkedVcs'))
+WHERE "viewType" = 'PROJECT'
+```
+This backs the `@>` containment lookups in `mint-project-linker.ts` and
+`findActivity`.
+
+---
+
+### R9 — Fix `mint-project-linker.ts` for topic-keyed projects
+
+When `projectKey = topicId` (M1), the existing Step 1.5 cs.ref join
+(`bv."projectKey" = cs.ref`) fails because `cs.ref` is a DID, never a topic ID.
+Fix Step 1.5 to also match against `linkedVcs[].csId`:
+```sql
+bv."projectKey" = m.documents->'credentialSubject'->0->>'ref'
+OR bv."businessData"->'linkedVcs' @>
+   jsonb_build_array(jsonb_build_object('csId',
+       m.documents->'credentialSubject'->0->>'ref'))
+```
+Also fix Step 1 (recursive CTE): add the `linkedVcs` containment arm alongside
+`bv."sourceTimestamp" = rc.ts` so chain timestamps match topic-keyed project rows.
+
+---
+
+### R10 — `findActivity` scoped to project's own VCs for shared topics
+
+**File:** `src/api/repositories/pg-project.repository.ts`
+
+Current `findActivity` scans all VCs on `relatedTopicId`, which over-lists when
+multiple projects share one instance topic. Fix:
+1. Count `business_view WHERE viewType='PROJECT' AND relatedTopicId=$topicId`.
+2. If count > 1 (shared topic): source the timeline from
+   `businessData.linkedVcs[].consensusTimestamp` — only fetch those specific
+   messages by timestamp from `message` table.
+3. If count = 1 (per-project dynamic topic): keep the existing full-topic scan.
+
+---
+
+### R11 — `schedulePolicyDecodeJobs` & `businessData.topicId` correct topic source
+
+**File:** `src/worker/schedulers/sync-scheduler.service.ts`
+
+In `schedulePolicyDecodeJobs()`, the `Instance-Policy publish-policy` message can
+be published on the instance topic (not the policy topic). `m."topicId"` would
+then be the instance topic. Always prefer the message content's `options.topicId`:
+```sql
+COALESCE(NULLIF(m.options->>'topicId', ''), m."topicId") AS policy_topic_id
+```
+Apply the same fix in the NOT EXISTS subquery that checks for an existing decoded
+policy row.
+
+**File:** `src/worker/processors/business-view-builder.processor.ts`
+
+Same fix for `businessData.topicId`:
+```sql
+'topicId', COALESCE(NULLIF(m.options->>'topicId', ''), m."topicId"),
+```
+
+---
+
+### R12 — Rescue orphaned topics on boot
+
+**File:** `src/worker/schedulers/sync-scheduler.service.ts`
+
+Add `rescheduleOrphanedTopics()` called from `onModuleInit()` after
+`schedulePolicyDecodeJobs()`. It finds all topic IDs referenced in
+`message.options.childId` (Topic messages) or `message.options.instanceTopicId`
+(Instance-Policy messages) that are NOT in `topic_cache`, then re-enqueues
+`topic-{id}-0` sync jobs for them (removing any stale failed job first).
+This fixes the "only 7 methodologies after 3 hours" scenario where failed
+topic-sync jobs silently leave entire policy subtrees unreachable.
+
+---
+
+### R13 — Unit tests
+
+**Pattern**: follow `test/unit/worker/mapping/` conventions (Jest, `@jest/globals`,
+no real DB). Write tests for:
+- `CircuitBreaker`: open/close/half-open transitions, sentinel null bug (mock
+  `Date.now()` to 0 to prove null sentinel is needed).
+- `ProjectKeyResolverChain`: first-resolved wins; reject short-circuits; throw is
+  absorbed as pass; all-pass returns null.
+- `TopicClassifierService`: dynamic-project / instance / other classification;
+  cache stores definitive results only.
+- `DynamicTopicResolver` (M1): resolves by topicId; passes for instance topics.
+- `ProjectSchemaResolver` (M4): keys project-schema VC; rejects non-schema VC in
+  classified policy; passes in unclassified policy.
+
+---
+
+## Part 2 — Frontend: Project Pipeline & Trust Chain View
+
+### Context
+Current project detail page (`frontend/pages/projects/[id].vue`) has tabs:
+Summary, Issuances, Documents (LinkedVcsPanel), Advanced. The activity log
+is a simple timeline at the bottom of the Summary tab.
+
+### Requirement
+Add a **"Pipeline"** tab to the project detail page that shows the full
+project lifecycle as a trust chain: every VC attributed to this project,
+grouped by document type (INF / PDD → Validation → Monitoring × N →
+Verification → Issuance), with:
+1. A step-by-step pipeline visualization (vertical timeline or horizontal
+   stages) with one card per document.
+2. Multiple Monitoring Reports shown individually (not collapsed).
+3. Each card has a small **info icon (ⓘ)** that opens a drawer/modal showing
+   the raw `credentialSubject[0]` JSON from the VC — styled as a "trust chain"
+   evidence panel (timestamp, schema, DID, raw payload).
+4. Raw VC data is fetched from the existing `/projects/:id/linked-vc/:ts`
+   endpoint (already wired in `mapping-reprocess.service.ts`).
+
+### Components to create/modify
+
+#### New: `frontend/components/project/ProjectPipeline.vue`
+Props: `project: Project` (existing type). Reads `project.schemas` (the
+`linkedVcs` grouped by schema already returned by the API in
+`ProjectResponseDto.fromRow`) to build the pipeline steps.
+
+Step ordering — classify each schema's documents by `docType` (available on
+each linked-vc entry via `schemaUuid` lookup against `schema.schemaName`):
+```
+registration / pdd  →  validationReport  →  monitoringReport(s)  →  verificationReport  →  credit/issuance
+```
+Unknown types appear at the end. Multiple monitoring reports are shown as
+separate steps in sequence order (by `consensusTimestamp`).
+
+Each step card shows:
+- Icon matching doc type (Shield for validation, BarChart for monitoring, etc.)
+- Schema name
+- Consensus timestamp (formatted)
+- Hedera Hashscan link for the topic
+- **ⓘ Raw VC button** → opens `RawVcDrawer`
+
+#### New: `frontend/components/project/RawVcDrawer.vue`
+- Prop: `consensusTimestamp: string`, `projectId: string`, `schemaName: string`
+- On open, calls `GET /api/v1/{network}/projects/{projectId}/linked-vc/{ts}`
+- Renders the JSON as a formatted trust-chain panel:
+  - Header: schema name + timestamp + "On-chain evidence"
+  - Issuer DID
+  - `credentialSubject` fields rendered as key-value pairs (no raw JSON dump —
+    read each field and render human-readable)
+  - "View on Hashscan" link
+- Uses existing `HederaReferences` styling conventions
+
+#### Modify: `frontend/pages/projects/[id].vue`
+Add `'pipeline'` to `TabKey` union. Add the Pipeline tab button and panel:
+```html
+<template v-if="activeTab === 'pipeline'">
+    <ProjectPipeline :project="project" />
+</template>
+```
+No other changes to existing tabs.
+
+#### Modify: `frontend/composables/useProjects.ts`
+The `ActivityEvent` interface needs `schemaName` surfaced (it's already returned
+by the API but stripped in `mapActivityEvent`). Add `schemaName: string | null`
+to `ActivityEvent` and pass it through from `raw.schemaName`.
+
+---
+
+## Implementation Order (architect assigns in this sequence)
+
+```
+Phase 1 — Resolver infrastructure (backend, no behaviour change)
+  Task 1.1  Create resolver.types.ts, circuit-breaker.ts, base-resolver.ts
+  Task 1.2  Create topic-classifier.ts
+  Task 1.3  Create the four resolver strategies (M1–M4)
+  Task 1.4  Create resolver-chain.service.ts
+  Task 1.5  Wire docType into policy-pipeline.service.ts (R5)
+  Task 1.6  Register all new providers in worker.module.ts (R7)
+
+Phase 2 — Rewrite project-mapper.service.ts (R6)
+  Task 2.1  Replace resolution block with chain call + docType guard
+  Task 2.2  Remove migrated helpers; confirm tsc clean + tests pass
+
+Phase 3 — Data alignment fixes
+  Task 3.1  Fix mint-project-linker.ts (R9)
+  Task 3.2  Fix findActivity in pg-project.repository.ts (R10)
+  Task 3.3  Fix schedulePolicyDecodeJobs + businessData.topicId (R11)
+  Task 3.4  Add rescheduleOrphanedTopics (R12)
+  Task 3.5  Add GIN index in schema-bootstrap.ts (R8)
+
+Phase 4 — Unit tests (R13)
+  Task 4.1  circuit-breaker, resolver-chain, topic-classifier tests
+  Task 4.2  M1 and M4 strategy tests
+
+Phase 5 — Frontend Pipeline tab
+  Task 5.1  Add schemaName to ActivityEvent composable
+  Task 5.2  Create RawVcDrawer.vue
+  Task 5.3  Create ProjectPipeline.vue
+  Task 5.4  Add Pipeline tab to [id].vue
+```
+
+---
+
+## Memory files both agents must maintain
+
+```
+.claude/architect-memory.md    — design decisions, open questions, phase status
+.claude/dev-memory.md          — files changed, tsc status, test status, blockers
+.claude/DECISIONS.md           — any deviations from this prompt, with rationale
+.claude/codebase-memory.md     — live summary of module topology (update when files change)
+```
+
+---
+
+## Hard constraints
+
+1. **No new npm packages** — use only what is in the existing `package.json`.
+2. **No `any` casts** beyond what already exists in the file being edited.
+3. **No `// TODO` left in delivered code** — every task must be complete.
+4. **No backwards-compat shims** — if a method moved to the base class, delete
+   it from the service; do not alias or re-export it.
+5. **All SQL parameterized** — `dataSource.query(sql, [params])` only.
+6. **NestJS DI** — every `@Injectable()` class must appear in `worker.module.ts`
+   providers before it can be injected anywhere.
+7. **Run tsc + jest after every task** — junior reports results; architect must
+   see "TSC_EXIT:0" and green test count before approving the next task.
+8. **The existing upsert SQL** in `project-mapper.service.ts` (the large
+   `INSERT INTO business_view … ON CONFLICT` block with the COALESCE merge
+   strategy, `_fromProjectSchema` priority, `linkedVcs` dedup, and orphan-cleanup
+   DELETE) must be preserved exactly — do not rewrite it.

--- a/sustainable-explorer/.claude/DECISIONS.md
+++ b/sustainable-explorer/.claude/DECISIONS.md
@@ -1,0 +1,118 @@
+# DECISIONS — deviations from AGENT-PROMPT.md with rationale
+
+## D1 — Reordered Phase 1 tasks so topic-classifier (R2) is built before base-resolver (R1)
+**Prompt says:** Task 1.1 = create resolver.types.ts + circuit-breaker.ts + base-resolver.ts;
+Task 1.2 = topic-classifier.ts.
+**Deviation:** Split into 1.1 (types + circuit-breaker), 1.2 (topic-classifier), 1.3
+(base-resolver) — topic-classifier moved ahead of base-resolver.
+**Why:** `base-resolver.ts` constructor signature is `(dataSource, topicClassifier:
+TopicClassifierService)` and `confirmProjectKey()` calls the classifier. If base-resolver is
+written before TopicClassifierService exists, `npx tsc --noEmit` fails on the missing import —
+violating hard-constraint #7 ("tsc clean after every task"). Reordering preserves the green-gate
+discipline with zero change to the final file set or design.
+
+## D2 — `document-type-classifier.ts`, `classifyDocumentType`, and `PolicyMappingEntry.docType` do NOT exist yet
+**Prompt says (Codebase Context, lines 102–117):** "`PolicyMappingEntry` (already has
+`docType?: string` field)" and "`src/worker/project-mapper/document-type-classifier.ts` exists
+and is correct; it is NOT wired into `policy-pipeline.service.ts` yet."
+**Reality (verified):** `glob src/worker/project-mapper/**` shows NO document-type-classifier.ts
+(there is `schema-classifier.ts` instead). `grep classifyDocumentType|DocumentType|
+document-type-classifier` matches ONLY `.claude/AGENT-PROMPT.md`. The actual
+`policy-pipeline.types.ts` `PolicyMappingEntry` has NO `docType` field.
+**Decision:** Task 1.6 (R5) will, in addition to wiring, FIRST create
+`document-type-classifier.ts` with the `DocumentType` union (per R5) and a
+`classifyDocumentType(schemaName, schemaId, fieldDefMap)` heuristic, and ADD `docType?: string`
+to `PolicyMappingEntry`. The classifier heuristic will be designed when we reach Task 1.6
+(needs the schema field shape). This is unavoidable: R5 cannot "wire in" a file that is absent.
+Recorded so the deviation is traceable; no scope beyond what R5 requires.
+
+## D3 — Phase 1 leaves ProjectMapperService constructor unchanged (R7 split across phases)
+**Prompt says (R7):** register new providers AND "update its injected dependencies by adding
+ProjectKeyResolverChain to its constructor."
+**Decision:** In Phase 1 Task 1.7, register the providers ONLY. The constructor change +
+chain usage land together in Phase 2 Task 2.1 (R6), where the service body actually calls
+`resolverChain.resolve(ctx)`.
+**Why:** Phase 1 is explicitly "backend, no behaviour change." Injecting an unused chain into
+the service in Phase 1 would be dead wiring and risks an unused-import lint hit; doing it in
+Phase 2 alongside the body rewrite keeps each phase coherent. Final state is identical to the
+prompt's intent.
+
+## D5 — docType classified by NAME heuristic (user-reviewed and endorsed)
+**Context:** R5 requires a `docType` per schema, but the existing policy mapping only carries
+`schemaType` (project/mintToken/standardRegistry/other) + `isProjectSchema` — it does NOT
+distinguish PDD / MonitoringReport / ValidationReport / VerificationReport. R6's validation-report
+guard and the Phase 5 pipeline ordering both need that finer label, so a classifier is unavoidable.
+**Question raised by user (2026-06-04):** "since we already have proper policy mapping, do we need
+these hardcoded [DocumentType] ones again?"
+**Findings:** (1) the mapping cannot supply docType — nothing to reuse. (2) The worker reads no
+authoritative Guardian type field; `RawSchema` exposes only name/description/document. (3) The
+existing `classifySchemaTypeByName` is itself a name heuristic, so `classifyDocumentType` mirrors an
+established pattern and is orthogonal to `schemaType` (lifecycle-role vs data-class).
+**Decision:** Keep the name-based `classifyDocumentType` as implemented in Task 1.6. User chose
+"Keep name heuristic" after being shown the metadata-driven and remove-entirely alternatives.
+**Upgrade path (deferred):** if a methodology misclassifies, source docType from authoritative
+metadata (schema `entity`/`category`, or policy.json workflow-block roles) — out of scope for R5.
+
+## D6 — `isDateOnlySource` defined as monitoring/verification reports (prompt left it undefined)
+**Context:** R6 instructs the extraction-loop guard
+`if (isDateOnlySource && !DATE_ONLY_FIELD_KEYS.has(field.key)) continue;  // only dates/credits`
+but never defines `isDateOnlySource`. `DATE_ONLY_FIELD_KEYS` = {vintageRaw, creditingPeriod,
+creditingPeriodStart, creditingPeriodEnd}.
+**Decision:** `isDateOnlySource = vcDocType === 'monitoringReport' || vcDocType === 'verificationReport'`.
+Rationale: periodic reports (monitoring/verification) should contribute only crediting-period dates
++ credits (ER_y handled separately), never descriptive fields (name/country/etc.) — their
+host_countries[] etc. are the noise the pipeline guards against. pdd/registration remain the source
+of descriptive fields; validationReport contributes nothing (separate `break`).
+**Adjustability:** single boolean expression; easy to narrow to monitoring-only if a methodology
+needs verification reports to contribute descriptive data.
+
+## D7 — Phase 5 uses REAL endpoint/field names, not the prompt's stale ones
+The prompt's Part 2 references `/projects/:id/linked-vc/:ts` and `project.schemas`. The actual API
+route is `GET /:id/linked-vcs/:consensusTimestamp` (plural) and the frontend field is
+`project.linkedSchemas`. Phase 5 uses the real names. Not a judgment call — the prompt is simply out
+of date.
+
+## D8 — docType exposed to frontend by REUSING the stamped value (not re-classified) — user choice
+The Pipeline needs lifecycle ordering, but `linkedSchemas` carried no docType. User chose "expose
+backend docType via API" (over a client-side heuristic or timestamp-only). Implementation threads the
+docType ALREADY stamped on policyMapping entries (Phase 1 R5) through `PolicySchemaRow.docType` →
+`LinkedSchemaDto.docType` → frontend `LinkedSchema.docType`. No second classification anywhere —
+directly honours D5 (don't duplicate the doctype heuristic).
+
+## D9 — Task 5.1 implemented FULLY (backend + frontend) — user choice
+The prompt assumed the activity API returns schemaName; it does NOT (ActivityEventDto consumes it
+server-side to derive action/type, then drops it). User chose "implement fully": add
+`schemaName: string | null` to the backend `ActivityEventDto` output AND the frontend `ActivityEvent`
++ `mapActivityEvent`. (Note: the Pipeline itself reads `linkedSchemas`, not the activity feed; this
+just surfaces schema names in the Advanced-tab activity log.)
+
+## D10 — Phase 5 frontend gated by `npx nuxi typecheck` — user choice
+frontend/package.json has no typecheck/lint script. User chose to set one up. Baseline captured
+before changes (frontend may have its own pre-existing type errors, treated as a frozen baseline like
+the jest one). Backend Phase 5 tasks still gate on tsc+jest.
+
+## D11 — Live-DB debug (2026-06-05): "0 projects after 6–7h" = pre-existing crawler starvation, NOT the resolver chain
+**Symptom:** mainnet_sustainable_explorer had 0 PROJECT business_view rows (CREDIT/METHODOLOGY/REGISTRY fine).
+**Diagnosis (from live Postgres + Redict):** only 63 VC-Documents ingested, all 46 fetched ones were
+StandardRegistry profile VCs (correctly skipped). ~52 instance topics (where project VCs live) NOT in
+topic_cache. `mirror-node-topics-mainnet` had 212 first-time discovery jobs (`topic-{id}-0`,
+`priority:10`) FROZEN in the BullMQ `prioritized` set (0 throughput across 100k+ completed poll jobs),
+while the worker drained a never-ending `wait` stream of `-poll-` re-syncs of the 144 known topics.
+**Root cause:** `message-process.processor.ts` enqueued discovered topics with `priority:10`. BullMQ's
+blocking worker keeps draining the always-non-empty `wait` list and never falls through to
+`prioritized` → discovery starved → project topics never crawled → nothing for the mapper to map. This
+is PRE-EXISTING crawler code (not our resolver/R12 work), exposed by mainnet's large topic tree.
+**Fix:** removed the `priority` option from the discovery enqueue so discovery rides the same `wait`
+FIFO (processed in seconds, unstarved). One line. tsc 0, jest 65/5. Deploy = rebuild+restart worker;
+R12 on boot remove-then-adds the ~203 stuck orphans into `wait`, draining the backlog.
+**Secondary issues noted (follow-ups, not the blocker):** 17 IPFS fetch failures; 21 policy-decode
+failures; `isProjectSchema=false` on every decoded policy's mapping (docType stamping works) — the last
+could limit mapping for shared-topic policies once ingestion flows (dynamic-topic policies map via M1).
+
+## D4 — Migrated graph-helpers temporarily duplicated between base-resolver and the service
+**Context:** Phase 1 Task 1.3 COPIES resolveViaRef / resolveViaRelationships /
+isCsIdReferencedByOtherVcs / isCsIdOnProjectSchema into `base-resolver.ts`. The originals stay
+in `project-mapper.service.ts` until Phase 2 Task 2.2 deletes them (per R6 "Remove" list).
+**Why:** Keeps Phase 1 a pure additive, no-behaviour-change step; the service still works off
+its own private copies until the chain takes over in Phase 2. Hard-constraint #4 (no
+backwards-compat shims) is honoured because the duplicates are DELETED in 2.2, not aliased.

--- a/sustainable-explorer/.claude/architect-memory.md
+++ b/sustainable-explorer/.claude/architect-memory.md
@@ -36,6 +36,192 @@ the AGENT-PROMPT review checklist.
 | 5 | 5.4 | Pipeline tab in [id].vue | ✅ DONE (typecheck-clean) |
 | 5 | — | **PHASE 5 COMPLETE** — nuxi typecheck error set == baseline (no new errors); new .vue files clean | ✅ |
 | — | — | **ALL PHASES COMPLETE (1–5).** Backend tsc 0 / jest 65p·5f(frozen). FE typecheck == baseline. | ✅ |
+| 6 | 6.1 | persist decodeMethod in project-mapper.service.ts (worker) | ✅ DONE (approved) |
+| 6 | 6.2 | expose decodeMethod via DTO + FE model + composable | ✅ DONE (approved) |
+| 6 | 6.3 | new ProjectTrustChain.vue (= current ProjectPipeline) + rewrite ProjectPipeline.vue as step-map | ✅ DONE (approved) |
+| 6 | 6.4 | restructure [id].vue tabs (Pipeline=stepmap, Advanced=trustchain; remove hardcoded workflow + API activity log) | ✅ DONE (approved) |
+| 6 | — | **PHASE 6 COMPLETE** — Architect-reviewed: backend tsc 0 / jest 65p·5f(frozen); FE nuxi typecheck == 12 frozen errors, ZERO new. decodeMethod wired W→DTO→model→composable; upsert SQL untouched; no dangling refs in [id].vue; 1 justified new FE file. **NOTE: existing PROJECT rows show decodeMethod badge 'Unknown' until reparsed** (per locked decision 3). | ✅ |
+| 7 | 7.1 | add @vue-flow/core dep + CSS | ✅ DONE (approved) |
+| 7 | 7.2 | ProjectPolicyCanvas.client.vue (interactive flowchart from linkedSchemas) | ✅ DONE (approved) |
+| 7 | 7.3 | wire canvas into Pipeline tab (canvas top + step-map below); decode badge moved to canvas | ✅ DONE (approved) |
+| 7 | — | **PHASE 7 COMPLETE** — @vue-flow/core@1.48.2 (yarn); ProjectPolicyCanvas builds nodes/edges from linkedSchemas (lifecycle columns, fan-out edges, custom #node-step, ⓘ→RawVcDrawer w/ @mousedown.stop+@click.stop drag-guard); decode badge moved off step-map (no dup/dangling). Backend tsc 0 / jest 65p·5f. FE typecheck == 12 frozen errors, zero new. 1 new dep (user-approved ×2). | ✅ |
+| 7 | 7.4 | **SSR FIX (post-deploy bug):** `build.transpile:['@vue-flow/core']` in nuxt.config.ts | ✅ DONE (verified) |
+| 7 | — | **LESSON:** junior's `nuxi build` PASS was NOT a sufficient gate — a passing build does NOT exercise SSR RUNTIME. The project page (default Summary tab) SSR-crashed at module-eval ("Cannot read properties of null (reading 'ce')", conn-reset/0-byte) because @vue-flow/core's untranspiled ESM is pulled into the server bundle graph via the .client.vue import — `.client.vue`/`<ClientOnly>` stops RENDER, not module LOAD. Fix = `build.transpile:['@vue-flow/core']` (vue-flow's documented Nuxt requirement). **Verified by running the Nitro preview server (PORT=3100, API on 3030): project page HTTP 200 / 114KB / 0.35s, no ce/vue-flow error — previously 000/0-byte/conn-reset.** ARCHITECT GATE going forward for any client-only DOM-lib dep: run `node .output/server/index.mjs` + curl the consuming page, not just `nuxi build`. **USER ACTION: nuxt.config changes are NOT hot-reloaded — the running dev server must be RESTARTED to pick up the fix.** | ✅ |
+
+## Phase 7 — Interactive policy flowchart canvas (Pipeline tab)
+
+User wants a "canvas-like flowchart" of the policy on the Pipeline tab: nodes by
+lifecycle, schema shown, VC-availability overlaid, decode-method at the very top.
+
+**Exploration facts (DB-confirmed):**
+- policy.json block tree lives under top-level `config` (root `interfaceContainerBlock`).
+  HUGE: 166–295 blocks/policy, 35–86 schema-bearing (heavy dup across
+  requestVcDocumentBlock / documentsSourceAddon / documentValidatorBlock /
+  externalDataBlock / interfaceActionBlock). A faithful full render is unreadable.
+- **No backend change needed**: `project.linkedSchemas` already delivers every
+  schema with `{ schemaUuid, schemaName, isProjectSchema, docType, vcCount,
+  linkedVcs:[{consensusTimestamp,topicId,csId}] }` — the node set + VC availability.
+- FE has NO flowchart lib. `RelationshipDiagram.client.vue` (522 lines) already
+  renders a STATIC SVG registry→policy→schema→VC graph in the Advanced tab (L983),
+  but NO pan/zoom. Client-only pattern in repo = `*.client.vue` + direct CSS import
+  + `<ClientOnly>` wrapper (see ProjectMap.client.vue, maps at [id].vue L597/982).
+
+**User decisions (locked):** (1) Document-workflow graph (distinct schemas as nodes,
+lifecycle order) — NOT the full block tree. (2) **Add @vue-flow/core** (new dep
+explicitly approved, twice — overrides the standing no-new-deps rule for THIS feature
+only; record in DECISIONS). (3) Canvas on top + existing vertical step-map below in
+the Pipeline tab. (4) RelationshipDiagram (Advanced) left untouched.
+
+**Design:**
+- NEW `frontend/components/project/ProjectPolicyCanvas.client.vue` (client-only;
+  vue-flow is DOM-bound). Nodes from `project.linkedSchemas`; lifecycle columns via
+  DOC_TYPE_RANK (registration0/pdd1/validationReport2/monitoringReport3/
+  verificationReport4/unknown=last); stack rows for multiple nodes in a stage. Edges
+  connect each populated column to the next (fan-out across parallel nodes). Custom
+  node via `<template #node-...>` slot: docType label+icon, schemaName, project-schema
+  badge, availability (vcCount>0 green "Data present · <latest ts>" else grey
+  "Awaiting data"), ⓘ → RawVcDrawer (latest VC of that schema; same prop contract).
+  Pan/zoom = vue-flow core default; `:fit-view-on-init`. Fixed-height container
+  (~h-[440px]). Decode-method badge MOVES here (top) — remove it from
+  ProjectPipeline.vue header to avoid duplication.
+- `[id].vue` Pipeline tab → `space-y-6`; `<ClientOnly><ProjectPolicyCanvas
+  :project="project" /></ClientOnly>` ABOVE the existing `<ProjectPipeline>`.
+- Only ONE new dep: `@vue-flow/core` (+ its CSS `dist/style.css` + `dist/theme-default.css`).
+  Do NOT add @vue-flow/background|controls|minimap (extra deps) — core pan/zoom suffices.
+
+**Gotchas to flag to junior:** vue-flow needs CSS import in the component; may need
+`build.transpile: ['@vue-flow/core']` in nuxt.config.ts if typecheck/build complains;
+detect FE package manager (yarn.lock vs package-lock.json) before installing; types
+ship with the package (`import { VueFlow, type Node, type Edge }`).
+
+**Gate:** FE `npx nuxi typecheck` — new component type-clean, no new errors beyond the
+12 frozen baseline; `npx nuxi build` SHOULD succeed (vue-flow SSR/transpile is the main
+risk). Backend untouched → tsc 0 / jest 65p·5f unchanged.
+
+### 9.1 DONE (architect-implemented; subagent hit session limit) + HARD FINDING on edges
+- Built `src/api/services/policy-graph.builder.ts` (pure, tested — 4 unit tests pass),
+  `getPolicyGraph` in mapping-reprocess.service, passthrough in project.service,
+  `GET /:id/policy-graph` in project.controller. tsc 0; jest 69p/5f (+4 new). Endpoint
+  LIVE-curled (policy 0.0.10380341): **NODES + ROLES are excellent** — 7 real labeled
+  steps (Project Description Document, Monitoring Report, Daily Usage, New VVB,
+  validation/verification reports, Mint Token), roles [Project_Proponent, VVB, General, daily].
+- **EDGES = 0, and this is a REAL LIMITATION, not a bug.** Verified on 2 policies +
+  ts-node diagnostics: document/action blocks have NO outgoing flow events; ~all events
+  are `RefreshEvent` (UI) or intra-screen button→save wiring. Guardian policies do NOT
+  statically encode document→document flow — the wizard advances at runtime via step
+  blocks/grids, not static edges. So event-derived doc→doc edges are unavailable.
+  Tried node-centric collapse AND screen-scope collapse → both ~0 on real data.
+- **USER DECISION (locked): authored step-sequence spine + genuine event edges.** Builder
+  enhanced: PolicyGraphNode gains `order` (pre-order authored index); PolicyGraphEdge gains
+  `kind: 'flow' | 'sequence'`. 'flow' = real event transition (sparse). 'sequence' = within
+  each role lane, consecutive documents by authored order (the honest backbone; not a guessed
+  lifecycle). Dedup: a pair already a flow edge is not re-added as sequence. tsc 0; 5 unit
+  tests pass; full jest 70p/5f. **VERIFIED on real policy 0.0.1810874 via ts-node: 7 real
+  nodes (Project information→Site details, New Installer→Device as within-role sequence
+  edges), flow=0 (confirms finding), roles from permissions+tag-prefix.** NOTE: live dev DB
+  is churning (worker re-keying/re-decoding) so endpoint curls 404 intermittently — code is
+  correct (proven via direct ts-node + unit tests). Role names from tag-prefix fallback
+  (e.g. 'request','mrv','mint') are a bit noisy — acceptable; cleanup is a future refinement.
+- **9.2 frontend DONE (architect-built).** Rewrote ProjectPolicyCanvas.client.vue: fetches
+  /policy-graph (guarded by import.meta.client), renders vue-flow role SWIMLANES (lane per
+  role in graph.roles order via #node-lane gutter labels; step nodes x = rank-within-lane by
+  authored order, y = lane). Edges: flow = solid primary+animated, sequence = dashed muted
+  (legend explains both). VC overlay from project.linkedSchemas by schemaUuid (green "Data
+  present · ts" + ⓘ→RawVcDrawer when vcCount>0, else "Awaiting data"). Decode badge kept at
+  top. **VERIFIED: my component type-clean (nuxi typecheck shows ZERO errors in
+  ProjectPolicyCanvas; the 2 errors seen are pre-existing drift in untouched credits/projects
+  index.vue — git confirms only my file changed). nuxi build PASS. SSR preview (node
+  .output/server, PORT 3100): project page summary + #pipeline both HTTP 200, 96KB, no
+  ce/SSR-error markers.** Backend untouched (tsc 0 / jest 70p·5f).
+- **PHASE 9 COMPLETE.** Honest outcome: real role lanes + documents + VC overlay + authored
+  step-sequence spine + genuine (sparse) flow edges — no fabricated lifecycle fan-out.
+
+### 9.3 fixes (user feedback on rendered canvas) — DONE
+User saw: no arrows, a bogus "Mint" role lane, wanted a policy-JSON view.
+1. **No arrows** = vue-flow custom nodes need `<Handle>` to attach edges. Added
+   `<Handle type=target Left>` + `<Handle type=source Right>` to #node-step. Edges
+   (5 in data) now render. (Lesson: custom VueFlow nodes MUST include Handles.)
+2. **Bogus 'Mint'/'request'/'mrv' role lanes** = tag-prefix fallback in roleOf. DROPPED
+   it — role = permissions[0] only, else 'General'. Live curl now: roles
+   ["Admin","Transcriber","General"] (was [...,"mint"]). Unit tests still 5/5 (use perms).
+3. **Policy JSON viewer**: new `GET /:id/policy-json` (rawPolicyJson; lazy) + "Policy JSON"
+   button in canvas header → slide-over with pretty-printed JSON. Live: HTTP 200, 41KB.
+   tsc 0; jest 70p/5f; canvas type-clean. Did NOT re-run `nuxi build` in-place (pollutes
+   dev .nuxt — Phase-7/8 lesson). USER: restart dev to see arrows + clean lanes + JSON btn.
+
+### 9.4 fixes (2nd canvas feedback) — DONE
+User saw: still no connecting lines; a document (dMRV) appeared TWICE with both "data
+present" while the Mint between them was "awaiting" (confusing).
+1. **Edges existed (curl showed 4) but rendered invisibly**: stroke was `hsl(var(--border))`
+   (~white on white) + no arrowhead. FIX (frontend): concrete colors (#6366f1 flow / #94a3b8
+   sequence) + `markerEnd: MarkerType.ArrowClosed`. Now clearly visible directed arrows.
+2. **Duplicate document nodes**: policy had two requestVcDocumentBlocks for the SAME schema
+   (dMRV) → two nodes, both data-present, with Mint awaiting in between. FIX (builder):
+   dedupe document nodes by schemaUuid (first authored occurrence wins; actions kept). Now
+   one node per document → Mint Token correctly LAST + awaiting. New unit test locks it.
+   tsc 0; builder jest 6/6; canvas type-clean. (Live curl flaky — dev DB churns project ids.)
+
+### 9.5 fixes (3rd feedback) — DONE
+User: DID shown as project name (project schema had no VC); proposed uniform cs.id keys +
+a metadata field; show projectKey on canvas.
+1. **Uniform cs.id keys + metadata**: resolver `resolved()` now carries `ResolutionMetadata`.
+   M1 (DynamicTopicResolver) keys by the topic's CANONICAL project cs.id (earliest
+   project-schema VC; base helper `canonicalCsIdInTopic`) instead of topicId, recording
+   `metadata.dynamicTopicId`. M2/M3/M4 record `metadata.rootVcTimestamp` (base helper
+   `earliestTimestampForCsId`). Service stores `newFields.metadata`. So ALL projects are
+   cs.id-keyed; the method anchor lives in businessData.metadata. Exposed via DTO.metadata
+   → FE model/composable → canvas header shows Project key + anchor.
+2. **Name gap-fill**: mapper now lets `name` extract from ANY data-bearing VC (gap-fills via
+   merge; other fields still guarded vs country pollution). PLUS API displayName fallback: a
+   DID/topic-looking title is replaced by the project-schema name → methodology name.
+3. Canvas shows projectKey + anchor (dynamicTopicId / rootVcTimestamp) by the decode badge.
+   tsc 0; jest 72p/5f (+2 new resolver tests, all updated for metadata); FE changed files
+   type-clean. **REQUIRES worker restart + reparse (BACKFILL_PROJECTS_ON_BOOT=true): M1
+   projects re-key topic→cs.id, metadata/name populate, project_mint_link rebuilds.**
+
+## Phase 6 — Pipeline step-map + decode-method badge + tab restructure
+
+User request (2026-06): the Pipeline tab must become a **methodology step-map** —
+each policy schema (step) shown with whether VC data exists + its timestamp, so the
+project's progress through the methodology is visible. At the TOP, a badge showing
+the **decode method** (M1 Dynamic Topic / M2 CS Ref / M3 Relationship / M4 Single
+Schema). The CURRENT Pipeline content (flat VC trust-chain) MOVES into the Advanced
+tab, replacing its API-sourced Activity Log.
+
+**User decisions (locked):** (1) REMOVE the hardcoded "Methodology Workflow" box from
+Advanced. (2) The moved VC trust-chain REPLACES the existing API Activity Log in
+Advanced. (3) PERSIST decodeMethod (+ reparse later); existing rows show 'unknown'
+until reparsed — acceptable.
+
+**Key facts established during exploration:**
+- `linkedSchemas` (ProjectResponseDto) ALREADY carries every policy schema incl.
+  empty ones: `{ schemaUuid, schemaName, isProjectSchema, docType, vcCount,
+  linkedVcs:[{consensusTimestamp,topicId,csId}] }`. The step-map needs NO new
+  backend step data — only `decodeMethod`.
+- Decode method strings (from resolver `.method`): `'topic'` | `'csRef'` |
+  `'relationships'` | `'projectSchema'`. Surfaced as `resolvedProject.method` in
+  project-mapper.service.ts (currently only in the debug log ~L548).
+- Merge SQL: project-schema VC's businessData overrides (`||` order via
+  `_fromProjectSchema`), so decodeMethod converges to the identity VC's method.
+- FE typecheck baseline is FROZEN (exit 2, ~12 pre-existing errors listed above).
+  Gate = no NEW errors; new/edited .vue must be clean.
+
+**Design (minimal, pattern-consistent — 1 new FE file justified):**
+- NEW `frontend/components/project/ProjectTrustChain.vue` = current
+  ProjectPipeline.vue content VERBATIM (flat VC list + RawVcDrawer). Used in Advanced.
+- REWRITE `frontend/components/project/ProjectPipeline.vue` = step-map + decode badge.
+  Reads `project.linkedSchemas` (one card per schema/step, ordered by DOC_TYPE_RANK,
+  show vcCount>0 = "data present" + latest `consensusTimestamp`; keep the ⓘ →
+  RawVcDrawer per step that has VCs). Decode badge from `project.decodeMethod`.
+- `[id].vue`: Pipeline tab keeps `<ProjectPipeline>` (now step-map). Advanced tab:
+  replace inline Activity-Log markup (L924-953) with `<ProjectTrustChain>`; DELETE
+  the hardcoded "Methodology Workflow" block + `methodologySteps`/`activityTypeIcon`/
+  `activityLog`/`useProjectActivity` usage now unused. Leave the composable + API
+  endpoint files intact (out of scope; just stop importing in the page).
+
+**Constraints reaffirmed:** match existing code patterns; no new npm deps; preserve
+the upsert SQL verbatim; parameterized SQL; new @Injectable (none here) → module.
+Backend gate `npx tsc --noEmit` == TSC_EXIT:0 and `npx jest` unchanged (65p/5f).
 
 **Frontend typecheck baseline (`npx nuxi typecheck`, captured pre-change) — NOT CLEAN (exit 2):**
 ~12 pre-existing errors, FROZEN (gate = no NEW errors beyond these):
@@ -46,6 +232,195 @@ the AGENT-PROMPT review checklist.
 - `pages/status.vue` 763,18 — TS2345 onClick type
 New `.vue` files (RawVcDrawer, ProjectPipeline) must be type-clean; edits must not add errors.
 NOTE: nuxi typecheck is slow (installs vue-tsc, runs nuxt prepare). Run at FE task checkpoints.
+
+## Phase 9 — Real policy-flow swimlane canvas (rebuild ProjectPolicyCanvas) — ⏳ IN PROGRESS
+
+User rejected the Phase-7 canvas: it built nodes from `linkedSchemas` ordered by a generic
+DOC_TYPE_RANK with SYNTHETIC fan-out edges — not the methodology's real flow → "messy / makes no
+sense". Rebuild from the REAL `policy.json` graph.
+
+**DB-confirmed structure (policy.rawPolicyJson.config block tree):**
+- Block tags encode role: `Methodology Owner_requestVcDocumentBlock_87`. Better: `block.permissions[0]`
+  (e.g. `["Methodology Owner"]`). Lane universe + order = `rawPolicyJson.policyRoles` (array).
+- Meaningful NODE block types: requestVcDocumentBlock(349)+externalDataBlock(9) = category 'document'
+  (carry `schema`); mintDocumentBlock(85)+tokenActionBlock(10) = category 'action'. EXCLUDE
+  interfaceActionBlock(buttons)/containers/sources (plumbing).
+- Real connections = `events[] {source,target,input,output,actor}` (70–125/policy) BUT mostly
+  `output:'RefreshEvent'` = UI table-refresh NOISE. Keep only NON-RefreshEvent (RunEvent/Button*)
+  for flow. Edges connect node→node by BFS-collapsing through non-node tags.
+
+**User decisions (locked):** (1) **Role swimlanes** (lanes by role, flow order within, cross-lane
+edges on real handoffs). (2) **Readability-first** (one node per document/action, meaningful edges
+only, abstract plumbing, pan/zoom). VC data overlaid by matching node.schemaUuid → linkedSchemas.
+
+**Two reviewed passes:**
+- **9.1 backend** (api-dev): pure `src/api/services/policy-graph.builder.ts` →
+  `buildPolicyWorkflowGraph(rawPolicyJson, rawSchemaJson): { roles[], nodes[], edges[] }`. Node =
+  {tag, role, blockType, category, label, schemaUuid}. role = permissions[0]||tag-prefix||'General';
+  label = uiMetaData.title || schema name || friendly(blockType); edges = non-Refresh events
+  collapsed node→node (BFS, cycle-guarded, depth cap). Endpoint `GET /:id/policy-graph` (resolve
+  project's policy via businessData.policyTopicId → decoded policy row). Unit test for the builder.
+  GATE: tsc 0 / jest baseline+new; ARCHITECT curls policy 0.0.9280802 (4 roles: Methodology Owner/
+  Data Collector/Analyst/Facilitator) + the screenshot's simple policy → confirm graph is sensible
+  BEFORE 9.2.
+- **9.2 frontend** (frontend-dev): rewrite ProjectPolicyCanvas.client.vue to fetch /policy-graph,
+  render vue-flow with role lanes (y by role index, x by flow order/topo), real edges, custom node
+  (label, category icon, VC overlay: vcCount/latest-ts from linkedSchemas by schemaUuid, ⓘ→RawVcDrawer
+  when data present), decode badge at top. GATE: FE typecheck==frozen baseline + `nuxi build` +
+  **SSR preview curl (node .output/server/index.mjs) — build PASS ≠ SSR runtime (Phase-7 lesson)**.
+
+## Phase 8.1 — Nested sub-field labels in RawVcDrawer — ✅ COMPLETE
+
+Follow-up: nested objects (Guardian sub-schemas embedded as a cs field, e.g. cs.field0 =
+{field0,field1,…}) rendered sub-keys via humanizeKey → "Field0/Field1". FIX was FRONTEND-ONLY
+(architect did it directly — ~8 lines, single file): `policy.schemaFields` flattens nested fields
+to DOTTED paths under the parent schema IRI (`field0.field3`→"Project Name"), and buildVcFieldLabels
+(Phase 8) ALREADY returns every path of the matching schema — so nested labels were already in
+`fieldLabels` under dotted keys, just unused. Made RawVcDrawer.formatValue path-aware: added
+`pathPrefix` param + `labelForPath(path,key)=fieldLabels[path]||humanizeKey(key)`; nested object keys
+look up `${pathPrefix}.${k}`; `fields` passes the top-level key as prefix; array items keep the
+parent prefix (schema paths carry no index). Layout unchanged (`·`-joined; '…' for deeper objects).
+**LIVE-VERIFIED (project 1690396922…, VC 1690397951…, schema bfe9b860): vc-evidence returns 62
+labels (50 nested) — field0→"Project", field0.field0→"Project ID"(TEST002), field0.field1→
+"Issuing Category"(SMOKE_TEST), field0.field3→"Project Name", field0.field6→"Classification".** FE
+typecheck == 12 frozen baseline, zero new. No backend change. User picks up on next page reload.
+
+## Phase 8 — Raw-VC field labels from schema description (RawVcDrawer) — ✅ COMPLETE (approved)
+
+Architect-reviewed independently: additive `GET /:id/vc-evidence/:ts` → `{document, fieldLabels}`
+(reuses getLinkedVcDocument; buildVcFieldLabels joins message→policy by policyId, matches
+schemaFields by bare-UUID, label = description||title, try/catch → {}); RawVcDrawer fetches it,
+label = fieldLabels[key]||humanizeKey. `/linked-vcs` + its 3 consumers untouched. Backend tsc 0 /
+jest 65p·5f (re-run). **LIVE-VERIFIED on the user's Capturiant VC (project 1688034970…): field19→
+"Project Developer Name", field20→"Name of Project", field22→"Location", field23→"Type of Project",
+field24→"Project Methodology" — exactly the schema descriptions, not "FieldN".** USER ACTION: API
+dev server already serves it (curl 200); frontend picks it up on next reload (no nuxt.config change).
+
+
+
+User: the raw-VC drawer shows generic Guardian keys (`Field0`, `Field19`, …) via
+`humanizeKey`. They want the schema field's **description** ("Project Name",
+"Project Type", …) shown instead.
+
+**DB-confirmed:** `policy.schemaFields` (FlattenedSchemaField[]) carries
+`{ schemaIri, schemaName, path, title, description, type, isGeoJson }` for EVERY
+field of EVERY schema. For Guardian doc schemas the **description** is the human
+label (e.g. path `field4` → title `name` → description **"Project Name"**); all
+1769 field entries have both populated. So label precedence = description.trim()
+|| title.trim() || humanizeKey(key).
+
+**Endpoint consumers of `/:id/linked-vcs/:ts` (must NOT break):** RawVcDrawer.vue,
+RelationshipDiagram.client.vue (own popover), [id].vue ×2 (JSON modal). Only the
+DRAWER needs labels → use an ADDITIVE endpoint, touch nothing else.
+
+**Design (isolated, additive — 4 files, zero regression):**
+- `mapping-reprocess.service.ts`: new `getLinkedVcEvidence(network, projectId, ts)`
+  → `{ document, fieldLabels }`. REUSE existing `getLinkedVcDocument` for the
+  verification + doc fetch (no dup), then `buildFieldLabels`: read schema IRI from
+  `document.credentialSubject[0].type` (bare-UUID = strip `#`, split `&`), get the
+  VC's `policyId` from message, fetch `policy.schemaFields`, filter by bare-UUID
+  match, build `{ [path]: description||title }` (skip empties). Return `{}` on any
+  miss (drawer falls back to humanizeKey). Parameterized SQL only.
+- `project.service.ts`: passthrough `getLinkedVcEvidence`.
+- `project.controller.ts`: `@Get(':id/vc-evidence/:consensusTimestamp')` (no route
+  conflict w/ linked-vcs). Mirror existing linked-vcs handler swagger/params.
+- `RawVcDrawer.vue`: switch fetch to `/projects/:id/vc-evidence/:ts`; response is
+  `{ document, fieldLabels }` → `vcDoc.value = res.document`, keep
+  `fieldLabels` ref; `fields` label = `fieldLabels[key] || humanizeKey(key)`.
+  /linked-vcs stays for the other 3 consumers.
+
+**Gate:** backend `npx tsc --noEmit` == 0; `npx jest` == 65p/5f frozen. FE typecheck
+== 12 frozen baseline. Verify live: open drawer → labels read "Project Name" etc.,
+not "Field4" (needs running api+frontend; otherwise inspect code + a curl of the new
+endpoint).
+
+## Phase 10 — Issuance↔Project linking — ✅ COMPLETE (architect-reviewed)
+
+Pass A (api-dev junior): 10.1 linker self-heal (candidate NOT EXISTS now JOINs business_view —
+stale links re-resolve; ON CONFLICT repairs); 10.2 M2 gate relaxation (`!onProjectSchema &&
+!isKnownProjectRow(root)` → reject; ELV-class lifecycles now attach; order-dependence documented
+in-code); 10.3 linker Step 1.75 'ref_root' (relationship ancestors' cs.id/cs.ref matched against
+projectKey — decouples linking from linkedVcs completeness); 10.4 issuanceEvents (repo query +
+IssuanceEventRow + IssuanceEventDto + ProjectResponseDto.issuanceEvents, per-token aggregation
+untouched); 10.6 cs-ref.resolver.spec.ts (4 tests). GATES: tsc 0; jest 76p/5f (+4).
+**ARCHITECT LIVE PROBES: new candidate query = exactly 338 (36 never-linked + 302 stale);
+sampled stale mint resolves via Step 1 to current DID key — self-heal verified.**
+Pass B (frontend-dev junior): IssuanceEvent model + composable mapping; IssuancesTable reworked
+(primary per-event history table, per-token totals strip, v-else fallback to old per-token table,
+view-vc contract preserved; junior's justified deviation: [id].vue handleViewVc falls back to
+c.rawVc for event rows). FE typecheck == pre-existing baseline only (now incl. the 2 'search'
+TS2339 drift errors in credits/projects index — NOT ours).
+**OPERATIONAL: worker RESTART required to load the new linker/resolver code; stale links then
+self-repair on the next business-view build cycle. The gate relaxation needs the already-pending
+reparse (BACKFILL_PROJECTS_ON_BOOT=true once) to re-attach dropped lifecycle VCs.**
+
+### Phase 10 original plan (user-approved decisions)
+
+**Goal:** every MintToken VC reliably linked to its project; project shows full issuance
+history (one project ↔ many issuances).
+
+**Live-DB diagnosis (mainnet, 2026-06-11):**
+- 397 MintToken VCs; 361 in project_mint_link (349 relationship / 11 topic_scope / 1 cs_ref).
+- **302/361 links STALE** — all old M1 topic-id keys (`0.0.x`) orphaned by the M1
+  topic→cs.id re-key. Linker is incremental (`NOT EXISTS pml`) → never repairs stale rows.
+- 36 never-linked mints: their topics hold NO project row yet (will link once projects
+  resolve there; linker already retries these each run).
+- Mint signals: 392/397 have options.relationships; 0 carry own cs.ref → relationship
+  CTE stays primary. Linker runs at end of business-view-builder (good cadence).
+- API findById: issuances AGGREGATED per token (mintsByToken) — multiple mints of one
+  token collapse to one row. Fallback paths (instanceTopicId CREDIT rows) exist because
+  pml is incomplete.
+
+**User decisions (locked):** (1) INCLUDE M2/M3 gate relaxation (accept ref-root that is
+an already-known PROJECT row, not only the designated project schema) — fixes both the
+pipeline "Awaiting data" gaps (ELV case) and gives the mint relationship-walk a complete
+linkedVcs to land on. (2) Issuances displayed PER MINT EVENT (date/amount/token/rawVc
+history) + keep per-token totals for summary numbers.
+
+**Tasks:**
+- 10.1 Linker self-heal (mint-project-linker.ts): widen the candidate query to ALSO
+  select mints whose pml.project_key no longer matches a PROJECT row (LEFT JOIN
+  business_view … IS NULL) — re-resolve + upsert (ON CONFLICT already updates). One-time
+  repair falls out automatically on next build cycle; optionally DELETE stale rows first.
+- 10.2 Gate relaxation (cs-ref.resolver.ts + relationships.resolver.ts already has it via
+  confirmProjectKey): M2 reject only if `!onProjectSchema && !isKnownProjectRow(root)`.
+  Update resolver unit tests. NOTE ordering: known-project check is inherently
+  order-dependent (root project row must exist first) — fine: the project-schema VC keys
+  the row via M4/M2 first; reparse passes are iterative; document this in DECISIONS.
+- 10.3 New linker step 1.75 (belt+braces): when relationship walk misses linkedVcs, take
+  each relationship-ancestor VC's cs.ref-chain ROOT cs.id and match bv."projectKey" —
+  decouples linking from linkedVcs completeness for not-yet-reparsed projects.
+- 10.4 API (pg-project.repository + project.dto): keep per-token aggregates for
+  totalIssued/summary; ADD `issuanceEvents` (one per pml row: mintConsensusTimestamp,
+  tokenId, amount, mintDate, linkMethod, rawVc lazily?) — expose via DTO; FE model +
+  composable mapping.
+- 10.5 FE IssuancesTable / project page: render issuance history (per-event rows,
+  date+amount+token), totals row per token unchanged.
+- 10.6 Unit tests: linker self-heal SQL shape (if testable), M2 relaxation cases.
+- 10.7 Verify on live DB: stale links → 0 after a build cycle; unlinked count drops as
+  projects appear; ELV project pipeline lights up post-reparse; project page shows
+  multi-issuance history. REQUIRES worker restart + reparse (BACKFILL_PROJECTS_ON_BOOT)
+  for the gate relaxation to re-attach dropped VCs.
+
+## Redict OOM fix (BullMQ unbounded completed jobs)
+
+Symptom: `ReplyError: OOM command not allowed when used memory > 'maxmemory'` on
+queue writes; Redict at 1.48G/1.46G cap (`noeviction`), 1.37M keys.
+Root cause (two layers): (1) `BullModule.registerQueue(...map(name => ({ name })))`
+in worker.module.ts attached NO defaultJobOptions, so the `removeOnComplete:100`
+configs in bullmq.config were NEVER applied — completed jobs kept forever.
+(2) topic-sync.processor re-enqueues a uniquely-named keep-alive job
+(`topic-{id}-poll-{Date.now()}`) every poll cycle → completed set grew to 677k
+(mainnet) + 544k (testnet) = the OOM.
+Fix: (a) topic-sync.processor — added `removeOnComplete: true, removeOnFail: 1000`
+to BOTH self-enqueues (poll + next-page) AND the message `addBulk` opts.
+(b) worker.module — wired per-queue `removeOnComplete`/`removeOnFail` from
+getQueueConfigs() into registerQueue defaultJobOptions (retention only; left
+attempts/backoff alone to not change retry behaviour). Freed Redict via FLUSHALL
+(1.48G→1.5M; transient BullMQ + se: cache only, Postgres untouched). tsc 0.
+**USER must restart the worker** to load the retention fix (else old code re-accumulates).
+LESSON: any uniquely-named recurring BullMQ job MUST set removeOnComplete, and
+registerQueue needs defaultJobOptions or the configured retention is silently ignored.
 
 ## Phase 1 plan & ordering rationale
 

--- a/sustainable-explorer/.claude/architect-memory.md
+++ b/sustainable-explorer/.claude/architect-memory.md
@@ -334,6 +334,27 @@ DRAWER needs labels → use an ADDITIVE endpoint, touch nothing else.
 not "Field4" (needs running api+frontend; otherwise inspect code + a curl of the new
 endpoint).
 
+## Phase 10.1 — Mint Token node overlay (canvas) — ✅ COMPLETE
+User: Mint Token action node showed "Awaiting data" despite linked issuances. Cause: canvas
+overlay matches node.schemaUuid→linkedVcs; action nodes have schemaUuid=null → never lit.
+Fix (architect-direct, small): (1) backend getLinkedVcDocument verification widened — accepts
+timestamps in project_mint_link (project_key match) besides linkedVcs, so RawVcDrawer can open
+MintToken VCs (LIVE: vc-evidence for mint ts on Amines = HTTP 200, was 404). (2) canvas
+`mintOverlay` computed from project.issuanceEvents → applied to category 'action' nodes
+(vcCount=events.length, latestVc=last event's mintConsensusTimestamp; ⓘ opens drawer). NOTE:
+all action nodes in a policy share the project-level overlay (fine for the common 1-mint-block
+case). tsc 0; jest 76p/5f; canvas type-clean. POST-RESTART CONFIRMED WORKING: linker live
+(150 links on Amines incl. 2 ref_root). OPEN UX ITEM (user not yet decided): group 150×(+1)
+NFT mint events by token+date in IssuancesTable; issuanceCount list-vs-detail inconsistency.
+
+## Phase 10.2 — Multi-record count on canvas nodes — ✅ COMPLETE
+User asked how multiple issuances visualize on the Mint node (was: latest-only, no count).
+Canvas node availability row now shows "×N · latest <ts>" when vcCount>1 (single record keeps
+"Data present · <ts>"), tooltip carries the full text, ⓘ titled "View latest raw VC". Generic:
+benefits multi-VC document schemas (e.g. 9 monitoring reports) AND mint overlays (×150). ⓘ
+still opens the LATEST VC only — full per-event history intentionally lives in the Issuances
+tab. Canvas type-clean.
+
 ## Phase 10 — Issuance↔Project linking — ✅ COMPLETE (architect-reviewed)
 
 Pass A (api-dev junior): 10.1 linker self-heal (candidate NOT EXISTS now JOINs business_view —

--- a/sustainable-explorer/.claude/architect-memory.md
+++ b/sustainable-explorer/.claude/architect-memory.md
@@ -1,0 +1,130 @@
+# Architect Memory — Sustainable Explorer Mapping & Trust-Chain Pipeline
+
+Role: Senior Software Architect (opus). Plans + reviews only; never writes app code.
+Junior implementer: Sonnet subagents spawned one task at a time.
+Gate after every task: `npx tsc --noEmit` (expect `TSC_EXIT:0`) + `npx jest` (green) +
+the AGENT-PROMPT review checklist.
+
+## Status board
+
+| Phase | Task | Description | State |
+|-------|------|-------------|-------|
+| 1 | 1.1 | resolver.types.ts + circuit-breaker.ts | ✅ DONE (approved) |
+| 1 | 1.2 | topic-classifier.ts (R2) — pulled earlier | ✅ DONE (approved) |
+| 1 | 1.3 | base-resolver.ts (R1) | ✅ DONE (approved) |
+| 1 | 1.4 | four resolver strategies M1–M4 (R3) | ✅ DONE (approved) |
+| 1 | 1.5 | resolver-chain.service.ts (R4) | ✅ DONE (approved) |
+| 1 | 1.6 | document-type-classifier.ts + docType field + wire (R5) | ✅ DONE (approved; user-endorsed, D5) |
+| 1 | 1.7 | register providers in worker.module.ts (R7, providers only) | ✅ DONE (approved) |
+| 1 | — | **PHASE 1 COMPLETE** — resolver infra in place, no behaviour change | ✅ |
+| 2 | 2.1 | rewrite project-mapper.service.ts to call chain + docType guard (R6) | ✅ DONE (approved) |
+| 2 | 2.2 | delete migrated helpers; tsc+jest green | ✅ DONE (approved) |
+| 2 | — | **PHASE 2 COMPLETE** — chain drives projectKey; upsert SQL preserved verbatim | ✅ |
+| 3 | 3.1 | mint-project-linker.ts (R9) | ✅ DONE (approved) |
+| 3 | 3.2 | findActivity scoping (R10) | ✅ DONE (approved) |
+| 3 | 3.3 | schedulePolicyDecodeJobs + businessData.topicId (R11) | ✅ DONE (approved) |
+| 3 | 3.4 | rescheduleOrphanedTopics (R12) | ✅ DONE (approved) |
+| 3 | 3.5 | GIN index in schema-bootstrap.ts (R8) | ✅ DONE (approved) |
+| 3 | — | **PHASE 3 COMPLETE** — data-alignment fixes (topic-keyed joins, scoping, topic source, orphan rescue, GIN index) | ✅ |
+| 4 | 4.1 | circuit-breaker / resolver-chain / topic-classifier tests | ✅ DONE (approved, +13 tests) |
+| 4 | 4.2 | M1 + M4 strategy tests | ✅ DONE (approved, +6 tests) |
+| 4 | — | **PHASE 4 COMPLETE** — +19 passing tests (jest now 65 passed / 5 failed) | ✅ |
+| 5 | 5.0 | BACKEND: docType on linkedSchemas (reuse stamped) + schemaName on ActivityEventDto (D8/D9) | ✅ DONE (approved) |
+| 5 | 5.1 | FE: docType+schemaName on types/models + useProjects composables | ✅ DONE (approved) |
+| 5 | 5.2 | RawVcDrawer.vue (REAL /linked-vcs/:ts, D7) | ✅ DONE (typecheck-clean) |
+| 5 | 5.3 | ProjectPipeline.vue (orders by docType, reads linkedSchemas) | ✅ DONE (typecheck-clean) |
+| 5 | 5.4 | Pipeline tab in [id].vue | ✅ DONE (typecheck-clean) |
+| 5 | — | **PHASE 5 COMPLETE** — nuxi typecheck error set == baseline (no new errors); new .vue files clean | ✅ |
+| — | — | **ALL PHASES COMPLETE (1–5).** Backend tsc 0 / jest 65p·5f(frozen). FE typecheck == baseline. | ✅ |
+
+**Frontend typecheck baseline (`npx nuxi typecheck`, captured pre-change) — NOT CLEAN (exit 2):**
+~12 pre-existing errors, FROZEN (gate = no NEW errors beyond these):
+- `components/shared/FilterBar.vue` 410,33 + 424,33 — TS1117 duplicate object props (×2)
+- `composables/useProjects.ts` 172,15 — TS2321 excessive stack depth (Nuxt route-type recursion) (×2)
+  — I edit this file for 5.1 but at lines ~187/~195 (ActivityEvent + mapActivityEvent), NOT line 172.
+- `pages/methodologies/[id].vue` 315/334/1146/1148/1149/1152/1155 — TS7053 ResolvedFieldKey index (×7)
+- `pages/status.vue` 763,18 — TS2345 onClick type
+New `.vue` files (RawVcDrawer, ProjectPipeline) must be type-clean; edits must not add errors.
+NOTE: nuxi typecheck is slow (installs vue-tsc, runs nuxt prepare). Run at FE task checkpoints.
+
+## Phase 1 plan & ordering rationale
+
+Prompt lists Phase 1 as 1.1–1.6. I REORDERED for compile-safety (see DECISIONS.md D1):
+
+1. **1.1** `resolver.types.ts` + `circuit-breaker.ts` — zero external deps, independently
+   tsc-clean and unit-testable. Done first.
+2. **1.2** `topic-classifier.ts` (R2) — pulled ahead of base-resolver because
+   `base-resolver.ts` imports `TopicClassifierService` in its constructor and uses it in
+   `confirmProjectKey()`. Building base-resolver first would fail tsc.
+3. **1.3** `base-resolver.ts` (R1) — abstract `@Injectable()` base. Ports the graph-walk
+   helpers from `project-mapper.service.ts` (resolveViaRef, resolveViaRelationships,
+   isCsIdReferencedByOtherVcs, isCsIdOnProjectSchema) + adds new ones (isKnownProjectRow,
+   confirmProjectKey, projectSchemaUuids, isCsIdOnProjectSchema permissive fallback).
+   NOTE: methods are COPIED here in Phase 1; they are DELETED from the service in Phase 2
+   Task 2.2. Temporary duplication is expected and acceptable (no behaviour change).
+4. **1.4** four strategies M1–M4, each extends base, implements only `resolve(ctx)`.
+5. **1.5** `resolver-chain.service.ts` — one CircuitBreaker per strategy (threshold=5,
+   cooldownMs=30_000), runs M1→M4.
+6. **1.6** R5 docType wiring — BLOCKED by missing files (see DECISIONS.md D2). Must FIRST
+   create `document-type-classifier.ts` (classifyDocumentType + DocumentType union) and ADD
+   `docType?` to PolicyMappingEntry, THEN wire into policy-pipeline.service.ts.
+7. **1.7** register new providers in `worker.module.ts` providers[] ONLY. Do NOT change
+   ProjectMapperService constructor yet — that happens in Phase 2 when its body uses the
+   chain. Phase 1 stays a true no-behaviour-change refactor (new providers registered but
+   not injected anywhere). NestJS tolerates unused providers; DI graph still resolves.
+
+## Source-of-truth facts gathered from the codebase
+
+- Stack confirmed: NestJS 11, TypeORM 0.3, BullMQ, ts-jest 29, TS 5.5. tsconfig: `strict`,
+  `noImplicitAny`, `strictNullChecks`. NO `noUnusedLocals/Parameters` → unused ctor params OK.
+- Path aliases: `@worker/*`, `@api/*`, `@shared/*` (tsconfig + jest moduleNameMapper).
+- Tests: `test/**`, `*.spec.ts`, `@jest/globals` imports, no real DB. tsconfig EXCLUDES
+  `test/` so `tsc --noEmit` covers `src/**` only; jest compiles tests via ts-jest.
+- `project-mapper.service.ts` ctor today: `(dataSource: DataSource, reverseGeoService)`.
+  Existing private methods to migrate: resolveProjectKeyViaRef (8 hops), isCsIdOnProjectSchema,
+  isCsIdReferencedByOtherVcs, findCanonicalProjectSchemaCsIdInTopic, resolveProjectKeyVia
+  Relationships (24-hop BFS, calls resolveProjectKeyViaRef internally), isDownstreamTopic +
+  DOWNSTREAM_TOPIC_NAMES static set. KEEP: queryPolicyByPolicyId, findPolicyVersionByTopicWalk,
+  the big upsert INSERT…ON CONFLICT, orphan-cleanup DELETE, module-level helpers.
+- `PolicyMapping = Partial<Record<ProjectFieldKey|string, PolicyMappingEntry[]>>`.
+  `PolicyMappingEntry` currently has source/schemaIri/schemaName/schemaType/fieldPath/
+  isProjectSchema/policyJsonPath/title/description/score. NO docType field (prompt wrong).
+- worker.module.ts: providers[] holds HederaService, IpfsService, ReverseGeoService,
+  ProjectMapperService, POLICY_ZIP_STORAGE, processors, scheduler, autoscaler. This is where
+  new @Injectables register.
+
+## Baseline test status (captured before any change) — NOT GREEN
+
+`npx tsc --noEmit` → **TSC_EXIT:0** (clean).
+`npx jest` → **46 passed, 5 failed, 3 suites broken.** Pre-existing, unrelated to this work:
+- `test/unit/message-parser.spec.ts:611` — `parsed.tokens` toEqual ['0.0.8001','0.0.8002'] fails.
+- `test/unit/worker/mapping/map-fields.strategy.spec.ts:259` — TS2554, `execute()` called with
+  3 args, signature now takes 2 (test stale vs mapping refactor).
+- `test/unit/worker/mapping/map-schemas.strategy.spec.ts` — imports missing members
+  (`IMapSchemasStrategy`, `map-schemas.provider`, `MapSchemasMethodType`) — test stale vs refactor.
+
+**Gate redefinition:** prompt assumes a green baseline; it is not. Until/unless the user asks me
+to fix these, the per-task gate is **TSC_EXIT:0 AND no failures beyond the 5 known-failing tests
+in the 3 broken suites above.** All Phase 1–4 work is in resolver/project-mapper/test files that
+do not touch these suites. FLAGGED to user.
+
+## Open questions / risks
+
+- **OQ1 (resolved → D2):** document-type-classifier.ts & PolicyMappingEntry.docType don't
+  exist. Plan: create them in Task 1.6. DocumentType union per R5. classifyDocumentType
+  signature `(schemaName, schemaId, fieldDefMap)` per R5 — design heuristic when we reach 1.6.
+- **OQ2:** `confirmProjectKey` "known PROJECT row" check reads business_view — must use
+  parameterized query + `viewType='PROJECT'`. Verify column is `projectKey` (it is, per upsert).
+- **OQ3:** TopicClassifierService cache must store ONLY definitive results
+  (kind!=='other' || instancePolicyTopicId!==null) to tolerate ingest-order misses.
+- **OQ4:** Phase 2/3 SQL fixes (R9–R12) touch live query behaviour — review each diff against
+  real column names before approving; cannot run the worker here, only tsc+jest.
+- **OQ5 (Phase 2):** R6 "Keep" list names `docTypeForSchema()` as if it exists in
+  project-mapper.service.ts — it does NOT (grep confirms only AGENT-PROMPT.md). It must be ADDED
+  in Phase 2 Task 2.1: a method that reads the docType stamped on the VC's schema entries
+  (from Task 1.6) to produce `vcDocType` for the extraction guard. Will add DECISIONS D5 then.
+
+## Review checklist (apply before every approval)
+No needless abstraction · no new deps · @Injectable + registered in worker.module ·
+parameterized SQL only · tsc clean · jest green · no existing behaviour changed unless required ·
+memory files updated.

--- a/sustainable-explorer/.claude/codebase-memory.md
+++ b/sustainable-explorer/.claude/codebase-memory.md
@@ -1,0 +1,44 @@
+# Codebase Memory — live module topology (update when files change)
+
+Stack: NestJS 11 (worker + api), TypeORM 0.3 (Postgres), BullMQ (Redict), Nuxt 3 frontend.
+TS strict, ts-jest. Path aliases `@worker/* @api/* @shared/*`. Git root is the parent
+`guardian/` dir (paths show `sustainable-explorer/...`).
+
+## Worker — project mapping subsystem
+- `src/worker/services/project-mapper.service.ts` — per-VC upsert into `business_view`.
+  Ctor: `(DataSource, ReverseGeoService)`. Resolves projectKey today via inline branches
+  (csRef walk → isProjectSchemaVc → strict-skip → relationships walk). Holds the big
+  INSERT…ON CONFLICT upsert + orphan-cleanup DELETE (must be preserved verbatim per prompt #8).
+  Private graph helpers here will migrate to base-resolver in Phase 1 / be deleted in Phase 2.
+- `src/worker/project-mapper/` — helpers.ts, improved-heuristic.mapper.ts, schema-classifier.ts
+  (classifyProjectSchema / buildSchemaEntryImproved), non-project-credential.ts, project-fields.ts
+  (PROJECT_EXTRACT_FIELDS / ProjectFieldKey), types.ts (FieldDef, SchemaEntry, ResolvedFieldPaths),
+  mint-project-linker.ts.
+  - `src/worker/project-mapper/resolvers/` (Phase 1, DONE): resolver.types.ts, circuit-breaker.ts
+    (CircuitBreaker, plain class), base-resolver.ts (abstract BaseProjectKeyResolver), the four
+    strategies (DynamicTopicResolver/CsRefResolver/RelationshipsResolver/ProjectSchemaResolver),
+    resolver-chain.service.ts (ProjectKeyResolverChain). All registered in worker.module.ts.
+  - `src/worker/project-mapper/topic-classifier.ts` (DONE) — TopicClassifierService (note: at
+    project-mapper/ root per prompt, not in resolvers/).
+  - `src/worker/project-mapper/document-type-classifier.ts` (DONE, created in 1.6 — was MISSING
+    despite prompt claiming it existed; see DECISIONS.md D2/D5). `DocumentType` union lives in
+    project-mapper/types.ts; `PolicyMappingEntry.docType?: string` added; stamped at decode time
+    in policy-pipeline.service.ts.
+  - STILL no `docTypeForSchema()` in project-mapper.service.ts despite R6 "Keep" list — must be
+    ADDED in Phase 2 Task 2.1 (architect-memory OQ5).
+- `src/worker/mapping/` — policy-pipeline.service.ts (decode-time stamping), policy-pipeline.types.ts
+  (PolicyMapping, PolicyMappingEntry, FlattenedSchemaField), classify-schema-type.ts,
+  flatten-schema-fields.ts, derive-project-meta.ts, mapping-pipeline.service.ts, mapping.module.ts.
+- `src/worker/worker.module.ts` — DI registration (providers[]). New @Injectables go here.
+- `src/worker/schedulers/sync-scheduler.service.ts` — onModuleInit scheduling (R11, R12 targets).
+- `src/worker/processors/business-view-builder.processor.ts` — businessData build (R11 target).
+
+## Shared / API / Frontend (touched in later phases)
+- `src/shared/database/schema-bootstrap.ts` — raw index creation (R8 GIN index target).
+- `src/api/repositories/pg-project.repository.ts` — findActivity/findById (R10 target).
+- `frontend/pages/projects/[id].vue`, `frontend/components/project/`,
+  `frontend/composables/useProjects.ts` — Phase 5 Pipeline tab.
+
+## Tests
+- `test/unit/**/*.spec.ts`, `@jest/globals`, no real DB. Only 3 spec files currently exist and
+  ALL 3 suites are RED at baseline (see dev-memory.md). New tests land in Phase 4.

--- a/sustainable-explorer/.claude/dev-memory.md
+++ b/sustainable-explorer/.claude/dev-memory.md
@@ -1,0 +1,123 @@
+# Dev Memory — implementation log (files changed, tsc/test status per task)
+
+Baseline (pre-work): `tsc` exit 0 · jest = 46 passed / 5 failed / 51 total / 3 suites.
+The 5 failures are PRE-EXISTING and out of scope:
+`message-parser.spec.ts`, `map-fields.strategy.spec.ts`, `map-schemas.strategy.spec.ts`.
+Gate going forward = tsc exit 0 AND jest no worse than this baseline.
+
+## Task 1.1 — resolver.types.ts + circuit-breaker.ts — ✅ APPROVED
+Created:
+- `src/worker/project-mapper/resolvers/resolver.types.ts` — ResolutionContext,
+  ResolutionOutcome (resolved|pass|reject), ResolvedProjectKey. Imports PolicyMapping from
+  `../../mapping/policy-pipeline.types`.
+- `src/worker/project-mapper/resolvers/circuit-breaker.ts` — `CircuitBreaker` plain class
+  (NOT @Injectable) + `CircuitBreakerLogger` interface. `run<T>(fn, fallback)`: OPEN→fallback
+  without calling fn; throw→counted+absorbed as fallback (never rethrows); success→CLOSED.
+  `openedAt: number | null` (null = CLOSED sentinel; required so Date.now()===0 still reads OPEN).
+Verified by architect: tsc exit 0; jest unchanged (5 failed/46 passed); only these 2 files added.
+
+## Task 1.2 — topic-classifier.ts — ✅ APPROVED
+`src/worker/project-mapper/topic-classifier.ts` — `TopicClassifierService` (@Injectable).
+`classifyTopic(dataSource, topicId)`: cache → instance check (Instance-Policy.instanceTopicId) →
+Topic msg parentId/name → dynamic-project (name ~/project/i + ancestor instance topic) → other.
+Caches only definitive. 12-hop ancestor walk w/ visited set. Verified tsc 0, jest unchanged.
+
+## Task 1.3 — base-resolver.ts — ✅ APPROVED
+`src/worker/project-mapper/resolvers/base-resolver.ts` — abstract @Injectable
+`BaseProjectKeyResolver(dataSource, topicClassifier)`. Outcome helpers resolved/pass/reject (use
+`this.method`). Ported verbatim: resolveViaRef, resolveViaRelationships, isCsIdReferencedByOtherVcs,
+isCsIdOnProjectSchema (now calls projectSchemaUuids; permissive empty-set→true). New:
+projectSchemaUuids, isKnownProjectRow, confirmProjectKey (dynamic-topic→topicId, project-schema→csId,
+known-row→csId, else null). Originals still in project-mapper.service.ts (deleted in 2.2). tsc 0.
+
+## Task 1.4 — four resolver strategies M1–M4 — ✅ APPROVED
+`resolvers/{dynamic-topic,cs-ref,relationships,project-schema}.resolver.ts`. Each @Injectable
+extends base, explicit ctor `super(dataSource, topicClassifier)`, fixed `method`. M1 topic (no
+over-merge guard), M2 csRef (reject 'cs.ref resolves to non-project-schema VC'), M3 relationships
+(pass if !walked or unconfirmed), M4 projectSchema (reject 'not the project schema, no cs.ref/ancestor').
+tsc 0, jest unchanged.
+
+## Task 1.5 — resolver-chain.service.ts — ✅ APPROVED
+`resolvers/resolver-chain.service.ts` — `ProjectKeyResolverChain` (@Injectable). Ctor (m1,m2,m3,m4);
+one CircuitBreaker per strategy (5, 30_000, logger). resolve() runs M1→M4: resolved→ResolvedProjectKey,
+reject→null+debug log, pass→next, all-pass→null. NestJS Logger accepted as CircuitBreakerLogger
+structurally (no cast). tsc 0.
+
+## Task 1.6 — document-type-classifier + docType wiring — ✅ APPROVED (user-endorsed, D5)
+NEW `project-mapper/document-type-classifier.ts` (classifyDocumentType, name heuristic). NEW
+`DocumentType` union appended to `project-mapper/types.ts`. Added `docType?: string` to
+PolicyMappingEntry. Wired into policy-pipeline.service.ts execute(): build titlesBySchema +
+docTypeBySchema, pass to attachSchemaMappings, stamp `docType: docTypeBySchema.get(schemaIri) ?? 'unknown'`.
+Purely additive; extraction unchanged. tsc 0, jest unchanged. User reviewed & chose name heuristic.
+
+## Task 1.7 — register providers in worker.module.ts — ✅ APPROVED
+Added 6 imports + 6 providers (TopicClassifierService, 4 resolvers, ProjectKeyResolverChain) to the
+always-on services block. ProjectMapperService ctor NOT changed (Phase 2). Abstract base NOT
+registered. DI graph closes (chain→resolvers→DataSource+TopicClassifierService). tsc 0, jest unchanged.
+
+## PHASE 1 COMPLETE
+New files: topic-classifier.ts, document-type-classifier.ts, resolvers/{resolver.types,
+circuit-breaker, base-resolver, dynamic-topic.resolver, cs-ref.resolver, relationships.resolver,
+project-schema.resolver, resolver-chain.service}. Modified (additive): worker.module.ts,
+policy-pipeline.service.ts, policy-pipeline.types.ts, project-mapper/types.ts.
+Gate at phase end: tsc exit 0; jest 5 failed / 46 passed (== baseline, no regression).
+No behaviour change — chain is registered but not yet called. Next: Phase 2 (R6) wires it in.
+
+## Task 2.1 — wire chain into project-mapper.service.ts — ✅ APPROVED
+10 edits: import ProjectKeyResolverChain + PolicyMapping; module-scope DATE_ONLY_FIELD_KEYS;
+ctor gains resolverChain; local policyMapping typed `as PolicyMapping`; inline if/else resolution
+block (72 lines) → `resolverChain.resolve(ctx)` + null-skip; vcDocType/isDateOnlySource before
+extraction loop; two loop guards (validationReport break, date-only continue); ER_y skipped for
+validationReport; `via=${method}` in debug; new `docTypeForSchema()`. Upsert INSERT + orphan DELETE
+byte-for-byte unchanged (verified via diff). Behaviour changes intentional (M1 topic-keying; M3
+gated by confirmProjectKey). tsc 0, jest baseline. isDateOnlySource def → DECISIONS D6.
+
+## Task 2.2 — delete migrated helpers — ✅ APPROVED
+Removed 7 now-unused private members (resolveProjectKeyViaRef, resolveProjectKeyViaRelationships,
+isCsIdReferencedByOtherVcs, isCsIdOnProjectSchema, findCanonicalProjectSchemaCsIdInTopic,
+isDownstreamTopic, DOWNSTREAM_TOPIC_NAMES) + JSDoc. Fixed 1 stale comment naming the deleted method
+in the orphan-cleanup block (DELETE statement untouched). Cumulative service diff: +47/-350.
+grep confirms 0 remaining references. Upsert INSERT + orphan DELETE intact. tsc 0, jest baseline.
+PHASE 2 COMPLETE — chain now drives projectKey end-to-end.
+
+## Phase 3 — data alignment (R8–R12) — ✅ ALL APPROVED
+- 3.1 mint-project-linker.ts (R9): added `linkedVcs @>` containment arm to BOTH joins (Step 1 CTE
+  on consensusTimestamp; Step 1.5 on csId) so topic-keyed projects link. tsc 0, jest baseline.
+- 3.2 pg-project.repository.ts findActivity (R10): fetch businessData; count PROJECT rows on topic;
+  shared topic (>1) → timeline from this project's linkedVcs[].consensusTimestamp via ANY(); single
+  topic → original full-topic LIMIT 100 scan verbatim. tsc 0, jest baseline.
+- 3.3 R11 (2 files): sync-scheduler schedulePolicyDecodeJobs SELECT alias + NOT EXISTS now use
+  `COALESCE(NULLIF(m.options->>'topicId',''), m."topicId")`; business-view-builder businessData
+  'topicId' same. tsc 0, jest baseline.
+- 3.4 sync-scheduler rescheduleOrphanedTopics (R12): new method called after schedulePolicyDecodeJobs
+  in onModuleInit; finds Topic.childId / Instance-Policy.instanceTopicId refs not in topic_cache,
+  re-enqueues `topic-{id}-0` (remove-then-add). tsc 0, jest baseline.
+- 3.5 schema-bootstrap.ts (R8): appended GIN index idx_business_view_linked_vcs on
+  ("businessData"->'linkedVcs') WHERE viewType='PROJECT'. tsc 0, jest baseline.
+PHASE 3 COMPLETE. Full changeset: 10 modified + 11 new files (resolvers/9, topic-classifier,
+document-type-classifier). Gate: tsc 0, jest 46 passed/5 failed (frozen baseline).
+NOTE: all Phase 1–3 correctness is static-verified only (tsc + diff review); no DB/worker run here.
+
+## Phase 4 — unit tests (R13) — ✅ ALL APPROVED
+- 4.1: `test/unit/worker/project-mapper/resolvers/circuit-breaker.spec.ts` (5),
+  `.../resolvers/resolver-chain.spec.ts` (4), `test/unit/worker/project-mapper/topic-classifier.spec.ts`
+  (4). Uses `@worker/*` alias imports (jest moduleNameMapper). Deviation: `afterEach(() => { jest.restoreAllMocks(); })`
+  with braces — arrow-returning-jest-namespace fails @types/jest@30 void check. Endorsed.
+- 4.2: `.../resolvers/dynamic-topic.resolver.spec.ts` (3), `.../resolvers/project-schema.resolver.spec.ts` (3).
+  Mock TopicClassifierService / DataSource via `as unknown as` (standard test casts).
+Jest now: **65 passed / 5 failed / 70 total** (5 failures = the 3 pre-existing broken suites, untouched).
+tsc 0. Only test files added. PHASE 4 COMPLETE.
+
+## Phase 5 — frontend Pipeline + Trust Chain (+ backend exposure) — ✅ ALL DONE
+Decisions D7–D10 (real endpoint/field names; reuse stamped docType; implement 5.1 fully; nuxi typecheck gate).
+- 5.0 BACKEND (tsc0/jest65): PolicySchemaRow.docType; findById builds docTypeByIri from policyMapping
+  (reuses Phase 1 stamped docType, no re-classify); LinkedSchemaDto.docType + fromRow; ActivityEventDto.schemaName.
+- 5.1 FE: types/models LinkedSchema.docType; useProjects mapApiProject docType + ActivityEvent.schemaName + mapActivityEvent.
+- 5.2 RawVcDrawer.vue — right slide-over, fetches `/projects/:id/linked-vcs/:ts` (PLURAL), renders cs[0]
+  as human-readable trust-chain panel (issuer DID, key-values, HashScan link). Teleport drawer.
+- 5.3 ProjectPipeline.vue — vertical timeline from linkedSchemas, ordered by docType
+  (registration→pdd→validation→monitoring(s)→verification→unknown last), each VC a step, ⓘ→RawVcDrawer.
+- 5.4 [id].vue — added 'pipeline' to TabKey/VALID_TABS, tab button (Activity icon), v-else-if panel.
+FE typecheck (`npx nuxi typecheck`): error set IDENTICAL to frozen baseline (FilterBar×2, useProjects:173
+TS2321×2 [was :172, shifted by additive edit], methodologies/[id]×7, status.vue×1). New .vue files = 0 errors.
+PHASE 5 COMPLETE. ALL PHASES (1–5) COMPLETE.

--- a/sustainable-explorer/.claude/dev-memory.md
+++ b/sustainable-explorer/.claude/dev-memory.md
@@ -121,3 +121,82 @@ Decisions D7–D10 (real endpoint/field names; reuse stamped docType; implement 
 FE typecheck (`npx nuxi typecheck`): error set IDENTICAL to frozen baseline (FilterBar×2, useProjects:173
 TS2321×2 [was :172, shifted by additive edit], methodologies/[id]×7, status.vue×1). New .vue files = 0 errors.
 PHASE 5 COMPLETE. ALL PHASES (1–5) COMPLETE.
+
+## Phase 6 — Pipeline step-map + decodeMethod badge (Tasks 6.1–6.4) — ✅ COMPLETE
+
+### Files changed
+- `src/worker/services/project-mapper.service.ts` — added `newFields.decodeMethod = resolvedProject.method;` after `newFields.status = 'Issuing'`. Upsert SQL untouched.
+- `src/api/dto/project.dto.ts` — added `decodeMethod: string | null` @ApiProperty field alongside vcCount; added `decodeMethod` in fromRow return object.
+- `frontend/types/models.ts` — added `decodeMethod?: string | null` to Project interface.
+- `frontend/composables/useProjects.ts` — added `decodeMethod: typeof raw.decodeMethod === 'string' ? raw.decodeMethod : null` in mapApiProject return object.
+- `frontend/components/project/ProjectTrustChain.vue` — CREATED: verbatim copy of old ProjectPipeline.vue (flat VC trust-chain timeline).
+- `frontend/components/project/ProjectPipeline.vue` — REWRITTEN: one card per schema (step-map), decode-method badge at top, data-present indicator with CheckCircle2/Circle, ⓘ→RawVcDrawer on latest VC per schema.
+- `frontend/pages/projects/[id].vue` — removed Activity Log card + Methodology Workflow card from Advanced tab; inserted `<ProjectTrustChain :project="project" />`; removed `useProjectActivity`/`activityEvents`/`activityLog`/`activityTypeIcon`/`methodologySteps` symbols; removed unused lucide icons (Clock, CheckCircle2, Circle, Zap). `fullMethodologyName` kept (still used by Methodology Field Mapping block at lines 1023/1025). Pipeline tab unchanged (auto-updated via component rewrite).
+
+### Verification
+- TSC_EXIT:0 (backend tsc --noEmit -p tsconfig.json)
+- Jest: Tests: 5 failed, 65 passed, 70 total — matches frozen baseline
+- Frontend nuxi typecheck: exit 2 with exactly the frozen baseline errors (FilterBar.vue×2, useProjects.ts:174 TS2321×2, methodologies/[id].vue×7, status.vue×1). Zero new errors introduced.
+
+## Phase 7 — Policy Flowchart Canvas (Tasks 7.1–7.3) — ✅ COMPLETE
+
+### Dependency added
+- `@vue-flow/core@1.48.2` installed via `yarn add` in `frontend/`.
+- `build.transpile` fix NOT needed — `.client.vue` suffix prevents SSR touching vue-flow; build passed without it.
+
+### Files changed
+- `frontend/components/project/ProjectPolicyCanvas.client.vue` — CREATED. `.client.vue` suffix for DOM-bound vue-flow. Imports VueFlow + Node/Edge types, `@vue-flow/core/dist/style.css` + `theme-default.css`. Custom `#node-step` slot renders a 220px card per schema: docType icon+label, schemaName, project-schema chip, VC availability row (CheckCircle2 / Circle), ⓘ button with `@mousedown.stop @click.stop` → RawVcDrawer. Nodes grouped by DOC_TYPE_RANK into columns (x = colIdx × 260, y = rowIdx × 140). Fan-out edges link every node in column i to every node in column i+1. `decodeMeta` computed with decode badge in header. Empty state when no linkedSchemas. Fixed-height container `h-[440px]`.
+- `frontend/components/project/ProjectPipeline.vue` — removed `decodeMeta` computed (interface + switch block) and the badge `<span>` from the header template. Step-map list and all other markup preserved.
+- `frontend/pages/projects/[id].vue` — Pipeline tab panel changed from `class="p-6"` to `class="p-6 space-y-6"`, `<ClientOnly><ProjectPolicyCanvas :project="project" /></ClientOnly>` added above `<ProjectPipeline>`.
+
+### Verification
+- @vue-flow/core version: 1.48.2 (yarn)
+- `build.transpile` needed: NO
+- `npx nuxi typecheck`: exit 2 with exactly the frozen baseline errors (FilterBar.vue×2, useProjects.ts TS2321×2, methodologies/[id].vue×7, status.vue×1). Zero new errors.
+- `npx nuxi build`: PASS — client built in ~46s, server built in ~9s, no SSR/transpile errors.
+- Backend `tsc --noEmit -p tsconfig.json`: EXIT 0
+- Backend `jest`: Tests: 5 failed, 65 passed, 70 total — matches frozen baseline exactly. No backend files touched.
+
+## Phase 8 — Schema labels in RawVcDrawer (Tasks 8.1–8.2) — ✅ COMPLETE
+
+### Files changed
+- `src/api/services/mapping-reprocess.service.ts` — additive: new private method `buildVcFieldLabels(ds, consensusTimestamp, document)` (extracts bareUuid from cs[0].type, joins message→policy on policyId WHERE decodeStatus='decoded', iterates schemaFields entries matching bareUuid, returns path→(description||title) map; wrapped in try/catch → returns {} on any error); new public method `getLinkedVcEvidence(network, projectId, consensusTimestamp)` (calls existing `getLinkedVcDocument`, then `buildVcFieldLabels`; returns `{ document, fieldLabels }`). getLinkedVcDocument unchanged.
+- `src/api/services/project.service.ts` — additive: passthrough `getLinkedVcEvidence(network, projectId, consensusTimestamp)` delegating to `mappingReprocessService.getLinkedVcEvidence`. getLinkedVcDocument passthrough unchanged.
+- `src/api/controllers/project.controller.ts` — additive: new route `@Get(':id/vc-evidence/:consensusTimestamp')` with `@ApiOperation`, `@ApiParam` ×3, `@ApiResponse` ×2 mirroring linked-vcs handler style. Calls `projectsService.getLinkedVcEvidence`. Existing linked-vcs route and all other routes unchanged.
+- `frontend/components/project/RawVcDrawer.vue` — added `fieldLabels = ref<Record<string,string>>({})`. `load()` now fetches `/vc-evidence/${props.consensusTimestamp}` (was `/linked-vcs/`), sets `vcDoc.value = res.document ?? null` + `fieldLabels.value = res.fieldLabels ?? {}`, resets `fieldLabels.value = {}` at start. `fields` computed uses `fieldLabels.value[key] || humanizeKey(key)` as label. No other consumers of /linked-vcs touched (RelationshipDiagram, [id].vue remain on /linked-vcs).
+
+### Verification
+- TSC_EXIT: 0
+- Jest: Tests: 5 failed, 65 passed, 70 total — frozen baseline exactly
+- Frontend nuxi typecheck: exit 2 with exactly the frozen baseline errors (methodologies/[id].vue×7, status.vue×1). Zero new errors from RawVcDrawer.vue.
+- curl `http://localhost:3030/api/v1/mainnet/projects/1759413394.156986243/vc-evidence/1759413394.156986243`: response shape `{ "document": {...}, "fieldLabels": {...} }` confirmed. fieldLabels has entries e.g. `"projectDescription":"Project Description"`. 2139 entries total (covers all schemas in the policy).
+- /linked-vcs route: HTTP 200 confirmed still working. No changes to RelationshipDiagram or [id].vue.
+
+## Phase 10B — IssuancesTable per-mint-event history (frontend) — ✅ COMPLETE
+
+### Files changed
+- `frontend/types/models.ts` — added `IssuanceEvent` interface (8 fields matching backend DTO); added `issuanceEvents?: IssuanceEvent[]` to `Project` interface (next to `issuances`).
+- `frontend/composables/useProjects.ts` — import `IssuanceEvent`; in `mapApiProject` added `issuanceEvents` mapping after `issuances` (Array.isArray guard; per-field typeof guards for string/number/object; defaults [] / null).
+- `frontend/components/project/IssuancesTable.vue` — reworked: primary path renders one row per `issuanceEvent` (Date/Token/Amount/Raw Data columns); per-token totals strip (border-t, px-5 py-2.5, text-xs muted) below history table; fallback v-else-if renders original per-token table verbatim when only `issuances` exist; empty state unchanged. Badge count shows events.length when events present, else linkedCredits.length. `makeEventCredit()` builds Credit-shaped payload with rawVc directly on it. linkMethod NOT shown in UI. Added no new imports.
+- `frontend/pages/projects/[id].vue` — `handleViewVc` now uses `issuance?.rawVc ?? c.rawVc ?? null` so event Credits (which carry rawVc on the payload) display correctly.
+
+### Verification
+- `npx nuxi typecheck`: exit 2 with exactly the frozen baseline errors (FilterBar.vue TS1117×2, useProjects.ts TS2321×2 at ~line 262, methodologies/[id].vue TS7053×5, credits/index.vue TS2339, projects/index.vue TS2339, status.vue TS2345). ZERO new errors.
+- view-vc emit contract preserved: still `(e: 'view-vc', payload: Credit): void`.
+- Fallback per-token table: markup preserved verbatim in `v-else-if="linkedCredits.length > 0"` branch.
+
+## Phase 10A — MintToken self-heal + M2 gate relax + issuance events API (Tasks 10.1–10.4, 10.6) — COMPLETE
+
+### Files changed
+- `src/worker/project-mapper/mint-project-linker.ts` — (10.1) candidate query NOT EXISTS now JOINs business_view to also pick up mints whose project_key no longer matches any PROJECT row (stale links self-heal on each run). Doc comment updated. (10.3) Added Step 1.75 (ref_root) between Step 1.5 and Step 2: recursive CTE walk of relationship ancestors; matches a PROJECT row where projectKey = ancestor cs.id OR cs.ref; linkMethod='ref_root', counter refRoot added. Final log line includes refRoot count.
+- `src/worker/project-mapper/resolvers/cs-ref.resolver.ts` — (10.2) M2 gate now also accepts a resolved root that is an already-known PROJECT row (isKnownProjectRow check added after onProjectSchema fails). Reject message updated. Comment explains ELV/registration-doc anchor case and order-dependence.
+- `src/api/repositories/project.repository.ts` — (10.4a/c) Added IssuanceEventRow interface; added issuanceEvents?: IssuanceEventRow[] to ProjectRow.
+- `src/api/repositories/pg-project.repository.ts` — (10.4a) mintTokenRows query SELECTs pml.mint_consensus_timestamp AS mint_ts, pml.link_method. (10.4b) issuanceEvents array built from mintTokenRows after metaMap is available. (10.4c) mapRow accepts + returns issuanceEvents (default []).
+- `src/api/dto/project.dto.ts` — (10.4d) New IssuanceEventDto class with @ApiProperty on all 8 fields + static fromRow. issuanceEvents: IssuanceEventDto[] added to ProjectResponseDto with @ApiProperty. Mapped in fromRow via IssuanceEventDto.fromRow.
+- `test/unit/worker/project-mapper/resolvers/cs-ref.resolver.spec.ts` — (10.6) New spec: 4 tests (pass with no csRef; classified + on-schema resolves; classified + NOT on schema but IS known PROJECT row resolves; classified + neither rejects).
+
+### Verification
+- `tsc --noEmit`: exit 0
+- `jest`: Tests: 5 failed, 76 passed, 81 total (baseline was 72 passed / 5 failed; +4 from new cs-ref spec). All 5 failures are pre-existing frozen failures.
+- Linker trigger/cadence: unchanged — still called from BusinessViewBuilderProcessor at end of view build.
+- Per-token aggregation logic: untouched — issuanceEvents is built separately after the aggregation loop.

--- a/sustainable-explorer/frontend/components/project/IssuancesTable.vue
+++ b/sustainable-explorer/frontend/components/project/IssuancesTable.vue
@@ -12,6 +12,10 @@ const emit = defineEmits<{
     (e: 'view-vc', payload: Credit): void;
 }>();
 
+// Per-mint-event issuance history (new path)
+const events = computed(() => props.project.issuanceEvents ?? []);
+
+// Per-token aggregate totals (derived from issuances — existing logic)
 const linkedCredits = computed<Credit[]>(() => {
     if (!props.project.issuances?.length) return [];
     return props.project.issuances.map(i => ({
@@ -27,6 +31,60 @@ const linkedCredits = computed<Credit[]>(() => {
         rawVc: i.rawVc ?? undefined,
     }));
 });
+
+// Header badge count: prefer events length, fall back to per-token count
+const badgeCount = computed(() =>
+    events.value.length > 0 ? events.value.length : linkedCredits.value.length,
+);
+
+function eventTypeLabel(type: string | null): 'Fungible' | 'Non-Fungible' {
+    return type === 'NON_FUNGIBLE_UNIQUE' ? 'Non-Fungible' : 'Fungible';
+}
+
+function makeEventCredit(e: {
+    mintConsensusTimestamp: string;
+    tokenId: string | null;
+    name: string | null;
+    symbol: string | null;
+    type: string | null;
+    amount: number | null;
+    mintDate: string | null;
+    rawVc: Record<string, any> | null;
+}): Credit {
+    return {
+        id: e.mintConsensusTimestamp,
+        tokenId: e.tokenId ?? '',
+        name: e.name ?? '',
+        symbol: e.symbol ?? '',
+        type: eventTypeLabel(e.type),
+        supply: e.amount ?? 0,
+        projectId: props.project.id,
+        registry: props.project.registry,
+        mintDate: e.mintDate ?? '',
+        rawVc: e.rawVc ?? undefined,
+    };
+}
+
+// Per-token totals from events (group by tokenId). Only worth showing when at
+// least one token was minted more than once — otherwise the strip just repeats
+// each row's amount.
+const tokenTotals = computed<{ symbol: string; total: number }[]>(() => {
+    if (!events.value.length) return [];
+    const map = new Map<string, { symbol: string; total: number; count: number }>();
+    for (const e of events.value) {
+        const key = e.tokenId ?? 'unknown';
+        const sym = e.symbol ?? e.tokenId ?? '—';
+        const existing = map.get(key);
+        if (existing) {
+            existing.total += e.amount ?? 0;
+            existing.count += 1;
+        } else {
+            map.set(key, { symbol: sym, total: e.amount ?? 0, count: 1 });
+        }
+    }
+    if (![...map.values()].some(t => t.count > 1)) return [];
+    return Array.from(map.values()).map(({ symbol, total }) => ({ symbol, total }));
+});
 </script>
 
 <template>
@@ -36,9 +94,76 @@ const linkedCredits = computed<Credit[]>(() => {
                 <Coins class="h-4 w-4 text-primary" />
                 Linked Issuances
             </h2>
-            <span class="text-xs text-muted-foreground">{{ linkedCredits.length }} issuance(s)</span>
+            <span class="text-xs text-muted-foreground">{{ badgeCount }} issuance(s)</span>
         </div>
-        <div v-if="linkedCredits.length > 0">
+
+        <!-- PRIMARY: per-mint-event issuance history -->
+        <template v-if="events.length > 0">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b bg-muted/20">
+                        <th class="text-left py-2.5 px-5 text-xs font-medium text-muted-foreground uppercase tracking-wider">Mint Date</th>
+                        <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Token</th>
+                        <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Token ID</th>
+                        <th class="text-left py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Type</th>
+                        <th class="text-right py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">Amount</th>
+                        <th class="text-center py-2.5 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                            <span class="inline-flex items-center gap-1">Raw Data <InfoTooltip text="Raw VC document on the blockchain" /></span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y">
+                    <tr v-for="e in events" :key="e.mintConsensusTimestamp" class="hover:bg-muted/30 transition-colors">
+                        <td class="py-3 px-5 text-muted-foreground tabular-nums">
+                            {{ e.mintDate ? formatDate(e.mintDate) : '—' }}
+                        </td>
+                        <td class="py-3 px-4">
+                            <div class="font-medium text-foreground">{{ e.name ?? e.tokenId ?? '—' }}</div>
+                            <div v-if="e.symbol" class="text-[11px] text-muted-foreground">{{ e.symbol }}</div>
+                        </td>
+                        <td class="py-3 px-4">
+                            <code v-if="e.tokenId" class="text-xs bg-muted rounded px-1.5 py-0.5 font-mono">{{ e.tokenId }}</code>
+                            <span v-else class="text-muted-foreground">—</span>
+                        </td>
+                        <td class="py-3 px-4">
+                            <span
+                                v-if="e.type"
+                                :class="[eventTypeLabel(e.type) === 'Fungible' ? 'bg-primary/10 text-primary' : 'bg-chart-4/10 text-chart-4', 'text-xs font-medium rounded-full px-2 py-0.5']"
+                            >
+                                {{ eventTypeLabel(e.type) }}
+                            </span>
+                            <span v-else class="text-muted-foreground">—</span>
+                        </td>
+                        <td class="py-3 px-4 text-right tabular-nums font-medium">
+                            {{ e.amount !== null ? `+${formatNumber(e.amount)}` : '—' }}
+                        </td>
+                        <td class="py-3 px-4 text-center">
+                            <button
+                                class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                                title="View Raw Data"
+                                @click="emit('view-vc', makeEventCredit(e))"
+                            >
+                                <FileJson class="h-3.5 w-3.5" />
+                            </button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <!-- Per-token totals strip -->
+            <div v-if="tokenTotals.length > 0" class="border-t px-5 py-2.5 flex flex-wrap gap-x-5 gap-y-1">
+                <span
+                    v-for="t in tokenTotals"
+                    :key="t.symbol"
+                    class="text-xs text-muted-foreground"
+                >
+                    {{ t.symbol }} &middot; total {{ formatNumber(t.total) }}
+                </span>
+            </div>
+        </template>
+
+        <!-- FALLBACK: per-token table (older CREDIT-row data) -->
+        <template v-else-if="linkedCredits.length > 0">
             <table class="w-full text-sm">
                 <thead>
                     <tr class="border-b bg-muted/20">
@@ -80,7 +205,9 @@ const linkedCredits = computed<Credit[]>(() => {
                     </tr>
                 </tbody>
             </table>
-        </div>
+        </template>
+
+        <!-- Empty state -->
         <div v-else class="px-5 py-8 text-center text-sm text-muted-foreground">
             No issuances have been made for this project yet.
         </div>

--- a/sustainable-explorer/frontend/components/project/ProjectPipeline.vue
+++ b/sustainable-explorer/frontend/components/project/ProjectPipeline.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { FileText, BookOpen, ShieldCheck, Activity, BadgeCheck, ExternalLink, Info } from 'lucide-vue-next';
+import type { Project } from '~/types/models';
+
+const props = defineProps<{ project: Project }>();
+
+const { network } = useNetwork();
+
+interface PipelineStep {
+    docType: string;
+    schemaName: string;
+    schemaUuid: string;
+    consensusTimestamp: string;
+    topicId: string;
+    isProjectSchema: boolean;
+}
+
+// Lifecycle order. Anything not listed (e.g. 'unknown', MintToken) sorts last.
+const DOC_TYPE_RANK: Record<string, number> = {
+    registration: 0,
+    pdd: 1,
+    validationReport: 2,
+    monitoringReport: 3,
+    verificationReport: 4,
+};
+
+interface DocTypeMeta { label: string; icon: unknown; color: string }
+const DOC_TYPE_META: Record<string, DocTypeMeta> = {
+    registration:       { label: 'Registration',  icon: FileText,   color: 'text-primary bg-primary/10' },
+    pdd:                { label: 'Project Design', icon: BookOpen,   color: 'text-primary bg-primary/10' },
+    validationReport:   { label: 'Validation',    icon: ShieldCheck, color: 'text-amber-600 bg-amber-50' },
+    monitoringReport:   { label: 'Monitoring',    icon: Activity,    color: 'text-sky-600 bg-sky-50' },
+    verificationReport: { label: 'Verification',  icon: BadgeCheck,  color: 'text-emerald-600 bg-emerald-50' },
+    unknown:            { label: 'Document',       icon: FileText,    color: 'text-muted-foreground bg-muted' },
+};
+
+function metaFor(docType: string): DocTypeMeta {
+    return DOC_TYPE_META[docType] ?? DOC_TYPE_META.unknown;
+}
+
+const steps = computed<PipelineStep[]>(() => {
+    const schemas = props.project.linkedSchemas ?? [];
+    const all: PipelineStep[] = [];
+    for (const s of schemas) {
+        for (const vc of s.linkedVcs) {
+            all.push({
+                docType: s.docType,
+                schemaName: s.schemaName ?? s.schemaUuid,
+                schemaUuid: s.schemaUuid,
+                consensusTimestamp: vc.consensusTimestamp,
+                topicId: vc.topicId,
+                isProjectSchema: s.isProjectSchema,
+            });
+        }
+    }
+    return all.sort((a, b) => {
+        const ra = DOC_TYPE_RANK[a.docType] ?? 99;
+        const rb = DOC_TYPE_RANK[b.docType] ?? 99;
+        if (ra !== rb) return ra - rb;
+        return a.consensusTimestamp.localeCompare(b.consensusTimestamp);
+    });
+});
+
+const projectId = computed(() => props.project.sourceTimestamp ?? props.project.id);
+
+function formatTimestamp(ts: string): string {
+    if (!ts) return '—';
+    const secs = parseFloat(ts);
+    return isNaN(secs) ? ts : new Date(secs * 1000).toLocaleString();
+}
+
+function hashscanTopic(topicId: string): string {
+    return topicId ? `https://hashscan.io/${network.value}/topic/${topicId}` : '';
+}
+
+const drawerOpen = ref(false);
+const activeStep = ref<PipelineStep | null>(null);
+function openDrawer(step: PipelineStep) {
+    activeStep.value = step;
+    drawerOpen.value = true;
+}
+</script>
+
+<template>
+    <div class="overflow-hidden rounded-xl border bg-card">
+        <div class="border-b bg-muted/30 px-5 py-3.5">
+            <h2 class="flex items-center gap-2 text-sm font-semibold text-foreground">
+                <Activity class="h-4 w-4 text-primary" />
+                Project Pipeline & Trust Chain
+            </h2>
+            <p class="mt-0.5 text-[11px] text-muted-foreground">Every credential in this project's lifecycle, in order.</p>
+        </div>
+
+        <div v-if="steps.length === 0" class="px-5 py-10 text-center text-sm text-muted-foreground">
+            No linked credentials found for this project yet.
+        </div>
+
+        <div v-else class="px-5 py-5">
+            <div class="relative">
+                <div class="absolute bottom-3 left-[19px] top-3 w-px bg-border" />
+                <div
+                    v-for="(step, idx) in steps"
+                    :key="step.consensusTimestamp + '-' + idx"
+                    class="relative flex items-start gap-4 pb-5 last:pb-0"
+                >
+                    <div :class="[metaFor(step.docType).color, 'relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full']">
+                        <component :is="metaFor(step.docType).icon" class="h-4 w-4" />
+                    </div>
+                    <div class="min-w-0 flex-1 rounded-lg border bg-card px-4 py-3">
+                        <div class="flex items-start justify-between gap-3">
+                            <div class="min-w-0">
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <span class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">{{ metaFor(step.docType).label }}</span>
+                                    <span v-if="step.isProjectSchema" class="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">Project Schema</span>
+                                </div>
+                                <h3 class="mt-0.5 truncate text-sm font-semibold text-foreground">{{ step.schemaName }}</h3>
+                                <p class="mt-0.5 text-[11px] tabular-nums text-muted-foreground">{{ formatTimestamp(step.consensusTimestamp) }}</p>
+                            </div>
+                            <button
+                                class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+                                title="View raw VC"
+                                @click="openDrawer(step)"
+                            >
+                                <Info class="h-4 w-4" />
+                            </button>
+                        </div>
+                        <a
+                            v-if="hashscanTopic(step.topicId)"
+                            :href="hashscanTopic(step.topicId)"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="mt-2 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+                        >
+                            <ExternalLink class="h-3 w-3" />
+                            Topic {{ step.topicId }}
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <RawVcDrawer
+            :open="drawerOpen"
+            :project-id="projectId"
+            :network="network"
+            :consensus-timestamp="activeStep?.consensusTimestamp ?? ''"
+            :schema-name="activeStep?.schemaName ?? null"
+            :topic-id="activeStep?.topicId ?? null"
+            @close="drawerOpen = false"
+        />
+    </div>
+</template>

--- a/sustainable-explorer/frontend/components/project/ProjectPipeline.vue
+++ b/sustainable-explorer/frontend/components/project/ProjectPipeline.vue
@@ -1,21 +1,48 @@
 <script setup lang="ts">
-import { FileText, BookOpen, ShieldCheck, Activity, BadgeCheck, ExternalLink, Info } from 'lucide-vue-next';
-import type { Project } from '~/types/models';
+import {
+    FileText, BookOpen, ShieldCheck, Activity, BadgeCheck,
+    ExternalLink, Info, CheckCircle2, Circle, ChevronDown,
+} from 'lucide-vue-next';
+import type { Project, LinkedSchema } from '~/types/models';
 
 const props = defineProps<{ project: Project }>();
 
 const { network } = useNetwork();
 
-interface PipelineStep {
+// Collapsed by default — this list can be long, and it sits above other Advanced
+// sections, so keep the page compact until the user expands it.
+const open = ref(false);
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface StepCard {
     docType: string;
-    schemaName: string;
     schemaUuid: string;
-    consensusTimestamp: string;
-    topicId: string;
+    schemaName: string;
     isProjectSchema: boolean;
+    vcCount: number;
+    latestVc: { consensusTimestamp: string; topicId: string } | null;
 }
 
-// Lifecycle order. Anything not listed (e.g. 'unknown', MintToken) sorts last.
+// ── Doc-type metadata (label / icon / color) ──────────────────────────────────
+
+interface DocTypeMeta { label: string; icon: unknown; color: string }
+
+const DOC_TYPE_META: Record<string, DocTypeMeta> = {
+    registration:       { label: 'Registration',  icon: FileText,    color: 'text-primary bg-primary/10' },
+    pdd:                { label: 'Project Design', icon: BookOpen,    color: 'text-primary bg-primary/10' },
+    validationReport:   { label: 'Validation',     icon: ShieldCheck, color: 'text-amber-600 bg-amber-50' },
+    monitoringReport:   { label: 'Monitoring',     icon: Activity,    color: 'text-sky-600 bg-sky-50' },
+    verificationReport: { label: 'Verification',   icon: BadgeCheck,  color: 'text-emerald-600 bg-emerald-50' },
+    unknown:            { label: 'Document',        icon: FileText,    color: 'text-muted-foreground bg-muted' },
+};
+
+function metaFor(docType: string): DocTypeMeta {
+    return DOC_TYPE_META[docType] ?? DOC_TYPE_META.unknown;
+}
+
+// ── Step rank (lifecycle order) ───────────────────────────────────────────────
+
 const DOC_TYPE_RANK: Record<string, number> = {
     registration: 0,
     pdd: 1,
@@ -24,44 +51,39 @@ const DOC_TYPE_RANK: Record<string, number> = {
     verificationReport: 4,
 };
 
-interface DocTypeMeta { label: string; icon: unknown; color: string }
-const DOC_TYPE_META: Record<string, DocTypeMeta> = {
-    registration:       { label: 'Registration',  icon: FileText,   color: 'text-primary bg-primary/10' },
-    pdd:                { label: 'Project Design', icon: BookOpen,   color: 'text-primary bg-primary/10' },
-    validationReport:   { label: 'Validation',    icon: ShieldCheck, color: 'text-amber-600 bg-amber-50' },
-    monitoringReport:   { label: 'Monitoring',    icon: Activity,    color: 'text-sky-600 bg-sky-50' },
-    verificationReport: { label: 'Verification',  icon: BadgeCheck,  color: 'text-emerald-600 bg-emerald-50' },
-    unknown:            { label: 'Document',       icon: FileText,    color: 'text-muted-foreground bg-muted' },
-};
+// ── Build one card per schema (not one per VC) ────────────────────────────────
 
-function metaFor(docType: string): DocTypeMeta {
-    return DOC_TYPE_META[docType] ?? DOC_TYPE_META.unknown;
-}
+const steps = computed<StepCard[]>(() => {
+    const schemas: LinkedSchema[] = props.project.linkedSchemas ?? [];
 
-const steps = computed<PipelineStep[]>(() => {
-    const schemas = props.project.linkedSchemas ?? [];
-    const all: PipelineStep[] = [];
-    for (const s of schemas) {
-        for (const vc of s.linkedVcs) {
-            all.push({
+    return schemas
+        .map((s): StepCard => {
+            // Pick the VC with the highest (latest) consensusTimestamp
+            const sorted = [...s.linkedVcs].sort((a, b) =>
+                b.consensusTimestamp.localeCompare(a.consensusTimestamp),
+            );
+            const latestVc = sorted.length > 0
+                ? { consensusTimestamp: sorted[0].consensusTimestamp, topicId: sorted[0].topicId }
+                : null;
+
+            return {
                 docType: s.docType,
-                schemaName: s.schemaName ?? s.schemaUuid,
                 schemaUuid: s.schemaUuid,
-                consensusTimestamp: vc.consensusTimestamp,
-                topicId: vc.topicId,
+                schemaName: s.schemaName ?? s.schemaUuid,
                 isProjectSchema: s.isProjectSchema,
-            });
-        }
-    }
-    return all.sort((a, b) => {
-        const ra = DOC_TYPE_RANK[a.docType] ?? 99;
-        const rb = DOC_TYPE_RANK[b.docType] ?? 99;
-        if (ra !== rb) return ra - rb;
-        return a.consensusTimestamp.localeCompare(b.consensusTimestamp);
-    });
+                vcCount: s.vcCount,
+                latestVc,
+            };
+        })
+        .sort((a, b) => {
+            const ra = DOC_TYPE_RANK[a.docType] ?? 99;
+            const rb = DOC_TYPE_RANK[b.docType] ?? 99;
+            if (ra !== rb) return ra - rb;
+            return a.schemaName.localeCompare(b.schemaName);
+        });
 });
 
-const projectId = computed(() => props.project.sourceTimestamp ?? props.project.id);
+// ── Timestamp formatting ──────────────────────────────────────────────────────
 
 function formatTimestamp(ts: string): string {
     if (!ts) return '—';
@@ -69,54 +91,104 @@ function formatTimestamp(ts: string): string {
     return isNaN(secs) ? ts : new Date(secs * 1000).toLocaleString();
 }
 
+// ── Hashscan link ─────────────────────────────────────────────────────────────
+
 function hashscanTopic(topicId: string): string {
     return topicId ? `https://hashscan.io/${network.value}/topic/${topicId}` : '';
 }
 
+// ── Drawer state ──────────────────────────────────────────────────────────────
+
+const projectId = computed(() => props.project.sourceTimestamp ?? props.project.id);
+
 const drawerOpen = ref(false);
-const activeStep = ref<PipelineStep | null>(null);
-function openDrawer(step: PipelineStep) {
+const activeStep = ref<StepCard | null>(null);
+
+function openDrawer(step: StepCard) {
     activeStep.value = step;
     drawerOpen.value = true;
 }
+
 </script>
 
 <template>
     <div class="overflow-hidden rounded-xl border bg-card">
-        <div class="border-b bg-muted/30 px-5 py-3.5">
-            <h2 class="flex items-center gap-2 text-sm font-semibold text-foreground">
-                <Activity class="h-4 w-4 text-primary" />
-                Project Pipeline & Trust Chain
-            </h2>
-            <p class="mt-0.5 text-[11px] text-muted-foreground">Every credential in this project's lifecycle, in order.</p>
+        <!-- Header (click to collapse/expand) -->
+        <div
+            class="cursor-pointer border-b bg-muted/30 px-5 py-3.5 transition-colors hover:bg-muted/50"
+            @click="open = !open"
+        >
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <h2 class="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <Activity class="h-4 w-4 text-primary" />
+                    Methodology Pipeline
+                    <span class="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">{{ steps.length }} steps</span>
+                </h2>
+                <ChevronDown :class="['h-4 w-4 text-muted-foreground transition-transform', open ? 'rotate-180' : '']" />
+            </div>
+            <p class="mt-0.5 text-[11px] text-muted-foreground">One step per schema in this project's methodology lifecycle.</p>
         </div>
 
-        <div v-if="steps.length === 0" class="px-5 py-10 text-center text-sm text-muted-foreground">
-            No linked credentials found for this project yet.
+        <!-- Empty state -->
+        <div v-if="open && steps.length === 0" class="px-5 py-10 text-center text-sm text-muted-foreground">
+            No linked schemas found for this project yet.
         </div>
 
-        <div v-else class="px-5 py-5">
+        <!-- Step list -->
+        <div v-else-if="open" class="px-5 py-5">
             <div class="relative">
                 <div class="absolute bottom-3 left-[19px] top-3 w-px bg-border" />
                 <div
                     v-for="(step, idx) in steps"
-                    :key="step.consensusTimestamp + '-' + idx"
+                    :key="step.schemaUuid + '-' + idx"
                     class="relative flex items-start gap-4 pb-5 last:pb-0"
                 >
+                    <!-- Step icon -->
                     <div :class="[metaFor(step.docType).color, 'relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full']">
                         <component :is="metaFor(step.docType).icon" class="h-4 w-4" />
                     </div>
+
+                    <!-- Step card -->
                     <div class="min-w-0 flex-1 rounded-lg border bg-card px-4 py-3">
                         <div class="flex items-start justify-between gap-3">
-                            <div class="min-w-0">
+                            <div class="min-w-0 flex-1">
+                                <!-- Doc-type label + project-schema badge -->
                                 <div class="flex flex-wrap items-center gap-2">
                                     <span class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">{{ metaFor(step.docType).label }}</span>
-                                    <span v-if="step.isProjectSchema" class="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">Project Schema</span>
+                                    <span
+                                        v-if="step.isProjectSchema"
+                                        class="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary"
+                                    >
+                                        Project Schema
+                                    </span>
                                 </div>
+
+                                <!-- Schema name -->
                                 <h3 class="mt-0.5 truncate text-sm font-semibold text-foreground">{{ step.schemaName }}</h3>
-                                <p class="mt-0.5 text-[11px] tabular-nums text-muted-foreground">{{ formatTimestamp(step.consensusTimestamp) }}</p>
+
+                                <!-- Data-present indicator -->
+                                <div class="mt-1 flex items-center gap-1.5">
+                                    <template v-if="step.vcCount > 0">
+                                        <CheckCircle2 class="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+                                        <span class="text-[11px] text-emerald-700">
+                                            Data present &middot; {{ formatTimestamp(step.latestVc?.consensusTimestamp ?? '') }}
+                                        </span>
+                                    </template>
+                                    <template v-else>
+                                        <Circle class="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
+                                        <span class="text-[11px] text-muted-foreground">Awaiting data</span>
+                                    </template>
+                                </div>
+
+                                <!-- Document count -->
+                                <p v-if="step.vcCount > 0" class="mt-0.5 text-[11px] tabular-nums text-muted-foreground">
+                                    {{ step.vcCount }} document{{ step.vcCount === 1 ? '' : 's' }}
+                                </p>
                             </div>
+
+                            <!-- ⓘ button — only when data is present -->
                             <button
+                                v-if="step.vcCount > 0"
                                 class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
                                 title="View raw VC"
                                 @click="openDrawer(step)"
@@ -124,28 +196,31 @@ function openDrawer(step: PipelineStep) {
                                 <Info class="h-4 w-4" />
                             </button>
                         </div>
+
+                        <!-- Hashscan topic link (latest VC's topicId) -->
                         <a
-                            v-if="hashscanTopic(step.topicId)"
-                            :href="hashscanTopic(step.topicId)"
+                            v-if="step.latestVc?.topicId && hashscanTopic(step.latestVc.topicId)"
+                            :href="hashscanTopic(step.latestVc.topicId)"
                             target="_blank"
                             rel="noopener noreferrer"
                             class="mt-2 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
                         >
                             <ExternalLink class="h-3 w-3" />
-                            Topic {{ step.topicId }}
+                            Topic {{ step.latestVc.topicId }}
                         </a>
                     </div>
                 </div>
             </div>
         </div>
 
+        <!-- RawVcDrawer (latest VC for the active step) -->
         <RawVcDrawer
             :open="drawerOpen"
             :project-id="projectId"
             :network="network"
-            :consensus-timestamp="activeStep?.consensusTimestamp ?? ''"
+            :consensus-timestamp="activeStep?.latestVc?.consensusTimestamp ?? ''"
             :schema-name="activeStep?.schemaName ?? null"
-            :topic-id="activeStep?.topicId ?? null"
+            :topic-id="activeStep?.latestVc?.topicId ?? null"
             @close="drawerOpen = false"
         />
     </div>

--- a/sustainable-explorer/frontend/components/project/ProjectPolicyCanvas.client.vue
+++ b/sustainable-explorer/frontend/components/project/ProjectPolicyCanvas.client.vue
@@ -94,6 +94,20 @@ const lanes = computed<string[]>(() => {
     return ordered;
 });
 
+// Mint/action overlay: action nodes carry no schema, so the linkedVcs match
+// can never light them up. Issuances are attributed via project_mint_link and
+// arrive as issuanceEvents — when the project has any, the Mint Token action
+// is factually "done", with the latest mint VC as its evidence.
+const mintOverlay = computed<VcInfo | null>(() => {
+    const events = props.project.issuanceEvents ?? [];
+    if (events.length === 0) return null;
+    const latest = events[events.length - 1]; // API order: oldest first
+    return {
+        vcCount: events.length,
+        latestVc: { consensusTimestamp: latest.mintConsensusTimestamp, topicId: '' },
+    };
+});
+
 const nodes = computed<Node[]>(() => {
     const g = graph.value;
     if (!g || g.nodes.length === 0) return [];
@@ -125,7 +139,9 @@ const nodes = computed<Node[]>(() => {
     });
 
     for (const n of g.nodes) {
-        const info = n.schemaUuid ? vc[n.schemaUuid] : undefined;
+        const info = n.schemaUuid
+            ? vc[n.schemaUuid]
+            : (n.category === 'action' ? mintOverlay.value ?? undefined : undefined);
         out.push({
             id: n.tag,
             type: 'step',
@@ -308,8 +324,12 @@ async function openPolicyJson() {
                             <div class="flex min-w-0 items-center gap-1">
                                 <template v-if="data.vcCount > 0">
                                     <CheckCircle2 class="h-3.5 w-3.5 shrink-0 text-emerald-500" />
-                                    <span class="truncate text-[11px] text-emerald-700">
-                                        Data present · {{ formatTimestamp(data.latestVc?.consensusTimestamp ?? '') }}
+                                    <span
+                                        class="truncate text-[11px] text-emerald-700"
+                                        :title="`${data.vcCount} record(s) · latest ${formatTimestamp(data.latestVc?.consensusTimestamp ?? '')}`"
+                                    >
+                                        <template v-if="data.vcCount > 1">×{{ data.vcCount }} · latest {{ formatTimestamp(data.latestVc?.consensusTimestamp ?? '') }}</template>
+                                        <template v-else>Data present · {{ formatTimestamp(data.latestVc?.consensusTimestamp ?? '') }}</template>
                                     </span>
                                 </template>
                                 <template v-else>
@@ -320,7 +340,7 @@ async function openPolicyJson() {
                             <button
                                 v-if="data.vcCount > 0"
                                 class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
-                                title="View raw VC"
+                                :title="data.vcCount > 1 ? 'View latest raw VC' : 'View raw VC'"
                                 @mousedown.stop
                                 @click.stop="openDrawer(data)"
                             >

--- a/sustainable-explorer/frontend/components/project/ProjectPolicyCanvas.client.vue
+++ b/sustainable-explorer/frontend/components/project/ProjectPolicyCanvas.client.vue
@@ -1,0 +1,376 @@
+<script setup lang="ts">
+import { VueFlow, Handle, Position, MarkerType, type Node, type Edge } from '@vue-flow/core';
+import '@vue-flow/core/dist/style.css';
+import '@vue-flow/core/dist/theme-default.css';
+import { FileText, Coins, Info, CheckCircle2, Circle, Loader2, Braces, X } from 'lucide-vue-next';
+import type { Project, LinkedSchema } from '~/types/models';
+
+const props = defineProps<{ project: Project }>();
+const { network } = useNetwork();
+const config = useRuntimeConfig();
+
+// ── Policy workflow graph (fetched from /policy-graph) ────────────────────────
+
+interface GraphNode {
+    tag: string;
+    role: string;
+    blockType: string;
+    category: 'document' | 'action';
+    label: string;
+    schemaUuid: string | null;
+    order: number;
+}
+interface GraphEdge { source: string; target: string; kind: 'flow' | 'sequence' }
+interface Graph { roles: string[]; nodes: GraphNode[]; edges: GraphEdge[] }
+
+const graph = ref<Graph | null>(null);
+const loading = ref(false);
+
+const projectId = computed(() => props.project.sourceTimestamp ?? props.project.id);
+
+async function loadGraph() {
+    if (!import.meta.client || !projectId.value) return;
+    loading.value = true;
+    try {
+        const baseURL = config.public.apiBaseUrl as string;
+        graph.value = await $fetch<Graph>(
+            `/api/v1/${network.value}/projects/${projectId.value}/policy-graph`,
+            { baseURL },
+        );
+    } catch {
+        graph.value = { roles: [], nodes: [], edges: [] };
+    } finally {
+        loading.value = false;
+    }
+}
+onMounted(loadGraph);
+watch(projectId, loadGraph);
+
+// ── VC-data overlay (match graph node schemaUuid → linkedSchemas) ─────────────
+
+function formatTimestamp(ts: string): string {
+    if (!ts) return '—';
+    const secs = parseFloat(ts);
+    return isNaN(secs) ? ts : new Date(secs * 1000).toLocaleString();
+}
+
+interface VcInfo { vcCount: number; latestVc: { consensusTimestamp: string; topicId: string } | null }
+
+const vcByUuid = computed<Record<string, VcInfo>>(() => {
+    const out: Record<string, VcInfo> = {};
+    for (const s of (props.project.linkedSchemas ?? []) as LinkedSchema[]) {
+        const sorted = [...s.linkedVcs].sort((a, b) => b.consensusTimestamp.localeCompare(a.consensusTimestamp));
+        out[s.schemaUuid] = {
+            vcCount: s.vcCount,
+            latestVc: sorted.length ? { consensusTimestamp: sorted[0].consensusTimestamp, topicId: sorted[0].topicId } : null,
+        };
+    }
+    return out;
+});
+
+// ── Swimlane layout (lane per role, x by authored order within lane) ──────────
+
+const LANE_H = 150;
+const COL_W = 240;
+const LABEL_W = 150;
+const TOP_PAD = 34;
+
+interface NodeData {
+    label: string;
+    role: string;
+    category: 'document' | 'action';
+    vcCount: number;
+    latestVc: { consensusTimestamp: string; topicId: string } | null;
+    schemaName: string;
+}
+
+// Lanes = roles that actually contain at least one node, in graph.roles order.
+const lanes = computed<string[]>(() => {
+    const g = graph.value;
+    if (!g) return [];
+    const used = new Set(g.nodes.map(n => n.role));
+    const ordered = g.roles.filter(r => used.has(r));
+    for (const r of used) if (!ordered.includes(r)) ordered.push(r);
+    return ordered;
+});
+
+const nodes = computed<Node[]>(() => {
+    const g = graph.value;
+    if (!g || g.nodes.length === 0) return [];
+    const laneList = lanes.value;
+    const laneIndex = Object.fromEntries(laneList.map((r, i) => [r, i]));
+    const vc = vcByUuid.value;
+
+    const out: Node[] = [];
+
+    // Lane label nodes (left gutter).
+    laneList.forEach((role, i) => {
+        out.push({
+            id: `lane-${i}`,
+            type: 'lane',
+            position: { x: 0, y: i * LANE_H + TOP_PAD },
+            data: { role },
+            draggable: false,
+            selectable: false,
+        });
+    });
+
+    // Step nodes: x = rank within lane (by authored order), y = lane.
+    const rankInLane = new Map<string, number>();
+    const counters = new Map<string, number>();
+    [...g.nodes].sort((a, b) => a.order - b.order).forEach(n => {
+        const c = counters.get(n.role) ?? 0;
+        rankInLane.set(n.tag, c);
+        counters.set(n.role, c + 1);
+    });
+
+    for (const n of g.nodes) {
+        const info = n.schemaUuid ? vc[n.schemaUuid] : undefined;
+        out.push({
+            id: n.tag,
+            type: 'step',
+            position: {
+                x: LABEL_W + (rankInLane.get(n.tag) ?? 0) * COL_W,
+                y: (laneIndex[n.role] ?? 0) * LANE_H + TOP_PAD,
+            },
+            data: {
+                label: n.label,
+                role: n.role,
+                category: n.category,
+                vcCount: info?.vcCount ?? 0,
+                latestVc: info?.latestVc ?? null,
+                schemaName: n.label,
+            } satisfies NodeData,
+        });
+    }
+    return out;
+});
+
+const edges = computed<Edge[]>(() => {
+    const g = graph.value;
+    if (!g) return [];
+    return g.edges.map((e, i) => {
+        const isFlow = e.kind === 'flow';
+        // Concrete colors (not CSS vars) so the lines are clearly visible on the
+        // light canvas, plus an arrowhead so direction reads at a glance.
+        const color = isFlow ? '#6366f1' : '#94a3b8'; // indigo (flow) / slate (sequence)
+        return {
+            id: `e-${i}-${e.source}-${e.target}`,
+            source: e.source,
+            target: e.target,
+            animated: isFlow,
+            markerEnd: { type: MarkerType.ArrowClosed, color, width: 18, height: 18 },
+            style: isFlow
+                ? { stroke: color, strokeWidth: 2 }
+                : { stroke: color, strokeWidth: 1.75, strokeDasharray: '6 4' },
+        };
+    });
+});
+
+const canvasHeight = computed(() => Math.max(300, lanes.value.length * LANE_H + 60));
+
+// ── Decode-method badge (unchanged) ──────────────────────────────────────────
+
+interface DecodeMeta { label: string; desc: string; chip: string }
+const decodeMeta = computed((): DecodeMeta => {
+    switch (props.project.decodeMethod) {
+        case 'topic':         return { label: 'Dynamic Topic ID',      desc: 'Project resolved via HCS topic',         chip: 'bg-primary/10 text-primary border-primary/20' };
+        case 'csRef':         return { label: 'CS Ref · Trust Chain',  desc: 'Credential subject reference chain',     chip: 'bg-sky-50 text-sky-700 border-sky-200' };
+        case 'relationships': return { label: 'Message Relationship',  desc: 'Resolved through message relationships', chip: 'bg-amber-50 text-amber-700 border-amber-200' };
+        case 'projectSchema': return { label: 'Single Schema Derived', desc: 'Derived from a single project schema VC', chip: 'bg-emerald-50 text-emerald-700 border-emerald-200' };
+        default:              return { label: 'Unknown',               desc: 'Resolver method not recorded',           chip: 'bg-muted text-muted-foreground border-border' };
+    }
+});
+
+// Resolution anchor (M1: dynamic topic; M2/M3/M4: root VC timestamp).
+const anchor = computed<{ label: string; value: string } | null>(() => {
+    const m = (props.project.metadata ?? {}) as Record<string, unknown>;
+    if (typeof m['dynamicTopicId'] === 'string') return { label: 'Dynamic topic', value: m['dynamicTopicId'] };
+    if (typeof m['rootVcTimestamp'] === 'string') return { label: 'Root VC', value: m['rootVcTimestamp'] };
+    return null;
+});
+
+// ── Raw-VC drawer ─────────────────────────────────────────────────────────────
+
+const drawerOpen = ref(false);
+const activeData = ref<NodeData | null>(null);
+function openDrawer(d: NodeData) {
+    activeData.value = d;
+    drawerOpen.value = true;
+}
+
+// ── Policy JSON inspector ─────────────────────────────────────────────────────
+
+const jsonOpen = ref(false);
+const jsonLoading = ref(false);
+const policyJson = ref<string>('');
+
+async function openPolicyJson() {
+    jsonOpen.value = true;
+    if (policyJson.value || !import.meta.client) return;
+    jsonLoading.value = true;
+    try {
+        const baseURL = config.public.apiBaseUrl as string;
+        const raw = await $fetch<Record<string, unknown> | null>(
+            `/api/v1/${network.value}/projects/${projectId.value}/policy-json`,
+            { baseURL },
+        );
+        policyJson.value = raw ? JSON.stringify(raw, null, 2) : '// No decoded policy available for this project.';
+    } catch {
+        policyJson.value = '// Failed to load policy JSON.';
+    } finally {
+        jsonLoading.value = false;
+    }
+}
+</script>
+
+<template>
+    <div class="overflow-hidden rounded-xl border bg-card">
+        <!-- Header -->
+        <div class="border-b bg-muted/30 px-5 py-3.5">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <h2 class="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <FileText class="h-4 w-4 text-primary" />
+                    Policy Flowchart
+                </h2>
+                <div class="flex items-center gap-2">
+                    <span
+                        :class="['inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium', decodeMeta.chip]"
+                        :title="decodeMeta.desc"
+                    >
+                        {{ decodeMeta.label }}
+                    </span>
+                    <button
+                        class="inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+                        title="View the raw policy.json"
+                        @click="openPolicyJson"
+                    >
+                        <Braces class="h-3.5 w-3.5" />
+                        Policy JSON
+                    </button>
+                </div>
+            </div>
+            <p class="mt-0.5 text-[11px] text-muted-foreground">
+                Role swimlanes of the methodology's documents, in the policy's authored step order. Pan and zoom to explore.
+            </p>
+            <div v-if="project.projectKey || anchor" class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+                <span v-if="project.projectKey" class="flex items-center gap-1.5">
+                    <span class="font-medium uppercase tracking-wider">Project key</span>
+                    <code class="max-w-[320px] truncate rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-foreground" :title="project.projectKey">{{ project.projectKey }}</code>
+                </span>
+                <span v-if="anchor" class="flex items-center gap-1.5">
+                    <span class="font-medium uppercase tracking-wider">{{ anchor.label }}</span>
+                    <code class="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-foreground" :title="anchor.value">{{ anchor.value }}</code>
+                </span>
+            </div>
+        </div>
+
+        <!-- Loading -->
+        <div v-if="loading" class="flex items-center justify-center gap-2 py-12 text-xs text-muted-foreground">
+            <Loader2 class="h-4 w-4 animate-spin" /> Loading methodology workflow…
+        </div>
+
+        <!-- Empty -->
+        <div v-else-if="nodes.length === 0" class="px-5 py-10 text-center text-sm text-muted-foreground">
+            No decoded methodology workflow available for this project yet.
+        </div>
+
+        <!-- Canvas -->
+        <div v-else class="w-full overflow-hidden" :style="{ height: canvasHeight + 'px' }">
+            <VueFlow :nodes="nodes" :edges="edges" :fit-view-on-init="true" class="h-full w-full">
+                <!-- Lane label -->
+                <template #node-lane="{ data }">
+                    <div class="flex h-[120px] w-[140px] items-center">
+                        <div class="rounded-md bg-muted/60 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                            {{ data.role }}
+                        </div>
+                    </div>
+                </template>
+
+                <!-- Document / action step -->
+                <template #node-step="{ data }">
+                    <div class="relative w-[210px] rounded-lg border bg-card px-3 py-2 shadow-sm">
+                        <!-- Handles let VueFlow attach the sequence/flow edges. -->
+                        <Handle type="target" :position="Position.Left" class="!h-2 !w-2 !border !border-border !bg-muted" />
+                        <Handle type="source" :position="Position.Right" class="!h-2 !w-2 !border !border-border !bg-muted" />
+                        <div class="flex items-center gap-1.5">
+                            <span :class="['inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full', data.category === 'action' ? 'bg-emerald-50 text-emerald-600' : 'bg-primary/10 text-primary']">
+                                <component :is="data.category === 'action' ? Coins : FileText" class="h-3.5 w-3.5" />
+                            </span>
+                            <span class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                                {{ data.category === 'action' ? 'Action' : 'Document' }}
+                            </span>
+                        </div>
+
+                        <h3 class="mt-1 truncate text-xs font-semibold text-foreground" :title="data.label">{{ data.label }}</h3>
+
+                        <div class="mt-1.5 flex items-center justify-between gap-1">
+                            <div class="flex min-w-0 items-center gap-1">
+                                <template v-if="data.vcCount > 0">
+                                    <CheckCircle2 class="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+                                    <span class="truncate text-[11px] text-emerald-700">
+                                        Data present · {{ formatTimestamp(data.latestVc?.consensusTimestamp ?? '') }}
+                                    </span>
+                                </template>
+                                <template v-else>
+                                    <Circle class="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
+                                    <span class="text-[11px] text-muted-foreground">Awaiting data</span>
+                                </template>
+                            </div>
+                            <button
+                                v-if="data.vcCount > 0"
+                                class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+                                title="View raw VC"
+                                @mousedown.stop
+                                @click.stop="openDrawer(data)"
+                            >
+                                <Info class="h-3.5 w-3.5" />
+                            </button>
+                        </div>
+                    </div>
+                </template>
+            </VueFlow>
+        </div>
+
+        <!-- Legend -->
+        <div v-if="nodes.length > 0" class="flex flex-wrap items-center gap-4 border-t px-5 py-2 text-[11px] text-muted-foreground">
+            <span class="flex items-center gap-1.5"><span class="inline-block h-0 w-5 border-t-2 border-primary" /> Genuine flow event</span>
+            <span class="flex items-center gap-1.5"><span class="inline-block h-0 w-5 border-t-2 border-dashed border-border" /> Authored step order</span>
+            <span class="flex items-center gap-1.5"><CheckCircle2 class="h-3 w-3 text-emerald-500" /> Data present</span>
+        </div>
+    </div>
+
+    <!-- RawVcDrawer -->
+    <RawVcDrawer
+        :open="drawerOpen"
+        :project-id="projectId"
+        :network="network"
+        :consensus-timestamp="activeData?.latestVc?.consensusTimestamp ?? ''"
+        :schema-name="activeData?.schemaName ?? null"
+        :topic-id="activeData?.latestVc?.topicId ?? null"
+        @close="drawerOpen = false"
+    />
+
+    <!-- Policy JSON inspector -->
+    <Teleport to="body">
+        <div v-if="jsonOpen" class="fixed inset-0 z-50 flex justify-end">
+            <div class="absolute inset-0 bg-black/40" @click="jsonOpen = false" />
+            <div class="relative z-10 flex h-full w-full max-w-2xl flex-col border-l bg-card shadow-xl">
+                <div class="flex items-center justify-between gap-3 border-b bg-muted/30 px-5 py-4">
+                    <h3 class="flex items-center gap-2 text-sm font-semibold text-foreground">
+                        <Braces class="h-4 w-4 text-primary" /> Policy JSON
+                    </h3>
+                    <button class="text-muted-foreground transition-colors hover:text-foreground" @click="jsonOpen = false">
+                        <X class="h-4 w-4" />
+                    </button>
+                </div>
+                <div class="flex-1 overflow-auto p-4">
+                    <div v-if="jsonLoading" class="flex items-center justify-center gap-2 py-10 text-xs text-muted-foreground">
+                        <Loader2 class="h-4 w-4 animate-spin" /> Loading policy.json…
+                    </div>
+                    <pre v-else class="whitespace-pre-wrap break-words rounded-lg bg-muted/30 p-3 font-mono text-[11px] leading-relaxed text-foreground">{{ policyJson }}</pre>
+                </div>
+            </div>
+        </div>
+    </Teleport>
+</template>

--- a/sustainable-explorer/frontend/components/project/ProjectTrustChain.vue
+++ b/sustainable-explorer/frontend/components/project/ProjectTrustChain.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { FileText, BookOpen, ShieldCheck, Activity, BadgeCheck, ExternalLink, Info } from 'lucide-vue-next';
+import type { Project } from '~/types/models';
+
+const props = defineProps<{ project: Project }>();
+
+const { network } = useNetwork();
+
+interface PipelineStep {
+    docType: string;
+    schemaName: string;
+    schemaUuid: string;
+    consensusTimestamp: string;
+    topicId: string;
+    isProjectSchema: boolean;
+}
+
+// Lifecycle order. Anything not listed (e.g. 'unknown', MintToken) sorts last.
+const DOC_TYPE_RANK: Record<string, number> = {
+    registration: 0,
+    pdd: 1,
+    validationReport: 2,
+    monitoringReport: 3,
+    verificationReport: 4,
+};
+
+interface DocTypeMeta { label: string; icon: unknown; color: string }
+const DOC_TYPE_META: Record<string, DocTypeMeta> = {
+    registration:       { label: 'Registration',  icon: FileText,   color: 'text-primary bg-primary/10' },
+    pdd:                { label: 'Project Design', icon: BookOpen,   color: 'text-primary bg-primary/10' },
+    validationReport:   { label: 'Validation',    icon: ShieldCheck, color: 'text-amber-600 bg-amber-50' },
+    monitoringReport:   { label: 'Monitoring',    icon: Activity,    color: 'text-sky-600 bg-sky-50' },
+    verificationReport: { label: 'Verification',  icon: BadgeCheck,  color: 'text-emerald-600 bg-emerald-50' },
+    unknown:            { label: 'Document',       icon: FileText,    color: 'text-muted-foreground bg-muted' },
+};
+
+function metaFor(docType: string): DocTypeMeta {
+    return DOC_TYPE_META[docType] ?? DOC_TYPE_META.unknown;
+}
+
+const steps = computed<PipelineStep[]>(() => {
+    const schemas = props.project.linkedSchemas ?? [];
+    const all: PipelineStep[] = [];
+    for (const s of schemas) {
+        for (const vc of s.linkedVcs) {
+            all.push({
+                docType: s.docType,
+                schemaName: s.schemaName ?? s.schemaUuid,
+                schemaUuid: s.schemaUuid,
+                consensusTimestamp: vc.consensusTimestamp,
+                topicId: vc.topicId,
+                isProjectSchema: s.isProjectSchema,
+            });
+        }
+    }
+    return all.sort((a, b) => {
+        const ra = DOC_TYPE_RANK[a.docType] ?? 99;
+        const rb = DOC_TYPE_RANK[b.docType] ?? 99;
+        if (ra !== rb) return ra - rb;
+        return a.consensusTimestamp.localeCompare(b.consensusTimestamp);
+    });
+});
+
+const projectId = computed(() => props.project.sourceTimestamp ?? props.project.id);
+
+function formatTimestamp(ts: string): string {
+    if (!ts) return '—';
+    const secs = parseFloat(ts);
+    return isNaN(secs) ? ts : new Date(secs * 1000).toLocaleString();
+}
+
+function hashscanTopic(topicId: string): string {
+    return topicId ? `https://hashscan.io/${network.value}/topic/${topicId}` : '';
+}
+
+const drawerOpen = ref(false);
+const activeStep = ref<PipelineStep | null>(null);
+function openDrawer(step: PipelineStep) {
+    activeStep.value = step;
+    drawerOpen.value = true;
+}
+</script>
+
+<template>
+    <div class="overflow-hidden rounded-xl border bg-card">
+        <div class="border-b bg-muted/30 px-5 py-3.5">
+            <h2 class="flex items-center gap-2 text-sm font-semibold text-foreground">
+                <Activity class="h-4 w-4 text-primary" />
+                Project Pipeline & Trust Chain
+            </h2>
+            <p class="mt-0.5 text-[11px] text-muted-foreground">Every credential in this project's lifecycle, in order.</p>
+        </div>
+
+        <div v-if="steps.length === 0" class="px-5 py-10 text-center text-sm text-muted-foreground">
+            No linked credentials found for this project yet.
+        </div>
+
+        <div v-else class="px-5 py-5">
+            <div class="relative">
+                <div class="absolute bottom-3 left-[19px] top-3 w-px bg-border" />
+                <div
+                    v-for="(step, idx) in steps"
+                    :key="step.consensusTimestamp + '-' + idx"
+                    class="relative flex items-start gap-4 pb-5 last:pb-0"
+                >
+                    <div :class="[metaFor(step.docType).color, 'relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full']">
+                        <component :is="metaFor(step.docType).icon" class="h-4 w-4" />
+                    </div>
+                    <div class="min-w-0 flex-1 rounded-lg border bg-card px-4 py-3">
+                        <div class="flex items-start justify-between gap-3">
+                            <div class="min-w-0">
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <span class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">{{ metaFor(step.docType).label }}</span>
+                                    <span v-if="step.isProjectSchema" class="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">Project Schema</span>
+                                </div>
+                                <h3 class="mt-0.5 truncate text-sm font-semibold text-foreground">{{ step.schemaName }}</h3>
+                                <p class="mt-0.5 text-[11px] tabular-nums text-muted-foreground">{{ formatTimestamp(step.consensusTimestamp) }}</p>
+                            </div>
+                            <button
+                                class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+                                title="View raw VC"
+                                @click="openDrawer(step)"
+                            >
+                                <Info class="h-4 w-4" />
+                            </button>
+                        </div>
+                        <a
+                            v-if="hashscanTopic(step.topicId)"
+                            :href="hashscanTopic(step.topicId)"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="mt-2 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+                        >
+                            <ExternalLink class="h-3 w-3" />
+                            Topic {{ step.topicId }}
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <RawVcDrawer
+            :open="drawerOpen"
+            :project-id="projectId"
+            :network="network"
+            :consensus-timestamp="activeStep?.consensusTimestamp ?? ''"
+            :schema-name="activeStep?.schemaName ?? null"
+            :topic-id="activeStep?.topicId ?? null"
+            @close="drawerOpen = false"
+        />
+    </div>
+</template>

--- a/sustainable-explorer/frontend/components/project/RawVcDrawer.vue
+++ b/sustainable-explorer/frontend/components/project/RawVcDrawer.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { ShieldCheck, X, Loader2, ExternalLink } from 'lucide-vue-next';
+
+const props = defineProps<{
+    open: boolean;
+    projectId: string;
+    network: string;
+    consensusTimestamp: string;
+    schemaName: string | null;
+    topicId?: string | null;
+}>();
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const config = useRuntimeConfig();
+
+const loading = ref(false);
+const error = ref(false);
+const vcDoc = ref<Record<string, any> | null>(null);
+
+const SYSTEM_KEYS = new Set(['@context', 'type', 'id', 'policyId', 'ref', 'uuid']);
+
+interface DisplayField { label: string; value: string }
+
+function humanizeKey(key: string): string {
+    return key
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .replace(/[_-]/g, ' ')
+        .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function formatValue(v: unknown): string {
+    if (v == null || v === '') return '—';
+    if (typeof v === 'string') return v;
+    if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+    if (Array.isArray(v)) {
+        if (v.length === 0) return '—';
+        return v.map(x => (x && typeof x === 'object' ? formatValue(x) : String(x))).join(', ');
+    }
+    if (typeof v === 'object') {
+        const obj = v as Record<string, unknown>;
+        const keys = Object.keys(obj).filter(k => !SYSTEM_KEYS.has(k));
+        if (keys.length === 0) return '—';
+        return keys
+            .map(k => `${humanizeKey(k)}: ${obj[k] && typeof obj[k] === 'object' ? '…' : String(obj[k] ?? '—')}`)
+            .join(' · ');
+    }
+    return String(v);
+}
+
+async function load() {
+    if (!import.meta.client) return;
+    if (!props.consensusTimestamp || !props.projectId) return;
+    loading.value = true;
+    error.value = false;
+    vcDoc.value = null;
+    try {
+        const baseURL = config.public.apiBaseUrl as string;
+        vcDoc.value = await $fetch<Record<string, any>>(
+            `/api/v1/${props.network}/projects/${props.projectId}/linked-vcs/${props.consensusTimestamp}`,
+            { baseURL },
+        );
+    } catch {
+        error.value = true;
+    } finally {
+        loading.value = false;
+    }
+}
+
+watch(() => props.open, (isOpen) => { if (isOpen) load(); });
+watch(() => props.consensusTimestamp, () => { if (props.open) load(); });
+
+const credentialSubject = computed<Record<string, any> | null>(() => {
+    const doc = vcDoc.value;
+    if (!doc) return null;
+    const cs = doc['credentialSubject'];
+    if (Array.isArray(cs)) return (cs[0] ?? null) as Record<string, any> | null;
+    if (cs && typeof cs === 'object') return cs as Record<string, any>;
+    return null;
+});
+
+const issuer = computed<string | null>(() => {
+    const doc = vcDoc.value;
+    if (!doc) return null;
+    const iss = doc['issuer'];
+    if (typeof iss === 'string') return iss;
+    if (iss && typeof iss === 'object' && typeof (iss as Record<string, unknown>)['id'] === 'string') {
+        return (iss as Record<string, string>)['id'];
+    }
+    return null;
+});
+
+const fields = computed<DisplayField[]>(() => {
+    const cs = credentialSubject.value;
+    if (!cs) return [];
+    const out: DisplayField[] = [];
+    for (const [key, val] of Object.entries(cs)) {
+        if (SYSTEM_KEYS.has(key)) continue;
+        if (val == null || val === '') continue;
+        out.push({ label: humanizeKey(key), value: formatValue(val) });
+    }
+    return out;
+});
+
+const formattedTimestamp = computed(() => {
+    const ts = props.consensusTimestamp;
+    if (!ts) return '';
+    const secs = parseFloat(ts);
+    return isNaN(secs) ? ts : new Date(secs * 1000).toLocaleString();
+});
+
+const hashscanUrl = computed(() => (props.topicId ? `https://hashscan.io/${props.network}/topic/${props.topicId}` : ''));
+</script>
+
+<template>
+    <Teleport to="body">
+        <div v-if="open" class="fixed inset-0 z-50 flex justify-end">
+            <div class="absolute inset-0 bg-black/40" @click="emit('close')" />
+            <div class="relative z-10 flex h-full w-full max-w-md flex-col border-l bg-card shadow-xl">
+                <!-- Header -->
+                <div class="flex items-start justify-between gap-3 border-b bg-muted/30 px-5 py-4">
+                    <div class="min-w-0">
+                        <div class="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-primary">
+                            <ShieldCheck class="h-3.5 w-3.5" />
+                            On-chain evidence
+                        </div>
+                        <h3 class="mt-1 truncate text-sm font-semibold text-foreground">{{ schemaName || 'Verifiable Credential' }}</h3>
+                        <p class="mt-0.5 text-[11px] tabular-nums text-muted-foreground">{{ formattedTimestamp }}</p>
+                    </div>
+                    <button class="shrink-0 text-muted-foreground transition-colors hover:text-foreground" @click="emit('close')">
+                        <X class="h-4 w-4" />
+                    </button>
+                </div>
+
+                <!-- Body -->
+                <div class="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+                    <div v-if="loading" class="flex items-center justify-center gap-2 py-10 text-xs text-muted-foreground">
+                        <Loader2 class="h-4 w-4 animate-spin" />
+                        Loading on-chain document…
+                    </div>
+                    <div v-else-if="error" class="py-10 text-center text-xs text-destructive">
+                        Failed to load the VC document.
+                    </div>
+                    <template v-else-if="credentialSubject">
+                        <div v-if="issuer" class="rounded-lg border bg-muted/20 px-4 py-3">
+                            <div class="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Issuer DID</div>
+                            <code class="break-all font-mono text-xs text-foreground">{{ issuer }}</code>
+                        </div>
+
+                        <div class="overflow-hidden rounded-lg border">
+                            <div
+                                v-for="(f, i) in fields"
+                                :key="f.label"
+                                :class="['px-4 py-2.5', i % 2 ? 'bg-card' : 'bg-muted/10']"
+                            >
+                                <div class="mb-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">{{ f.label }}</div>
+                                <div class="break-words text-sm text-foreground">{{ f.value }}</div>
+                            </div>
+                            <div v-if="fields.length === 0" class="px-4 py-6 text-center text-xs text-muted-foreground">
+                                No readable fields in this credential.
+                            </div>
+                        </div>
+
+                        <a
+                            v-if="hashscanUrl"
+                            :href="hashscanUrl"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+                        >
+                            <ExternalLink class="h-3.5 w-3.5" />
+                            View topic on HashScan
+                        </a>
+                    </template>
+                    <div v-else class="py-10 text-center text-xs text-muted-foreground">No credential data.</div>
+                </div>
+            </div>
+        </div>
+    </Teleport>
+</template>

--- a/sustainable-explorer/frontend/components/project/RawVcDrawer.vue
+++ b/sustainable-explorer/frontend/components/project/RawVcDrawer.vue
@@ -17,6 +17,7 @@ const config = useRuntimeConfig();
 const loading = ref(false);
 const error = ref(false);
 const vcDoc = ref<Record<string, any> | null>(null);
+const fieldLabels = ref<Record<string, string>>({});
 
 const SYSTEM_KEYS = new Set(['@context', 'type', 'id', 'policyId', 'ref', 'uuid']);
 
@@ -29,20 +30,33 @@ function humanizeKey(key: string): string {
         .replace(/\b\w/g, c => c.toUpperCase());
 }
 
-function formatValue(v: unknown): string {
+// Label for a (possibly nested) field path. Guardian VCs nest sub-schema data as
+// objects whose keys are generic (field0, field1…). The policy's schemaFields are
+// flattened to dotted paths (e.g. "field0.field3" → "Project Name"), and the
+// backend returns those in fieldLabels — so a nested key resolves via its full
+// dotted path, falling back to a humanized key when unlabeled.
+function labelForPath(path: string, key: string): string {
+    return fieldLabels.value[path] || humanizeKey(key);
+}
+
+function formatValue(v: unknown, pathPrefix = ''): string {
     if (v == null || v === '') return '—';
     if (typeof v === 'string') return v;
     if (typeof v === 'number' || typeof v === 'boolean') return String(v);
     if (Array.isArray(v)) {
         if (v.length === 0) return '—';
-        return v.map(x => (x && typeof x === 'object' ? formatValue(x) : String(x))).join(', ');
+        // Array items share the parent's sub-paths (schema paths carry no index).
+        return v.map(x => (x && typeof x === 'object' ? formatValue(x, pathPrefix) : String(x))).join(', ');
     }
     if (typeof v === 'object') {
         const obj = v as Record<string, unknown>;
         const keys = Object.keys(obj).filter(k => !SYSTEM_KEYS.has(k));
         if (keys.length === 0) return '—';
         return keys
-            .map(k => `${humanizeKey(k)}: ${obj[k] && typeof obj[k] === 'object' ? '…' : String(obj[k] ?? '—')}`)
+            .map(k => {
+                const childPath = pathPrefix ? `${pathPrefix}.${k}` : k;
+                return `${labelForPath(childPath, k)}: ${obj[k] && typeof obj[k] === 'object' ? '…' : String(obj[k] ?? '—')}`;
+            })
             .join(' · ');
     }
     return String(v);
@@ -54,12 +68,15 @@ async function load() {
     loading.value = true;
     error.value = false;
     vcDoc.value = null;
+    fieldLabels.value = {};
     try {
         const baseURL = config.public.apiBaseUrl as string;
-        vcDoc.value = await $fetch<Record<string, any>>(
-            `/api/v1/${props.network}/projects/${props.projectId}/linked-vcs/${props.consensusTimestamp}`,
+        const res = await $fetch<{ document: Record<string, any>; fieldLabels: Record<string, string> }>(
+            `/api/v1/${props.network}/projects/${props.projectId}/vc-evidence/${props.consensusTimestamp}`,
             { baseURL },
         );
+        vcDoc.value = res.document ?? null;
+        fieldLabels.value = (res.fieldLabels ?? {}) as Record<string, string>;
     } catch {
         error.value = true;
     } finally {
@@ -97,7 +114,7 @@ const fields = computed<DisplayField[]>(() => {
     for (const [key, val] of Object.entries(cs)) {
         if (SYSTEM_KEYS.has(key)) continue;
         if (val == null || val === '') continue;
-        out.push({ label: humanizeKey(key), value: formatValue(val) });
+        out.push({ label: fieldLabels.value[key] || humanizeKey(key), value: formatValue(val, key) });
     }
     return out;
 });

--- a/sustainable-explorer/frontend/composables/useProjects.ts
+++ b/sustainable-explorer/frontend/composables/useProjects.ts
@@ -80,6 +80,7 @@ export function mapApiProject(raw: Record<string, any>): Project {
                 schemaUuid: s['schemaUuid'] ?? '',
                 schemaName: s['schemaName'] ?? null,
                 isProjectSchema: Boolean(s['isProjectSchema']),
+                docType: typeof s['docType'] === 'string' ? s['docType'] : 'unknown',
                 vcCount: typeof s['vcCount'] === 'number' ? s['vcCount'] : 0,
                 linkedVcs: Array.isArray(s['linkedVcs'])
                     ? (s['linkedVcs'] as Array<Record<string, any>>).map((v): LinkedVc => ({
@@ -188,6 +189,7 @@ export interface ActivityEvent {
     date: string;
     action: string;
     type: string;
+    schemaName: string | null;
 }
 
 const VALID_ACTIVITY_TYPES = new Set(['document', 'verification', 'registry', 'monitoring', 'credit']);
@@ -200,6 +202,7 @@ function mapActivityEvent(raw: Record<string, unknown>): ActivityEvent {
         date: typeof raw.date === 'string' ? raw.date : '',
         action: typeof raw.action === 'string' ? raw.action : 'Activity recorded',
         type,
+        schemaName: typeof raw.schemaName === 'string' ? raw.schemaName : null,
     };
 }
 

--- a/sustainable-explorer/frontend/composables/useProjects.ts
+++ b/sustainable-explorer/frontend/composables/useProjects.ts
@@ -1,4 +1,4 @@
-import type { Project, ProjectIssuance, LinkedSchema, LinkedVc } from '~/types/models';
+import type { Project, ProjectIssuance, IssuanceEvent, LinkedSchema, LinkedVc } from '~/types/models';
 
 // country display name → ISO 3166-1 alpha-3 for CountryFlag component
 export const COUNTRY_ALPHA3: Record<string, string> = {
@@ -147,6 +147,19 @@ export function mapApiProject(raw: Record<string, any>): Project {
                 rawVc: i['rawVc'] ?? null,
             }))
             : [],
+        issuanceEvents: Array.isArray(raw.issuanceEvents)
+            ? (raw.issuanceEvents as Array<Record<string, any>>).map((e): IssuanceEvent => ({
+                mintConsensusTimestamp: typeof e['mintConsensusTimestamp'] === 'string' ? e['mintConsensusTimestamp'] : '',
+                tokenId: typeof e['tokenId'] === 'string' ? e['tokenId'] : null,
+                name: typeof e['name'] === 'string' ? e['name'] : null,
+                symbol: typeof e['symbol'] === 'string' ? e['symbol'] : null,
+                type: typeof e['type'] === 'string' ? e['type'] : null,
+                amount: typeof e['amount'] === 'number' ? e['amount'] : null,
+                mintDate: typeof e['mintDate'] === 'string' ? e['mintDate'] : null,
+                linkMethod: typeof e['linkMethod'] === 'string' ? e['linkMethod'] : null,
+                rawVc: e['rawVc'] && typeof e['rawVc'] === 'object' ? (e['rawVc'] as Record<string, any>) : null,
+            }))
+            : [],
         totalIssued: typeof raw.totalIssued === 'number' ? raw.totalIssued : 0,
         totalRetired: typeof raw.totalRetired === 'number' ? raw.totalRetired : 0,
         totalActive: typeof raw.totalActive === 'number' ? raw.totalActive : 0,
@@ -166,6 +179,8 @@ export function mapApiProject(raw: Record<string, any>): Project {
                     : [],
             }))
             : [],
+        decodeMethod: typeof raw.decodeMethod === 'string' ? raw.decodeMethod : null,
+        metadata: raw.metadata && typeof raw.metadata === 'object' ? (raw.metadata as Record<string, unknown>) : null,
     };
 }
 

--- a/sustainable-explorer/frontend/nuxt.config.ts
+++ b/sustainable-explorer/frontend/nuxt.config.ts
@@ -20,6 +20,14 @@ export default defineNuxtConfig({
 
     css: ['~/assets/css/main.css'],
 
+    // @vue-flow/core ships untranspiled ESM that touches Vue component internals;
+    // it must be transpiled so it is SSR-safe when pulled into the server bundle
+    // graph (the project page imports the .client.vue canvas). Without this, SSR
+    // crashes at module-eval with "Cannot read properties of null (reading 'ce')".
+    build: {
+        transpile: ['@vue-flow/core'],
+    },
+
     vite: {
         plugins: [
             // @ts-ignore

--- a/sustainable-explorer/frontend/package.json
+++ b/sustainable-explorer/frontend/package.json
@@ -12,6 +12,7 @@
         "@tanstack/vue-table": "^8",
         "@unovis/ts": "^1",
         "@unovis/vue": "^1",
+        "@vue-flow/core": "^1.48.2",
         "@vue-leaflet/vue-leaflet": "^0.10",
         "@vueuse/core": "^12",
         "class-variance-authority": "^0.7",

--- a/sustainable-explorer/frontend/pages/projects/[id].vue
+++ b/sustainable-explorer/frontend/pages/projects/[id].vue
@@ -51,8 +51,8 @@ const displayCountry = computed(() => {
 
 // ─── Tabs (synced with URL hash) ──────────────────────────────────────────────
 
-type TabKey = 'summary' | 'issuances' | 'documents' | 'advanced';
-const VALID_TABS = new Set<TabKey>(['summary', 'issuances', 'documents', 'advanced']);
+type TabKey = 'summary' | 'pipeline' | 'issuances' | 'documents' | 'advanced';
+const VALID_TABS = new Set<TabKey>(['summary', 'pipeline', 'issuances', 'documents', 'advanced']);
 
 const router = useRouter();
 const initialHash = (route.hash?.replace('#', '') ?? '') as TabKey;
@@ -65,6 +65,7 @@ function setTab(key: TabKey) {
 
 const tabs = [
     { key: 'summary' as const,   label: 'Summary',              icon: FolderKanban },
+    { key: 'pipeline' as const,  label: 'Pipeline',             icon: Activity },
     { key: 'documents' as const, label: 'Detailed Information',  icon: FileText },
     { key: 'issuances' as const, label: 'Issuances & Credits',  icon: Coins },
     { key: 'advanced' as const,  label: 'Advanced',             icon: Shield },
@@ -623,6 +624,11 @@ const emissions = computed(() => {
                         </ClientOnly>
                     </div>
                 </div>
+            </div>
+
+            <!-- ── Tab: Pipeline & Trust Chain ─────────────────────────────────── -->
+            <div v-else-if="activeTab === 'pipeline'" class="p-6">
+                <ProjectPipeline :project="project" />
             </div>
 
             <!-- ── Tab: Issuances & Credits ────────────────────────────────────── -->

--- a/sustainable-explorer/frontend/pages/projects/[id].vue
+++ b/sustainable-explorer/frontend/pages/projects/[id].vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import {
     BookOpen, Coins, Layers, Shield,
-    Globe, MapPin, Clock, Activity,
+    Globe, MapPin,
     Network, FileText, ChevronDown,
-    CheckCircle2, Circle, Zap, Database,
+    Database,
     FolderKanban, BarChart3, RotateCcw, CloudDownload, Loader2, Search, X, Download,
 } from 'lucide-vue-next';
 import type { Credit } from '~/types/models';
@@ -19,7 +19,6 @@ const route = useRoute();
 const { network } = useNetwork();
 const projectId = computed(() => route.params.id as string);
 const { project, pending } = useProjectDetail(projectId);
-const { activity: activityEvents } = useProjectActivity(projectId);
 
 // When the API returns no country (UNK) but we have valid coordinates, fall back
 // to a Nominatim reverse-geocode lookup so the correct flag is shown.
@@ -38,14 +37,17 @@ const INVALID_COUNTRY = new Set([
 ]);
 const displayCountryCode = computed(() => geocodedCountry.value?.code ?? project.value?.countryCode ?? 'UNK');
 const displayCountry = computed(() => {
-    const raw = geocodedCountry.value?.name ?? project.value?.country ?? '';
-    return INVALID_COUNTRY.has(raw.toLowerCase().trim()) ? '' : raw;
+    const raw = (geocodedCountry.value?.name ?? project.value?.country ?? '').trim();
+    if (!raw || INVALID_COUNTRY.has(raw.toLowerCase())) return '';
+    // Never show a URL / IPFS-or-file URI / raw CID as a location.
+    if (/:\/\//.test(raw) || /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-z0-9]{20,})$/i.test(raw)) return '';
+    return raw;
 });
 
 // ─── Tabs (synced with URL hash) ──────────────────────────────────────────────
 
-type TabKey = 'summary' | 'pipeline' | 'issuances' | 'documents' | 'advanced';
-const VALID_TABS = new Set<TabKey>(['summary', 'pipeline', 'issuances', 'documents', 'advanced']);
+type TabKey = 'summary' | 'issuances' | 'documents' | 'advanced';
+const VALID_TABS = new Set<TabKey>(['summary', 'issuances', 'documents', 'advanced']);
 
 const router = useRouter();
 const initialHash = (route.hash?.replace('#', '') ?? '') as TabKey;
@@ -58,7 +60,6 @@ function setTab(key: TabKey) {
 
 const tabs = [
     { key: 'summary' as const,   label: 'Summary',              icon: FolderKanban },
-    { key: 'pipeline' as const,  label: 'Pipeline',             icon: Activity },
     { key: 'documents' as const, label: 'Detailed Information',  icon: FileText },
     { key: 'issuances' as const, label: 'Issuances & Credits',  icon: Coins },
     { key: 'advanced' as const,  label: 'Advanced',             icon: Shield },
@@ -395,7 +396,7 @@ async function viewProjectVc() {
 function handleViewVc(c: Credit) {
     vcViewerTitle.value = c.name;
     const issuance = project.value?.issuances?.find(i => i.tokenId === c.tokenId);
-    vcViewerData.value = issuance?.rawVc ?? null;
+    vcViewerData.value = issuance?.rawVc ?? c.rawVc ?? null;
     vcViewerOpen.value = true;
 }
 
@@ -486,31 +487,7 @@ const hashscanTopicUrl = computed(() => {
     return `https://hashscan.io/${network.value}/topic/${project.value.topicId}`;
 });
 
-// ─── Activity log ──────────────────────────────────────────────────────────────
-
-const activityLog = computed(() => activityEvents.value ?? []);
-
-const activityTypeIcon: Record<string, { icon: any; color: string }> = {
-    document: { icon: FileText, color: 'text-muted-foreground bg-muted' },
-    verification: { icon: Shield, color: 'text-amber-600 bg-amber-50' },
-    registry: { icon: Database, color: 'text-primary bg-primary/10' },
-    monitoring: { icon: Activity, color: 'text-sky-600 bg-sky-50' },
-    credit: { icon: Coins, color: 'text-emerald-600 bg-emerald-50' },
-};
-
-// ─── Methodology workflow steps ────────────────────────────────────────────────
-
-const methodologySteps = computed(() => {
-    if (!project.value) return [];
-    return [
-        { label: 'Project Design', desc: 'PDD submission & stakeholder consultation', status: 'complete' },
-        { label: 'Validation', desc: 'Third-party validation audit', status: 'complete' },
-        { label: 'Registration', desc: 'Project registration on registry', status: 'complete' },
-        { label: 'Monitoring', desc: 'Data collection & MRV reporting', status: ['Verified', 'Issuing', 'Completed'].includes(project.value.status) ? 'complete' : (project.value.status === 'Under Validation' ? 'active' : 'pending') },
-        { label: 'Verification', desc: 'Emission reduction verification', status: ['Issuing', 'Completed'].includes(project.value.status) ? 'complete' : (project.value.status === 'Verified' ? 'active' : 'pending') },
-        { label: 'Issuance', desc: 'Token minting to Hedera', status: project.value.status === 'Completed' ? 'complete' : (project.value.status === 'Issuing' ? 'active' : 'pending') },
-    ];
-});
+// ─── Methodology name ──────────────────────────────────────────────────────────
 
 const fullMethodologyName = computed(() => {
     if (!project.value) return '';
@@ -695,11 +672,6 @@ const emissions = computed(() => {
                         </ClientOnly>
                     </div>
                 </div>
-            </div>
-
-            <!-- ── Tab: Pipeline & Trust Chain ─────────────────────────────────── -->
-            <div v-else-if="activeTab === 'pipeline'" class="p-6">
-                <ProjectPipeline :project="project" />
             </div>
 
             <!-- ── Tab: Issuances & Credits ────────────────────────────────────── -->
@@ -991,6 +963,12 @@ const emissions = computed(() => {
                 <!-- Hedera On-Chain References -->
                 <HederaReferences :project="project" :network="network" />
 
+                <!-- Pipeline (moved from the former Pipeline tab) -->
+                <ClientOnly>
+                    <ProjectPolicyCanvas :project="project" />
+                </ClientOnly>
+                <ProjectPipeline :project="project" />
+
                 <!-- Linked VCs (raw) -->
                 <LinkedVcsPanel
                     :project="project"
@@ -998,86 +976,8 @@ const emissions = computed(() => {
                     @view-vc-json="handleViewVcJson"
                 />
 
-                <!-- Activity Log -->
-                <div class="rounded-xl border bg-card overflow-hidden">
-                    <div class="px-5 py-3.5 border-b bg-muted/30">
-                        <h2 class="text-sm font-semibold text-foreground flex items-center gap-2">
-                            <Clock class="h-4 w-4 text-primary" />
-                            Activity Log
-                        </h2>
-                    </div>
-                    <div v-if="activityLog.length > 0" class="px-5 py-5">
-                        <div class="relative">
-                            <div class="absolute left-[15px] top-3 bottom-3 w-px bg-border" />
-                            <div
-                                v-for="(event, idx) in activityLog"
-                                :key="idx"
-                                class="relative flex items-start gap-4 pb-5 last:pb-0"
-                            >
-                                <div :class="[activityTypeIcon[event.type]?.color || 'text-muted-foreground bg-muted', 'relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full']">
-                                    <component :is="activityTypeIcon[event.type]?.icon || Circle" class="h-3.5 w-3.5" />
-                                </div>
-                                <div class="pt-1">
-                                    <div class="text-sm text-foreground">{{ event.action }}</div>
-                                    <div class="text-[11px] text-muted-foreground mt-0.5">{{ event.date }}</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div v-else class="px-5 py-8 text-center text-sm text-muted-foreground">
-                        No activity log entries available for this project.
-                    </div>
-                </div>
-
-                <!-- Methodology Workflow -->
-                <div class="rounded-xl border bg-card overflow-hidden">
-                    <div class="px-5 py-3.5 border-b bg-muted/30">
-                        <h2 class="text-sm font-semibold text-foreground flex items-center gap-2">
-                            <BookOpen class="h-4 w-4 text-primary" />
-                            Methodology
-                        </h2>
-                        <p class="text-[11px] text-muted-foreground mt-0.5">{{ fullMethodologyName }}</p>
-                    </div>
-                    <div class="px-5 py-5">
-                        <div class="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-4">Workflow</div>
-                        <div class="flex items-center gap-0 overflow-x-auto pb-2">
-                            <template v-for="(step, idx) in methodologySteps" :key="idx">
-                                <div class="flex flex-col items-center min-w-[120px]">
-                                    <div
-                                        :class="[
-                                            step.status === 'complete' ? 'bg-emerald-50 border-emerald-200' :
-                                            step.status === 'active' ? 'bg-primary/10 border-primary/30 ring-2 ring-primary/20' :
-                                            'bg-muted/50 border-border',
-                                            'flex h-10 w-10 items-center justify-center rounded-full border transition-colors',
-                                        ]"
-                                    >
-                                        <CheckCircle2 v-if="step.status === 'complete'" class="h-5 w-5 text-emerald-600" />
-                                        <Zap v-else-if="step.status === 'active'" class="h-5 w-5 text-primary" />
-                                        <Circle v-else class="h-5 w-5 text-muted-foreground/40" />
-                                    </div>
-                                    <div class="mt-2 text-center">
-                                        <div
-                                            :class="[
-                                                step.status === 'active' ? 'text-primary font-semibold' :
-                                                step.status === 'complete' ? 'text-foreground font-medium' :
-                                                'text-muted-foreground',
-                                                'text-xs',
-                                            ]"
-                                        >
-                                            {{ step.label }}
-                                        </div>
-                                        <div class="text-[10px] text-muted-foreground mt-0.5 max-w-[110px] leading-tight">{{ step.desc }}</div>
-                                    </div>
-                                </div>
-                                <div
-                                    v-if="idx < methodologySteps.length - 1"
-                                    class="flex-1 min-w-[24px] h-px mt-[-24px]"
-                                    :class="step.status === 'complete' ? 'bg-emerald-300' : 'bg-border'"
-                                />
-                            </template>
-                        </div>
-                    </div>
-                </div>
+                <!-- Trust Chain (moved from Pipeline tab) -->
+                <ProjectTrustChain :project="project" />
 
                 <!-- Methodology Field Mapping (lazy) -->
                 <div class="rounded-xl border bg-card overflow-hidden">

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -19,10 +19,20 @@ const INVALID_COUNTRY = new Set([
     'point', 'multipoint', 'linestring', 'multilinestring',
     'polygon', 'multipolygon', 'geometrycollection',
 ]);
+// A country cell should be a place name — never a URL, IPFS/file URI, or raw CID
+// that leaked in from a geo/file field during mapping.
+function looksLikeLocation(name: string): boolean {
+    const v = name.trim();
+    if (!v) return false;
+    if (INVALID_COUNTRY.has(v.toLowerCase())) return false;
+    if (/:\/\//.test(v)) return false;                       // ipfs:// http(s):// ar:// …
+    if (/^(Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-z0-9]{20,})$/i.test(v)) return false; // bare CID
+    return true;
+}
 function displayCountry(p: Project): string | null {
     const name = resolvedName(p);
     if (!name) return null;
-    return INVALID_COUNTRY.has(name.toLowerCase().trim()) ? null : name;
+    return looksLikeLocation(name) ? name : null;
 }
 
 

--- a/sustainable-explorer/frontend/types/models.ts
+++ b/sustainable-explorer/frontend/types/models.ts
@@ -8,6 +8,18 @@ export interface ProjectIssuance {
     rawVc?: Record<string, any> | null;
 }
 
+export interface IssuanceEvent {
+    mintConsensusTimestamp: string;
+    tokenId: string | null;
+    name: string | null;
+    symbol: string | null;
+    type: string | null;
+    amount: number | null;
+    mintDate: string | null;
+    linkMethod: string | null;
+    rawVc: Record<string, any> | null;
+}
+
 export interface LinkedVc {
     consensusTimestamp: string;
     topicId: string;
@@ -53,12 +65,15 @@ export interface Project {
     sourceTimestamp?: string;
     projectKey?: string | null;
     issuances?: ProjectIssuance[];
+    issuanceEvents?: IssuanceEvent[];
     issuanceCount?: number;
     linkedSchemas?: LinkedSchema[];
     totalIssued?: number;
     totalRetired?: number;
     totalActive?: number;
     rawVc?: Record<string, any>;
+    decodeMethod?: string | null;
+    metadata?: Record<string, unknown> | null;
 }
 
 export interface Credit {

--- a/sustainable-explorer/frontend/types/models.ts
+++ b/sustainable-explorer/frontend/types/models.ts
@@ -18,6 +18,7 @@ export interface LinkedSchema {
     schemaUuid: string;
     schemaName: string | null;
     isProjectSchema: boolean;
+    docType: string;
     vcCount: number;
     linkedVcs: LinkedVc[];
 }

--- a/sustainable-explorer/frontend/yarn.lock
+++ b/sustainable-explorer/frontend/yarn.lock
@@ -2576,6 +2576,11 @@
     "@types/topojson-simplify" "*"
     "@types/topojson-specification" "*"
 
+"@types/web-bluetooth@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz#f066abfcd1cbe66267cdbbf0de010d8a41b41597"
+  integrity sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==
+
 "@types/web-bluetooth@^0.0.21":
   version "0.0.21"
   resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz#525433c784aed9b457aaa0ee3d92aeb71f346b63"
@@ -2780,6 +2785,17 @@
   version "2.4.28"
   resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-2.4.28.tgz#b40254e8c96199e5f1e0796777c593c617ad270e"
   integrity sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==
+
+"@vue-flow/core@^1.48.2":
+  version "1.48.2"
+  resolved "https://registry.yarnpkg.com/@vue-flow/core/-/core-1.48.2.tgz#cef8641b17f6220c257d4208bdb2082cee882225"
+  integrity sha512-raxhgKWE+G/mcEvXJjGFUDYW9rAI3GOtiHR3ZkNpwBWuIaCC1EYiBmKGwJOoNzVFgwO7COgErnK7i08i287AFA==
+  dependencies:
+    "@vueuse/core" "^10.5.0"
+    d3-drag "^3.0.0"
+    d3-interpolate "^3.0.1"
+    d3-selection "^3.0.0"
+    d3-zoom "^3.0.0"
 
 "@vue-leaflet/vue-leaflet@^0.10":
   version "0.10.1"
@@ -3043,6 +3059,16 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.32.tgz#dd8ba0d709bf3f758c324a81c8897bad5e1540cf"
   integrity sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==
 
+"@vueuse/core@^10.5.0":
+  version "10.11.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.11.1.tgz#15d2c0b6448d2212235b23a7ba29c27173e0c2c6"
+  integrity sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.20"
+    "@vueuse/metadata" "10.11.1"
+    "@vueuse/shared" "10.11.1"
+    vue-demi ">=0.14.8"
+
 "@vueuse/core@^12":
   version "12.8.2"
   resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-12.8.2.tgz#007c6dd29a7d1f6933e916e7a2f8ef3c3f968eaa"
@@ -3062,6 +3088,11 @@
     "@vueuse/metadata" "14.2.1"
     "@vueuse/shared" "14.2.1"
 
+"@vueuse/metadata@10.11.1":
+  version "10.11.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-10.11.1.tgz#209db7bb5915aa172a87510b6de2ca01cadbd2a7"
+  integrity sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==
+
 "@vueuse/metadata@12.8.2":
   version "12.8.2"
   resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-12.8.2.tgz#6cb3a4e97cdcf528329eebc1bda73cd7f64318d3"
@@ -3071,6 +3102,13 @@
   version "14.2.1"
   resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-14.2.1.tgz#bd3338a565c2f651b9d18ac0f8825aa6077ee461"
   integrity sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==
+
+"@vueuse/shared@10.11.1":
+  version "10.11.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-10.11.1.tgz#62b84e3118ae6e1f3ff38f4fbe71b0c5d0f10938"
+  integrity sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==
+  dependencies:
+    vue-demi ">=0.14.8"
 
 "@vueuse/shared@12.8.2":
   version "12.8.2"
@@ -3841,7 +3879,7 @@ d3-delaunay@6:
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
 
-"d3-drag@2 - 3", d3-drag@3, d3-drag@~3:
+"d3-drag@2 - 3", d3-drag@3, d3-drag@^3.0.0, d3-drag@~3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
@@ -3910,7 +3948,7 @@ d3-interpolate-path@^2.2.3:
   resolved "https://registry.yarnpkg.com/d3-interpolate-path/-/d3-interpolate-path-2.3.0.tgz#ff919acb52968619f4b0dc5fa95653e581d5a0ca"
   integrity sha512-tZYtGXxBmbgHsIc9Wms6LS5u4w6KbP8C09a4/ZYc4KLMYYqub57rRBUgpUr2CIarIrJEpdAWWxWQvofgaMpbKQ==
 
-"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3, d3-interpolate@~3:
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3, d3-interpolate@^3.0.1, d3-interpolate@~3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
@@ -3969,7 +4007,7 @@ d3-scale@4, d3-scale@~4:
     d3-time "2.1.1 - 3"
     d3-time-format "2 - 4"
 
-"d3-selection@2 - 3", d3-selection@3, d3-selection@~3:
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0, d3-selection@~3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
@@ -4018,7 +4056,7 @@ d3-shape@^1.2.0:
     d3-interpolate "1 - 3"
     d3-timer "1 - 3"
 
-d3-zoom@3, d3-zoom@~3:
+d3-zoom@3, d3-zoom@^3.0.0, d3-zoom@~3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
   integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
@@ -7305,7 +7343,7 @@ vue-bundle-renderer@^2.2.0:
   dependencies:
     ufo "^1.6.1"
 
-vue-demi@>=0.13.0, vue-demi@^0.14.10:
+vue-demi@>=0.13.0, vue-demi@>=0.14.8, vue-demi@^0.14.10:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
   integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==

--- a/sustainable-explorer/src/api/controllers/project.controller.ts
+++ b/sustainable-explorer/src/api/controllers/project.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Param, Query, NotFoundException, BadRequestExcep
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { ProjectsService } from '../services/project.service';
 import { ProjectExportService, type ExportFormat } from '../services/project-export.service';
+import { PolicyWorkflowGraph } from '../services/policy-graph.builder';
 import {
     ProjectQueryDto,
     ProjectResponseDto,
@@ -175,6 +176,86 @@ export class ProjectsController {
         @Param('consensusTimestamp') consensusTimestamp: string,
     ): Promise<Record<string, unknown>> {
         return this.projectsService.getLinkedVcDocument(network, id, consensusTimestamp);
+    }
+
+    @Get(':id/vc-evidence/:consensusTimestamp')
+    @ApiOperation({
+        summary: 'Get the raw VC document and schema field labels for a single linked VC',
+        description:
+            'Returns the full JSONB VC document from the message table together with a ' +
+            'fieldLabels map (credentialSubject key → human-readable label from the policy ' +
+            'schemaFields).  The consensusTimestamp must appear in the project\'s ' +
+            'businessData->linkedVcs list.  fieldLabels is an empty object when the policy ' +
+            'schema cannot be resolved — callers must fall back gracefully.',
+    })
+    @ApiParam({
+        name: 'network',
+        enum: ['mainnet', 'testnet', 'previewnet'],
+        description: 'Hedera network',
+    })
+    @ApiParam({
+        name: 'id',
+        description: 'HCS consensus timestamp (sourceTimestamp) or projectKey of the project',
+    })
+    @ApiParam({
+        name: 'consensusTimestamp',
+        description: 'HCS consensus timestamp of the linked VC message (e.g. "1234567890.123456789")',
+    })
+    @ApiResponse({
+        status: 200,
+        description: 'Raw VC document and per-field label map',
+        schema: {
+            type: 'object',
+            properties: {
+                document: { type: 'object', additionalProperties: true },
+                fieldLabels: { type: 'object', additionalProperties: { type: 'string' } },
+            },
+        },
+    })
+    @ApiResponse({ status: 404, description: 'Project not found, VC not linked to this project, or no document stored' })
+    async getLinkedVcEvidence(
+        @Param('network') network: string,
+        @Param('id') id: string,
+        @Param('consensusTimestamp') consensusTimestamp: string,
+    ): Promise<{ document: Record<string, unknown>; fieldLabels: Record<string, string> }> {
+        return this.projectsService.getLinkedVcEvidence(network, id, consensusTimestamp);
+    }
+
+    @Get(':id/policy-graph')
+    @ApiOperation({
+        summary: 'Get the methodology workflow graph for a project',
+        description:
+            'Returns the policy.json-derived workflow graph: role swimlanes of document/action ' +
+            'steps and the real flow edges between them (UI-refresh events are filtered out). ' +
+            'Each node carries its schema UUID so the frontend can overlay VC availability. ' +
+            'Returns an empty graph ({roles:[],nodes:[],edges:[]}) when the project has no decoded policy.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'], description: 'Hedera network' })
+    @ApiParam({ name: 'id', description: 'HCS consensus timestamp (sourceTimestamp) or projectKey of the project' })
+    @ApiResponse({ status: 200, description: 'Policy workflow graph (roles, nodes, edges)' })
+    @ApiResponse({ status: 404, description: 'Project not found' })
+    async getPolicyGraph(
+        @Param('network') network: string,
+        @Param('id') id: string,
+    ): Promise<PolicyWorkflowGraph> {
+        return this.projectsService.getPolicyGraph(network, id);
+    }
+
+    @Get(':id/policy-json')
+    @ApiOperation({
+        summary: 'Get the raw decoded policy.json for a project',
+        description: 'Returns the full policy.json document of the project\'s decoded policy, ' +
+            'for the in-app JSON inspector. Returns null when no decoded policy exists.',
+    })
+    @ApiParam({ name: 'network', enum: ['mainnet', 'testnet', 'previewnet'], description: 'Hedera network' })
+    @ApiParam({ name: 'id', description: 'HCS consensus timestamp (sourceTimestamp) or projectKey of the project' })
+    @ApiResponse({ status: 200, description: 'Raw policy.json (or null)' })
+    @ApiResponse({ status: 404, description: 'Project not found' })
+    async getPolicyJson(
+        @Param('network') network: string,
+        @Param('id') id: string,
+    ): Promise<Record<string, unknown> | null> {
+        return this.projectsService.getPolicyJson(network, id);
     }
 
     @Get(':id/export/:format')

--- a/sustainable-explorer/src/api/dto/project.dto.ts
+++ b/sustainable-explorer/src/api/dto/project.dto.ts
@@ -1,7 +1,7 @@
 import { IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginationQueryDto } from './pagination.dto';
-import { ProjectRow, ActivityEventRow, PolicySchemaRow } from '../repositories/project.repository';
+import { ProjectRow, ActivityEventRow, PolicySchemaRow, IssuanceEventRow } from '../repositories/project.repository';
 
 export class ActivityEventDto {
     @ApiProperty({ description: 'Date of the activity (YYYY-MM-DD)' })
@@ -71,6 +71,49 @@ export class IssuanceDto {
 
     @ApiProperty({ nullable: true, description: 'Raw MintToken VC document from the Hedera message' })
     rawVc: Record<string, any> | null;
+}
+
+export class IssuanceEventDto {
+    @ApiProperty({ description: 'HCS consensus timestamp of the MintToken VC message' })
+    mintConsensusTimestamp: string;
+
+    @ApiProperty({ nullable: true, description: 'Hedera token ID (e.g. 0.0.12345)' })
+    tokenId: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Token name from token_cache' })
+    name: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Token symbol from token_cache' })
+    symbol: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Token type (FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE)' })
+    type: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Minted amount for this event' })
+    amount: number | null;
+
+    @ApiProperty({ nullable: true, description: 'Mint date (YYYY-MM-DD)' })
+    mintDate: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Link method used to associate this mint with the project (relationship | cs_ref | ref_root | topic_scope)' })
+    linkMethod: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Raw MintToken VC document from the Hedera message' })
+    rawVc: Record<string, any> | null;
+
+    static fromRow(row: IssuanceEventRow): IssuanceEventDto {
+        return {
+            mintConsensusTimestamp: row.mintConsensusTimestamp,
+            tokenId: row.tokenId ?? null,
+            name: row.name ?? null,
+            symbol: row.symbol ?? null,
+            type: row.type ?? null,
+            amount: row.amount ?? null,
+            mintDate: row.mintDate ?? null,
+            linkMethod: row.linkMethod ?? null,
+            rawVc: row.rawVc ?? null,
+        };
+    }
 }
 
 export class LinkedVcDto {
@@ -233,6 +276,12 @@ export class ProjectResponseDto {
     @ApiProperty({ description: 'Number of VC-Document messages that contributed to this project row' })
     vcCount: number;
 
+    @ApiProperty({ nullable: true, description: 'Resolver method that established this project identity: topic | csRef | relationships | projectSchema' })
+    decodeMethod: string | null;
+
+    @ApiProperty({ nullable: true, description: 'Resolution anchor metadata: { dynamicTopicId } for the topic method, { rootVcTimestamp } for cs.ref / relationships / projectSchema' })
+    metadata: Record<string, unknown> | null;
+
     @ApiProperty({ description: 'HCS consensus timestamp of the earliest source VC message' })
     sourceTimestamp: string;
 
@@ -247,6 +296,9 @@ export class ProjectResponseDto {
 
     @ApiProperty({ type: [IssuanceDto], description: 'Linked token issuances for this project' })
     issuances: IssuanceDto[];
+
+    @ApiProperty({ type: [IssuanceEventDto], description: 'Per-mint-event issuance history, oldest first' })
+    issuanceEvents: IssuanceEventDto[];
 
     @ApiProperty({ description: 'Total credits ever minted (NFT serials + fungible supply)' })
     totalIssued: number;
@@ -358,10 +410,20 @@ export class ProjectResponseDto {
             return 0;
         });
 
+        // Friendly display name: when the stored displayName is a bare DID or
+        // topic id (the project-schema VC never landed to supply a real title),
+        // fall back to the project schema's name, then the methodology name.
+        const rawName = row.displayName ?? '';
+        const looksLikeId = !rawName || /^did:/i.test(rawName) || /^\d+\.\d+\.\d+$/.test(rawName) || rawName === (row.projectKey ?? '');
+        const projectSchemaName = linkedSchemas.find(s => s.isProjectSchema && s.schemaName)?.schemaName ?? null;
+        const friendlyName = looksLikeId
+            ? (projectSchemaName ?? (typeof data['methodology'] === 'string' ? (data['methodology'] as string) : null) ?? rawName)
+            : rawName;
+
         return {
             id: row.id,
             network,
-            name: row.displayName,
+            name: friendlyName,
             description: typeof data['description'] === 'string' ? data['description'] : null,
             country: typeof data['country'] === 'string' ? data['country'] : null,
             lat: typeof data['lat'] === 'number' ? data['lat'] : null,
@@ -386,6 +448,10 @@ export class ProjectResponseDto {
             policyTopicId: typeof data['policyTopicId'] === 'string' ? data['policyTopicId'] : null,
             instanceTopicId: typeof data['instanceTopicId'] === 'string' ? data['instanceTopicId'] : null,
             vcCount: typeof data['vcCount'] === 'number' ? data['vcCount'] : 0,
+            decodeMethod: typeof data['decodeMethod'] === 'string' ? data['decodeMethod'] : null,
+            metadata: data['metadata'] && typeof data['metadata'] === 'object' && !Array.isArray(data['metadata'])
+                ? (data['metadata'] as Record<string, unknown>)
+                : null,
             sourceTimestamp: row.sourceTimestamp,
             projectKey: row.projectKey ?? null,
             updatedAt: row.updatedAt,
@@ -398,6 +464,7 @@ export class ProjectResponseDto {
                 mintDate: i.mintDate,
                 rawVc: i.rawVc ?? null,
             })),
+            issuanceEvents: (row.issuanceEvents ?? []).map(e => IssuanceEventDto.fromRow(e)),
             issuanceCount: row.issuanceCount ?? 0,
             totalIssued: row.totalIssued ?? 0,
             totalRetired: row.totalRetired ?? 0,

--- a/sustainable-explorer/src/api/dto/project.dto.ts
+++ b/sustainable-explorer/src/api/dto/project.dto.ts
@@ -13,6 +13,9 @@ export class ActivityEventDto {
     @ApiProperty({ description: 'Activity category: document | verification | registry | monitoring | credit' })
     type: string;
 
+    @ApiProperty({ nullable: true, description: 'Schema name of the VC for this activity, when known' })
+    schemaName: string | null;
+
     static fromRow(row: ActivityEventRow): ActivityEventDto {
         const seconds = parseFloat(row.consensusTimestamp);
         const date = new Date(seconds * 1000).toISOString().split('T')[0];
@@ -43,7 +46,7 @@ export class ActivityEventDto {
             action = row.schemaName ? `${row.schemaName} submitted` : 'Document submitted';
         }
 
-        return { date, action, type };
+        return { date, action, type, schemaName: row.schemaName ?? null };
     }
 }
 
@@ -90,6 +93,9 @@ export class LinkedSchemaDto {
 
     @ApiProperty({ description: 'True when this schema is flagged isProjectSchema in the policyMapping' })
     isProjectSchema: boolean;
+
+    @ApiProperty({ description: 'Coarse Guardian document type (pdd | monitoringReport | validationReport | verificationReport | registration | unknown)' })
+    docType: string;
 
     @ApiProperty({ description: 'Number of linked VCs carrying this schema UUID' })
     vcCount: number;
@@ -270,11 +276,12 @@ export class ProjectResponseDto {
         const trimSchemaId = (id: string): string =>
             id.replace(/^#/, '').split('&')[0].trim();
 
-        const schemaMetaMap = new Map<string, Pick<PolicySchemaRow, 'name' | 'isProjectSchema'>>();
+        const schemaMetaMap = new Map<string, Pick<PolicySchemaRow, 'name' | 'isProjectSchema' | 'docType'>>();
         for (const s of (row.policySchemas ?? [])) {
             schemaMetaMap.set(trimSchemaId(s.schemaId), {
                 name: s.name,
                 isProjectSchema: s.isProjectSchema,
+                docType: s.docType,
             });
         }
 
@@ -304,6 +311,7 @@ export class ProjectResponseDto {
                 schemaUuid: uuid,
                 schemaName: meta?.name ?? null,
                 isProjectSchema: meta?.isProjectSchema ?? false,
+                docType: meta?.docType ?? 'unknown',
                 vcCount: vcs.length,
                 linkedVcs: vcs,
             });
@@ -323,6 +331,7 @@ export class ProjectResponseDto {
                     schemaUuid: trimmed,
                     schemaName: s.name,
                     isProjectSchema: s.isProjectSchema,
+                    docType: s.docType,
                     vcCount: 0,
                     linkedVcs: [],
                 });

--- a/sustainable-explorer/src/api/repositories/pg-project.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-project.repository.ts
@@ -377,6 +377,7 @@ export class PgProjectRepository extends ProjectRepository {
                 const policyMapping = (pr.policyMapping ?? {}) as Record<string, unknown[]>;
 
                 const projectIris = new Set<string>();
+                const docTypeByIri = new Map<string, string>();
                 for (const entries of Object.values(policyMapping)) {
                     if (!Array.isArray(entries)) continue;
                     for (const entry of entries) {
@@ -384,6 +385,9 @@ export class PgProjectRepository extends ProjectRepository {
                         const e = entry as Record<string, unknown>;
                         if (e['isProjectSchema'] === true && typeof e['schemaIri'] === 'string') {
                             projectIris.add(e['schemaIri'] as string);
+                        }
+                        if (typeof e['schemaIri'] === 'string' && typeof e['docType'] === 'string') {
+                            docTypeByIri.set(e['schemaIri'] as string, e['docType'] as string);
                         }
                     }
                 }
@@ -395,6 +399,7 @@ export class PgProjectRepository extends ProjectRepository {
                         schemaId: iri,
                         name,
                         isProjectSchema: projectIris.has(iri),
+                        docType: docTypeByIri.get(iri) ?? 'unknown',
                     };
                 }).sort((a, b) => {
                     if (a.isProjectSchema && !b.isProjectSchema) return -1;
@@ -408,8 +413,8 @@ export class PgProjectRepository extends ProjectRepository {
     }
 
     async findActivity(sourceTimestamp: string): Promise<ActivityEventRow[]> {
-        const projectRows: Array<{ relatedTopicId: string | null }> = await this.dataSource.query(
-            `SELECT "relatedTopicId"
+        const projectRows: Array<{ relatedTopicId: string | null; businessData: Record<string, any> | null }> = await this.dataSource.query(
+            `SELECT "relatedTopicId", "businessData"
              FROM business_view
              WHERE "viewType" = 'PROJECT'
                AND "sourceTimestamp" = $1
@@ -450,26 +455,60 @@ export class PgProjectRepository extends ProjectRepository {
             }
         }
 
-        const rows: Array<{
-            consensusTimestamp: string;
-            type: string;
-            vc_schema_iri: string | null;
-        }> = await this.dataSource.query(
-            `SELECT
-                m."consensusTimestamp",
-                m.type,
-                split_part(
-                    m.documents -> 'credentialSubject' -> 0 ->> 'type',
-                    '&', 1
-                ) AS vc_schema_iri
-             FROM message m
-             WHERE m."topicId" = $1
-               AND m.type IN ('VC-Document', 'VP-Document')
-               AND m.documents IS NOT NULL
-             ORDER BY m."consensusTimestamp" ASC
-             LIMIT 100`,
+        // Scope the timeline. When multiple PROJECT rows share this instance topic,
+        // a full-topic scan over-lists sibling projects' VCs — so source the
+        // timeline from THIS project's own linkedVcs. A per-project dynamic topic
+        // (exactly one PROJECT row) keeps the existing full-topic scan.
+        const projectCountRows: Array<{ cnt: number }> = await this.dataSource.query(
+            `SELECT COUNT(*)::int AS cnt
+             FROM business_view
+             WHERE "viewType" = 'PROJECT' AND "relatedTopicId" = $1`,
             [topicId],
         );
+        const projectCount = projectCountRows[0]?.cnt ?? 1;
+
+        let rows: Array<{ consensusTimestamp: string; type: string; vc_schema_iri: string | null }>;
+        if (projectCount > 1) {
+            const linkedVcs = Array.isArray(projectRows[0].businessData?.['linkedVcs'])
+                ? (projectRows[0].businessData!['linkedVcs'] as Array<{ consensusTimestamp?: unknown }>)
+                : [];
+            const timestamps = linkedVcs
+                .map(v => v?.consensusTimestamp)
+                .filter((ts): ts is string => typeof ts === 'string' && ts.length > 0);
+            if (timestamps.length === 0) return [];
+            rows = await this.dataSource.query(
+                `SELECT
+                    m."consensusTimestamp",
+                    m.type,
+                    split_part(
+                        m.documents -> 'credentialSubject' -> 0 ->> 'type',
+                        '&', 1
+                    ) AS vc_schema_iri
+                 FROM message m
+                 WHERE m."consensusTimestamp" = ANY($1::varchar[])
+                   AND m.type IN ('VC-Document', 'VP-Document')
+                   AND m.documents IS NOT NULL
+                 ORDER BY m."consensusTimestamp" ASC`,
+                [timestamps],
+            );
+        } else {
+            rows = await this.dataSource.query(
+                `SELECT
+                    m."consensusTimestamp",
+                    m.type,
+                    split_part(
+                        m.documents -> 'credentialSubject' -> 0 ->> 'type',
+                        '&', 1
+                    ) AS vc_schema_iri
+                 FROM message m
+                 WHERE m."topicId" = $1
+                   AND m.type IN ('VC-Document', 'VP-Document')
+                   AND m.documents IS NOT NULL
+                 ORDER BY m."consensusTimestamp" ASC
+                 LIMIT 100`,
+                [topicId],
+            );
+        }
 
         return rows.map(r => ({
             consensusTimestamp: r.consensusTimestamp,

--- a/sustainable-explorer/src/api/repositories/pg-project.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-project.repository.ts
@@ -5,6 +5,7 @@ import {
     ProjectListResult,
     ProjectRow,
     IssuanceRow,
+    IssuanceEventRow,
     ActivityEventRow,
     PolicySchemaRow,
 } from './project.repository';
@@ -200,6 +201,7 @@ export class PgProjectRepository extends ProjectRepository {
         // walking options.relationships, so this query is correct even for
         // grouped projects that share one instance topic.
         let issuances: IssuanceRow[] = [];
+        let issuanceEvents: IssuanceEventRow[] = [];
         let totalIssued = 0;
         let totalRetired = 0;
 
@@ -208,12 +210,16 @@ export class PgProjectRepository extends ProjectRepository {
             amount: number | null;
             mint_date: Date | null;
             documents: Record<string, any> | null;
+            mint_ts: string;
+            link_method: string | null;
         }> = await this.dataSource.query(
             `SELECT
                 pml.token_id,
                 pml.amount,
                 pml.mint_date,
-                m.documents
+                m.documents,
+                pml.mint_consensus_timestamp AS mint_ts,
+                pml.link_method
              FROM project_mint_link pml
              JOIN message m ON m."consensusTimestamp" = pml.mint_consensus_timestamp
              WHERE pml.project_key = $1
@@ -259,6 +265,23 @@ export class PgProjectRepository extends ProjectRepository {
                         ? data.mintDate.toISOString().split('T')[0]
                         : null,
                     rawVc: data.rawVc,
+                };
+            });
+
+            // Per-mint-event issuance history — one entry per MintToken VC row,
+            // ordered oldest-first (same ORDER BY as the mintTokenRows query).
+            issuanceEvents = mintTokenRows.map(r => {
+                const meta = r.token_id ? metaMap.get(r.token_id) : undefined;
+                return {
+                    mintConsensusTimestamp: r.mint_ts,
+                    tokenId: r.token_id ?? null,
+                    name: meta?.name ?? null,
+                    symbol: meta?.symbol ?? null,
+                    type: meta?.type ?? null,
+                    amount: r.amount != null ? Number(r.amount) : null,
+                    mintDate: r.mint_date ? r.mint_date.toISOString().split('T')[0] : null,
+                    linkMethod: r.link_method ?? null,
+                    rawVc: r.documents ?? null,
                 };
             });
 
@@ -428,7 +451,7 @@ export class PgProjectRepository extends ProjectRepository {
             }
         }
 
-        return PgProjectRepository.mapRow(row, issuances, { totalIssued, totalRetired, totalActive }, policySchemas);
+        return PgProjectRepository.mapRow(row, issuances, { totalIssued, totalRetired, totalActive }, policySchemas, issuanceEvents);
     }
 
     async findActivity(sourceTimestamp: string): Promise<ActivityEventRow[]> {
@@ -541,6 +564,7 @@ export class PgProjectRepository extends ProjectRepository {
         issuances?: IssuanceRow[],
         lifecycle?: { totalIssued: number; totalRetired: number; totalActive: number },
         policySchemas?: PolicySchemaRow[],
+        issuanceEvents?: IssuanceEventRow[],
     ): ProjectRow {
         return {
             id: row.id,
@@ -556,6 +580,7 @@ export class PgProjectRepository extends ProjectRepository {
             createdAt: row.createdAt,
             updatedAt: row.updatedAt,
             issuances,
+            issuanceEvents: issuanceEvents ?? [],
             issuanceCount: row.issuance_count ?? undefined,
             totalIssued: lifecycle?.totalIssued,
             totalRetired: lifecycle?.totalRetired,

--- a/sustainable-explorer/src/api/repositories/project.repository.ts
+++ b/sustainable-explorer/src/api/repositories/project.repository.ts
@@ -20,6 +20,7 @@ export interface PolicySchemaRow {
     schemaId: string;
     name: string | null;
     isProjectSchema: boolean;
+    docType: string;
 }
 
 export interface ProjectRow {

--- a/sustainable-explorer/src/api/repositories/project.repository.ts
+++ b/sustainable-explorer/src/api/repositories/project.repository.ts
@@ -16,6 +16,18 @@ export interface IssuanceRow {
     rawVc?: Record<string, any> | null;
 }
 
+export interface IssuanceEventRow {
+    mintConsensusTimestamp: string;
+    tokenId: string | null;
+    name: string | null;
+    symbol: string | null;
+    type: string | null;
+    amount: number | null;
+    mintDate: string | null;
+    linkMethod: string | null;
+    rawVc: Record<string, any> | null;
+}
+
 export interface PolicySchemaRow {
     schemaId: string;
     name: string | null;
@@ -37,6 +49,7 @@ export interface ProjectRow {
     createdAt: Date;
     updatedAt: Date;
     issuances?: IssuanceRow[];
+    issuanceEvents?: IssuanceEventRow[];
     issuanceCount?: number;
     totalIssued?: number;
     totalRetired?: number;

--- a/sustainable-explorer/src/api/services/mapping-reprocess.service.ts
+++ b/sustainable-explorer/src/api/services/mapping-reprocess.service.ts
@@ -8,6 +8,7 @@ import { PROJECT_EXTRACT_FIELDS } from '@worker/project-mapper/project-fields';
 import { UpdateMappingDto } from '../dto/update-mapping.dto';
 import { DecodedMethodologyResponseDto } from '../dto/decoded-methodology.dto';
 import { PgPolicySchemaRepository } from '../repositories/pg-policy-schema.repository';
+import { buildPolicyWorkflowGraph, PolicyWorkflowGraph } from './policy-graph.builder';
 
 // ---------------------------------------------------------------------------
 // Internal row shapes
@@ -778,9 +779,166 @@ export class MappingReprocessService {
         return msgRows[0].documents!;
     }
 
+    /**
+     * Returns the raw VC document AND a per-field label map derived from the
+     * policy's schemaFields.  The document fetch is delegated to
+     * getLinkedVcDocument so all verification logic is reused exactly once.
+     *
+     * fieldLabels maps credentialSubject key → human label (description or
+     * title from the matching schemaFields entry).  Returns an empty map when
+     * the schema cannot be resolved — the caller must fall back gracefully.
+     */
+    async getLinkedVcEvidence(
+        network: string,
+        projectId: string,
+        consensusTimestamp: string,
+    ): Promise<{ document: Record<string, unknown>; fieldLabels: Record<string, string> }> {
+        const document = await this.getLinkedVcDocument(network, projectId, consensusTimestamp);
+        const ds = this.dataSources.getDataSource(network);
+        const fieldLabels = await this.buildVcFieldLabels(ds, consensusTimestamp, document);
+        return { document, fieldLabels };
+    }
+
+    /**
+     * Returns the methodology workflow graph (role swimlanes of document/action
+     * steps + real flow edges) for a project's policy, extracted from
+     * policy.json. Returns an empty graph when the project has no decoded policy
+     * (the frontend renders an empty-state).
+     */
+    async getPolicyGraph(network: string, projectId: string): Promise<PolicyWorkflowGraph> {
+        const ds = this.dataSources.getDataSource(network);
+
+        const projectRows: Array<{ businessData: Record<string, unknown> | null }> = await ds.query(
+            `SELECT "businessData"
+             FROM business_view
+             WHERE "viewType" = 'PROJECT'
+               AND ("sourceTimestamp" = $1 OR "projectKey" = $1)
+             LIMIT 1`,
+            [projectId],
+        );
+        if (projectRows.length === 0) {
+            throw new NotFoundException(`Project with ID "${projectId}" not found on ${network}.`);
+        }
+
+        const businessData = projectRows[0].businessData ?? {};
+        const policyTopicId = typeof businessData['policyTopicId'] === 'string'
+            ? (businessData['policyTopicId'] as string)
+            : null;
+        if (!policyTopicId) return { roles: [], nodes: [], edges: [] };
+
+        const policyRows: Array<{ rawPolicyJson: Record<string, unknown> | null; rawSchemaJson: Record<string, unknown> | null }> =
+            await ds.query(
+                `SELECT "rawPolicyJson", "rawSchemaJson"
+                 FROM policy
+                 WHERE "policyTopicId" = $1 AND "decodeStatus" = 'decoded'
+                 LIMIT 1`,
+                [policyTopicId],
+            );
+        if (policyRows.length === 0) return { roles: [], nodes: [], edges: [] };
+
+        return buildPolicyWorkflowGraph(policyRows[0].rawPolicyJson, policyRows[0].rawSchemaJson);
+    }
+
+    /**
+     * Returns the raw decoded policy.json for a project's policy (for the
+     * "view policy JSON" inspector). Returns null when no decoded policy exists.
+     */
+    async getPolicyJson(network: string, projectId: string): Promise<Record<string, unknown> | null> {
+        const ds = this.dataSources.getDataSource(network);
+
+        const projectRows: Array<{ businessData: Record<string, unknown> | null }> = await ds.query(
+            `SELECT "businessData"
+             FROM business_view
+             WHERE "viewType" = 'PROJECT'
+               AND ("sourceTimestamp" = $1 OR "projectKey" = $1)
+             LIMIT 1`,
+            [projectId],
+        );
+        if (projectRows.length === 0) {
+            throw new NotFoundException(`Project with ID "${projectId}" not found on ${network}.`);
+        }
+
+        const policyTopicId = typeof projectRows[0].businessData?.['policyTopicId'] === 'string'
+            ? (projectRows[0].businessData!['policyTopicId'] as string)
+            : null;
+        if (!policyTopicId) return null;
+
+        const policyRows: Array<{ rawPolicyJson: Record<string, unknown> | null }> = await ds.query(
+            `SELECT "rawPolicyJson"
+             FROM policy
+             WHERE "policyTopicId" = $1 AND "decodeStatus" = 'decoded'
+             LIMIT 1`,
+            [policyTopicId],
+        );
+        return policyRows[0]?.rawPolicyJson ?? null;
+    }
+
     // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------
+
+    /**
+     * Builds a map of { [fieldPath]: humanLabel } for the credentialSubject
+     * fields of the given VC document by looking up the policy's schemaFields.
+     *
+     * Returns {} when any required data is absent — callers must handle this
+     * gracefully (fall back to humanizeKey on the frontend).
+     */
+    private async buildVcFieldLabels(
+        ds: import('typeorm').DataSource,
+        consensusTimestamp: string,
+        document: Record<string, unknown>,
+    ): Promise<Record<string, string>> {
+        try {
+            // 1. Extract the schema IRI from credentialSubject[0].type
+            const cs = Array.isArray(document['credentialSubject'])
+                ? (document['credentialSubject'][0] as Record<string, unknown> | undefined)
+                : (document['credentialSubject'] as Record<string, unknown> | undefined);
+            if (!cs) return {};
+
+            const schemaIriRaw = String(cs['type'] ?? '');
+            const bareUuid = schemaIriRaw.replace(/^#/, '').split('&')[0].trim();
+            if (!bareUuid) return {};
+
+            // 2. Fetch policy schemaFields for the message's policyId
+            const rows: Array<{ schemaFields: unknown }> = await ds.query(
+                `SELECT p."schemaFields"
+                 FROM message m
+                 JOIN policy p ON p."policyId" = m."policyId"
+                 WHERE m."consensusTimestamp" = $1
+                   AND p."decodeStatus" = 'decoded'
+                 LIMIT 1`,
+                [consensusTimestamp],
+            );
+
+            if (rows.length === 0) return {};
+            const schemaFields = rows[0].schemaFields;
+            if (!Array.isArray(schemaFields)) return {};
+
+            // 3. Build the label map for entries whose schemaIri bare-UUID matches
+            const labels: Record<string, string> = {};
+            for (const entry of schemaFields as Array<Record<string, unknown>>) {
+                const entryIri = String(entry['schemaIri'] ?? '');
+                const entryBareUuid = entryIri.replace(/^#/, '').split('&')[0].trim();
+                if (entryBareUuid !== bareUuid) continue;
+
+                const path = String(entry['path'] ?? '').trim();
+                if (!path) continue;
+
+                const description = String(entry['description'] ?? '').trim();
+                const title = String(entry['title'] ?? '').trim();
+                const label = description || title;
+                if (!label) continue;
+
+                labels[path] = label;
+            }
+
+            return labels;
+        } catch {
+            // Never let label resolution failures surface as HTTP errors
+            return {};
+        }
+    }
 
     /**
      * Resolves the policy topic ID for a methodology given its URL `id` param.

--- a/sustainable-explorer/src/api/services/mapping-reprocess.service.ts
+++ b/sustainable-explorer/src/api/services/mapping-reprocess.service.ts
@@ -733,8 +733,8 @@ export class MappingReprocessService {
         const ds = this.dataSources.getDataSource(network);
 
         // Resolve the project and verify the timestamp is in its linkedVcs.
-        const projectRows: Array<{ businessData: Record<string, unknown> | null }> = await ds.query(
-            `SELECT "businessData"
+        const projectRows: Array<{ projectKey: string | null; businessData: Record<string, unknown> | null }> = await ds.query(
+            `SELECT "projectKey", "businessData"
              FROM business_view
              WHERE "viewType" = 'PROJECT'
                AND ("sourceTimestamp" = $1 OR "projectKey" = $1)
@@ -753,9 +753,22 @@ export class MappingReprocessService {
             ? (businessData['linkedVcs'] as Array<Record<string, unknown>>)
             : [];
 
-        const isLinked = linkedVcs.some(
+        let isLinked = linkedVcs.some(
             v => typeof v['consensusTimestamp'] === 'string' && v['consensusTimestamp'] === consensusTimestamp,
         );
+
+        // MintToken VCs are attributed via project_mint_link (the mint linker),
+        // not businessData.linkedVcs — accept those too so issuance evidence is
+        // viewable from the project namespace.
+        if (!isLinked && projectRows[0].projectKey) {
+            const mintRows: unknown[] = await ds.query(
+                `SELECT 1 FROM project_mint_link
+                 WHERE mint_consensus_timestamp = $1 AND project_key = $2
+                 LIMIT 1`,
+                [consensusTimestamp, projectRows[0].projectKey],
+            );
+            isLinked = mintRows.length > 0;
+        }
 
         if (!isLinked) {
             throw new NotFoundException(

--- a/sustainable-explorer/src/api/services/policy-graph.builder.ts
+++ b/sustainable-explorer/src/api/services/policy-graph.builder.ts
@@ -1,0 +1,335 @@
+/**
+ * Extracts a human-readable workflow graph from a Guardian policy.json so the
+ * frontend can render a role-swimlane flowchart of the methodology.
+ *
+ * Guardian policies are large block trees (`config.children`, 150-300 blocks)
+ * wired by an `events[]` graph. Most events are `RefreshEvent`s that only
+ * re-render UI tables — pure noise for a workflow view. This builder keeps only
+ * the document/action blocks (the steps a human cares about) and connects them
+ * by the real, non-Refresh flow edges, collapsing the plumbing in between.
+ */
+
+export interface PolicyGraphNode {
+    /** Block tag — unique within the policy; used as the node id. */
+    tag: string;
+    /** Role lane this step belongs to (from block.permissions, tag prefix, or 'General'). */
+    role: string;
+    blockType: string;
+    category: 'document' | 'action';
+    /** Display label: block title -> schema name -> friendly block type. */
+    label: string;
+    /** Bare schema UUID (no '#', no version) for VC-data overlay, or null. */
+    schemaUuid: string | null;
+    /** Authored position (pre-order index in policy.json) — the real step order. */
+    order: number;
+}
+
+export interface PolicyGraphEdge {
+    source: string; // node tag
+    target: string; // node tag
+    /**
+     * 'flow'     — a genuine event transition found in policy.json (sparse; reliable).
+     * 'sequence' — authored step order within a role lane (the order the policy
+     *              author laid out the steps). Guardian does not statically encode
+     *              doc->doc flow, so this sequence is the honest primary backbone.
+     */
+    kind: 'flow' | 'sequence';
+}
+
+export interface PolicyWorkflowGraph {
+    /** Lane order: policyRoles first, then any extra roles found on nodes. */
+    roles: string[];
+    nodes: PolicyGraphNode[];
+    edges: PolicyGraphEdge[];
+}
+
+const DOCUMENT_BLOCK_TYPES = new Set(['requestVcDocumentBlock', 'externalDataBlock']);
+const ACTION_BLOCK_TYPES = new Set(['mintDocumentBlock', 'tokenActionBlock']);
+const RESERVED_ROLES = new Set(['OWNER', 'ANY', 'NO_ROLE', '']);
+
+const FRIENDLY_BLOCK_TYPE: Record<string, string> = {
+    requestVcDocumentBlock: 'Document',
+    externalDataBlock: 'External Data',
+    mintDocumentBlock: 'Mint Token',
+    tokenActionBlock: 'Token Action',
+};
+
+function bareUuid(iri: unknown): string | null {
+    if (typeof iri !== 'string' || !iri) return null;
+    const u = iri.replace(/^#/, '').split('&')[0].trim();
+    return u || null;
+}
+
+function asObject(v: unknown): Record<string, unknown> | null {
+    return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+function categoryOf(blockType: string): 'document' | 'action' | null {
+    if (DOCUMENT_BLOCK_TYPES.has(blockType)) return 'document';
+    if (ACTION_BLOCK_TYPES.has(blockType)) return 'action';
+    return null;
+}
+
+function roleOf(block: Record<string, unknown>): string {
+    // Roles come ONLY from explicit block permissions — the reliable source.
+    // Deriving a role from the tag prefix produced noise lanes like 'mint' /
+    // 'request' / 'mrv' (lowercased block-name fragments, not real roles), so
+    // unowned/system steps fall into a single 'General' lane instead.
+    const perms = block['permissions'];
+    if (Array.isArray(perms)) {
+        const first = perms.find(p => typeof p === 'string' && !RESERVED_ROLES.has(p as string));
+        if (typeof first === 'string') return first;
+    }
+    return 'General';
+}
+
+/**
+ * Resolves a schema's human name from rawSchemaJson, matching first by exact
+ * IRI then by bare UUID (rawSchemaJson keys are full IRIs).
+ */
+function schemaName(
+    schemaIri: unknown,
+    rawSchemaJson: Record<string, unknown>,
+    uuid: string | null,
+): string | null {
+    if (typeof schemaIri === 'string' && rawSchemaJson[schemaIri]) {
+        const doc = asObject(rawSchemaJson[schemaIri]);
+        if (doc && typeof doc['name'] === 'string' && doc['name']) return doc['name'] as string;
+    }
+    if (uuid) {
+        for (const [key, val] of Object.entries(rawSchemaJson)) {
+            if (bareUuid(key) !== uuid) continue;
+            const doc = asObject(val);
+            if (doc && typeof doc['name'] === 'string' && doc['name']) return doc['name'] as string;
+        }
+    }
+    return null;
+}
+
+function labelOf(
+    block: Record<string, unknown>,
+    blockType: string,
+    category: 'document' | 'action',
+    rawSchemaJson: Record<string, unknown>,
+    uuid: string | null,
+): string {
+    const ui = asObject(block['uiMetaData']);
+    const title = ui && typeof ui['title'] === 'string' ? (ui['title'] as string).trim() : '';
+    if (title) return title;
+    if (category === 'document') {
+        const name = schemaName(block['schema'], rawSchemaJson, uuid);
+        if (name) return name;
+    }
+    return FRIENDLY_BLOCK_TYPE[blockType] ?? blockType;
+}
+
+/**
+ * Builds the workflow graph. Pure and fully defensive: any malformed/missing
+ * input yields an empty graph rather than throwing.
+ */
+export function buildPolicyWorkflowGraph(
+    rawPolicyJson: Record<string, unknown> | null | undefined,
+    rawSchemaJson: Record<string, unknown> | null | undefined,
+): PolicyWorkflowGraph {
+    const empty: PolicyWorkflowGraph = { roles: [], nodes: [], edges: [] };
+    const policy = asObject(rawPolicyJson);
+    const config = policy ? asObject(policy['config']) : null;
+    if (!config) return empty;
+    const schemas = asObject(rawSchemaJson) ?? {};
+
+    const nodes: PolicyGraphNode[] = [];
+    const nodeTags = new Set<string>();
+    const emittedSchema = new Set<string>(); // dedupe document nodes by schema
+    const blockTypeByTag = new Map<string, string>();
+    const childrenByTag = new Map<string, string[]>();
+    const parentByTag = new Map<string, string>();
+    // adjacency over real (non-Refresh) flow events: sourceTag -> targetTag[]
+    const adj = new Map<string, string[]>();
+
+    // DFS the block tree: collect node blocks, tree structure, flow-event
+    // adjacency. The real workflow events live on sibling PLUMBING blocks
+    // (buttonBlock / sendToGuardianBlock RunEvent / switchBlock), not on the
+    // document/action blocks — so edges are derived at containing-screen scope.
+    const walk = (block: Record<string, unknown>, parentTag: string): void => {
+        const tag = typeof block['tag'] === 'string' ? (block['tag'] as string) : '';
+        const blockType = typeof block['blockType'] === 'string' ? (block['blockType'] as string) : '';
+        if (tag) {
+            blockTypeByTag.set(tag, blockType);
+            if (parentTag) {
+                parentByTag.set(tag, parentTag);
+                const sib = childrenByTag.get(parentTag) ?? [];
+                sib.push(tag);
+                childrenByTag.set(parentTag, sib);
+            }
+        }
+
+        const category = categoryOf(blockType);
+        if (category && tag && !nodeTags.has(tag)) {
+            const uuid = category === 'document' ? bareUuid(block['schema']) : null;
+            // Collapse repeated blocks that submit the SAME document schema into a
+            // single node (e.g. "submit dMRV" + "edit dMRV") — keeping both was
+            // confusing (one document appearing twice, both "data present"). The
+            // first occurrence (authored order) wins. Action blocks (no schema)
+            // are kept individually.
+            if (uuid && emittedSchema.has(uuid)) {
+                // duplicate document schema — skip as a node (still walked for events)
+            } else {
+                if (uuid) emittedSchema.add(uuid);
+                nodes.push({
+                    tag,
+                    role: roleOf(block),
+                    blockType,
+                    category,
+                    label: labelOf(block, blockType, category, schemas, uuid),
+                    schemaUuid: uuid,
+                    order: nodes.length, // pre-order index = authored position
+                });
+                nodeTags.add(tag);
+            }
+        }
+
+        const events = block['events'];
+        if (Array.isArray(events)) {
+            for (const ev of events) {
+                const e = asObject(ev);
+                if (!e) continue;
+                if (e['output'] === 'RefreshEvent') continue; // UI noise
+                const source = typeof e['source'] === 'string' ? (e['source'] as string) : '';
+                const target = typeof e['target'] === 'string' ? (e['target'] as string) : '';
+                if (!source || !target) continue;
+                const list = adj.get(source) ?? [];
+                list.push(target);
+                adj.set(source, list);
+            }
+        }
+
+        const children = block['children'];
+        if (Array.isArray(children)) {
+            for (const child of children) {
+                const c = asObject(child);
+                if (c) walk(c, tag);
+            }
+        }
+    };
+    walk(config, '');
+
+    const SCOPE_TYPES = new Set(['interfaceStepBlock', 'interfaceContainerBlock']);
+    const rootTag = typeof config['tag'] === 'string' ? (config['tag'] as string) : '';
+
+    // The "screen" a node lives on: nearest step/container ancestor (excluding
+    // the root). Flow events on that screen's plumbing represent the node's exits.
+    const scopeOf = (tag: string): string => {
+        let cur = parentByTag.get(tag);
+        const seen = new Set<string>();
+        while (cur && !seen.has(cur)) {
+            seen.add(cur);
+            if (cur !== rootTag && SCOPE_TYPES.has(blockTypeByTag.get(cur) ?? '')) return cur;
+            cur = parentByTag.get(cur);
+        }
+        return parentByTag.get(tag) ?? tag; // fall back to the direct parent
+    };
+
+    const subtreeTags = (root: string): string[] => {
+        const out: string[] = [];
+        const stack = [root];
+        const seen = new Set<string>();
+        let steps = 0;
+        while (stack.length && steps < 2000) {
+            steps++;
+            const t = stack.pop()!;
+            if (seen.has(t)) continue;
+            seen.add(t);
+            out.push(t);
+            for (const c of childrenByTag.get(t) ?? []) stack.push(c);
+        }
+        return out;
+    };
+
+    // First node(s) reached descending into a subtree — the "entry steps" of a
+    // target screen. Stops at the first node on each branch.
+    const entryNodes = (root: string): string[] => {
+        if (nodeTags.has(root)) return [root];
+        const found: string[] = [];
+        const queue = [...(childrenByTag.get(root) ?? [])];
+        const seen = new Set<string>([root]);
+        let steps = 0;
+        while (queue.length && steps < 2000) {
+            steps++;
+            const t = queue.shift()!;
+            if (seen.has(t)) continue;
+            seen.add(t);
+            if (nodeTags.has(t)) { found.push(t); continue; }
+            for (const c of childrenByTag.get(t) ?? []) queue.push(c);
+        }
+        return found;
+    };
+
+    const edgeSet = new Set<string>();
+    const edges: PolicyGraphEdge[] = [];
+
+    // 'flow' edges: genuine event transitions. For each node, follow flow events
+    // leaving its screen scope to the entry node(s) of the target screen. These
+    // are reliable but sparse (Guardian rarely wires doc->doc statically).
+    const entryCache = new Map<string, string[]>();
+    for (const node of nodes) {
+        const scope = scopeOf(node.tag);
+        const scopeTags = new Set(subtreeTags(scope));
+        for (const src of scopeTags) {
+            for (const target of adj.get(src) ?? []) {
+                if (scopeTags.has(target)) continue; // internal wiring
+                let entries = entryCache.get(target);
+                if (!entries) { entries = entryNodes(target); entryCache.set(target, entries); }
+                for (const succ of entries) {
+                    if (succ === node.tag || scopeTags.has(succ)) continue;
+                    const key = `${node.tag} ${succ}`;
+                    if (edgeSet.has(key)) continue;
+                    edgeSet.add(key);
+                    edges.push({ source: node.tag, target: succ, kind: 'flow' });
+                }
+            }
+        }
+    }
+
+    // 'sequence' edges: within each role lane, connect documents in authored
+    // order (the policy author's step sequence). This is the honest primary
+    // backbone — real structure from policy.json, not a guessed lifecycle. A
+    // pair already linked by a 'flow' edge is not duplicated.
+    const byRole = new Map<string, PolicyGraphNode[]>();
+    for (const n of nodes) {
+        const list = byRole.get(n.role) ?? [];
+        list.push(n);
+        byRole.set(n.role, list);
+    }
+    for (const laneNodes of byRole.values()) {
+        const ordered = [...laneNodes].sort((a, b) => a.order - b.order);
+        for (let i = 0; i + 1 < ordered.length; i++) {
+            const a = ordered[i].tag;
+            const b = ordered[i + 1].tag;
+            const key = `${a} ${b}`;
+            if (edgeSet.has(key)) continue; // already a flow edge
+            edgeSet.add(key);
+            edges.push({ source: a, target: b, kind: 'sequence' });
+        }
+    }
+
+    // Lane order: policyRoles first, then extra roles found on nodes.
+    const roles: string[] = [];
+    const seenRole = new Set<string>();
+    const policyRoles = policy?.['policyRoles'];
+    if (Array.isArray(policyRoles)) {
+        for (const r of policyRoles) {
+            if (typeof r === 'string' && r && !seenRole.has(r)) {
+                seenRole.add(r);
+                roles.push(r);
+            }
+        }
+    }
+    for (const n of nodes) {
+        if (!seenRole.has(n.role)) {
+            seenRole.add(n.role);
+            roles.push(n.role);
+        }
+    }
+
+    return { roles, nodes, edges };
+}

--- a/sustainable-explorer/src/api/services/project.service.ts
+++ b/sustainable-explorer/src/api/services/project.service.ts
@@ -5,6 +5,7 @@ import { NetworkDataSourceRegistry } from '../database/network-datasource.regist
 import { PgProjectRepository } from '../repositories/pg-project.repository';
 import { ProjectRepository } from '../repositories/project.repository';
 import { MappingReprocessService } from './mapping-reprocess.service';
+import { PolicyWorkflowGraph } from './policy-graph.builder';
 
 @Injectable()
 export class ProjectsService {
@@ -87,6 +88,32 @@ export class ProjectsService {
         consensusTimestamp: string,
     ): Promise<Record<string, unknown>> {
         return this.mappingReprocessService.getLinkedVcDocument(network, projectId, consensusTimestamp);
+    }
+
+    /**
+     * Returns the raw VC document plus a per-field label map derived from the
+     * policy's schemaFields.  Delegates entirely to MappingReprocessService.
+     */
+    async getLinkedVcEvidence(
+        network: string,
+        projectId: string,
+        consensusTimestamp: string,
+    ): Promise<{ document: Record<string, unknown>; fieldLabels: Record<string, string> }> {
+        return this.mappingReprocessService.getLinkedVcEvidence(network, projectId, consensusTimestamp);
+    }
+
+    /**
+     * Returns the methodology workflow graph (role swimlanes + real flow edges)
+     * for a project's policy, extracted from policy.json. Delegates to
+     * MappingReprocessService.
+     */
+    async getPolicyGraph(network: string, id: string): Promise<PolicyWorkflowGraph> {
+        return this.mappingReprocessService.getPolicyGraph(network, id);
+    }
+
+    /** Raw decoded policy.json for the project's policy (JSON inspector). */
+    async getPolicyJson(network: string, id: string): Promise<Record<string, unknown> | null> {
+        return this.mappingReprocessService.getPolicyJson(network, id);
     }
 
     /**

--- a/sustainable-explorer/src/shared/database/schema-bootstrap.ts
+++ b/sustainable-explorer/src/shared/database/schema-bootstrap.ts
@@ -134,4 +134,12 @@ export async function bootstrapSchema(dataSource: DataSource): Promise<void> {
         ON business_view ("relatedTopicId")
         WHERE "viewType" = 'METHODOLOGY' AND "relatedTopicId" IS NOT NULL
     `);
+
+    // GIN index backing the linkedVcs @> containment lookups used by
+    // mint-project-linker (topic-keyed projects) and findActivity.
+    await dataSource.query(`
+        CREATE INDEX IF NOT EXISTS idx_business_view_linked_vcs
+        ON business_view USING GIN (("businessData" -> 'linkedVcs'))
+        WHERE "viewType" = 'PROJECT'
+    `);
 }

--- a/sustainable-explorer/src/worker/mapping/policy-pipeline.service.ts
+++ b/sustainable-explorer/src/worker/mapping/policy-pipeline.service.ts
@@ -5,6 +5,8 @@ import { PROJECT_EXTRACT_FIELDS } from '../project-mapper/project-fields';
 import { derivePerPolicyProjectMeta } from './derive-project-meta';
 import { flattenSchemaDocument } from './flatten-schema-fields';
 import { classifySchemaTypeByName } from './classify-schema-type';
+import { DocumentType } from '../project-mapper/types';
+import { classifyDocumentType } from '../project-mapper/document-type-classifier';
 import {
     FlattenedSchemaField,
     PolicyMapping,
@@ -31,13 +33,25 @@ export class PolicyMappingPipelineService {
 
         const schemaFields = this.flattenAll(schemas, schemaTypes);
 
+        // Per-schema field-title lists feed the (weak) doctype signal.
+        const titlesBySchema = new Map<string, string[]>();
+        for (const f of schemaFields) {
+            const list = titlesBySchema.get(f.schemaIri);
+            if (list) list.push(f.title);
+            else titlesBySchema.set(f.schemaIri, [f.title]);
+        }
+        const docTypeBySchema = new Map<string, DocumentType>();
+        for (const s of schemas) {
+            docTypeBySchema.set(s.id, classifyDocumentType(s.name, s.id, titlesBySchema.get(s.id) ?? []));
+        }
+
         const fieldDescriptors = this.fieldDescriptors();
         const { fieldMap } = await this.base.executePipeline(schemas, fieldDescriptors);
         const projectMeta = derivePerPolicyProjectMeta(fieldMap, schemas);
         if (projectMeta) schemaTypes.set(projectMeta.projectSchemaId, 'project');
 
         const policyMapping: PolicyMapping = {};
-        this.attachSchemaMappings(policyMapping, fieldMap, schemas, schemaTypes, projectMeta?.projectSchemaId);
+        this.attachSchemaMappings(policyMapping, fieldMap, schemas, schemaTypes, projectMeta?.projectSchemaId, docTypeBySchema);
         this.attachPolicyJsonMappings(policyMapping, input.rawPolicyJson);
 
         return { policyMapping, schemaFields };
@@ -126,6 +140,7 @@ export class PolicyMappingPipelineService {
         schemas: SchemaInfo[],
         schemaTypes: Map<string, PolicyMappingSchemaType>,
         projectSchemaId: string | undefined,
+        docTypeBySchema: Map<string, DocumentType>,
     ): void {
         const schemaById = new Map(schemas.map(s => [s.id, s] as const));
         // Longest-first so e.g. "#uuid&1.0.0" matches before "#uuid&1".
@@ -147,6 +162,7 @@ export class PolicyMappingPipelineService {
                     schemaType: schemaTypes.get(schemaIri) ?? 'other',
                     fieldPath,
                     isProjectSchema: schemaIri === projectSchemaId,
+                    docType: docTypeBySchema.get(schemaIri) ?? 'unknown',
                     title: field.label,
                     description: '',
                 };

--- a/sustainable-explorer/src/worker/mapping/policy-pipeline.types.ts
+++ b/sustainable-explorer/src/worker/mapping/policy-pipeline.types.ts
@@ -24,6 +24,7 @@ export interface PolicyMappingEntry {
     schemaType?: PolicyMappingSchemaType;
     fieldPath?: string;          // path within the schema document, dot-separated
     isProjectSchema?: boolean;   // priority hint, not a filter
+    docType?: string;            // coarse Guardian document type (see DocumentType)
 
     // when source = 'policyJson'
     policyJsonPath?: string;

--- a/sustainable-explorer/src/worker/processors/business-view-builder.processor.ts
+++ b/sustainable-explorer/src/worker/processors/business-view-builder.processor.ts
@@ -83,7 +83,7 @@ export class BusinessViewBuilderProcessor extends WorkerHost {
                 jsonb_build_object(
                     'description', m.options->>'description',
                     'status', m.status,
-                    'topicId', m."topicId",
+                    'topicId', COALESCE(NULLIF(m.options->>'topicId', ''), m."topicId"),
                     'tokenId', COALESCE(m.options->>'tokenId', tc."tokenId"),
                     'owner', m.owner,
                     'options', m.options,

--- a/sustainable-explorer/src/worker/processors/message-process.processor.ts
+++ b/sustainable-explorer/src/worker/processors/message-process.processor.ts
@@ -223,6 +223,10 @@ export class MessageProcessProcessor extends WorkerHost {
                 );
                 continue;
             }
+            // No priority: prioritized jobs are starved here because the
+            // continuous topic re-poll stream keeps the `wait` list non-empty,
+            // so the worker never drains the `prioritized` set. Enqueueing
+            // discovery on the same `wait` FIFO guarantees it is processed.
             await this.topicQueue.add(
                 'sync',
                 {
@@ -232,7 +236,6 @@ export class MessageProcessProcessor extends WorkerHost {
                 },
                 {
                     jobId: `topic-${topic.topicId}-0`,
-                    priority: topic.isOrgTopic ? 1 : 10,
                 },
             );
         }

--- a/sustainable-explorer/src/worker/processors/topic-sync.processor.ts
+++ b/sustainable-explorer/src/worker/processors/topic-sync.processor.ts
@@ -56,6 +56,10 @@ export class TopicSyncProcessor extends WorkerHost {
             }, {
                 jobId: `topic-${topicId}-poll-${Date.now()}`,
                 delay,
+                // Each poll is a uniquely-named keep-alive job; without these the
+                // completed/failed sets grow unbounded and eventually OOM Redict.
+                removeOnComplete: true,
+                removeOnFail: 1000,
             });
             this.logger.debug(`No new messages for topic ${topicId}, re-polling in ${delay}ms`);
             return;
@@ -79,6 +83,10 @@ export class TopicSyncProcessor extends WorkerHost {
                 opts: {
                     priority: isOrgTopic ? 1 : 10,
                     jobId: `msg-${msg.consensus_timestamp}`,
+                    // Trim on finish — message data lives in Postgres, so retained
+                    // completed/failed job hashes are pure Redict bloat.
+                    removeOnComplete: true,
+                    removeOnFail: 1000,
                 },
             })),
         );
@@ -108,6 +116,10 @@ export class TopicSyncProcessor extends WorkerHost {
         }, {
             jobId: `topic-${topicId}-${maxSequence}-${Date.now()}`,
             delay: nextDelay,
+            // Uniquely-named per page/watermark — trim on finish so they don't
+            // accumulate in the completed/failed sets and exhaust Redict memory.
+            removeOnComplete: true,
+            removeOnFail: 1000,
         });
 
         this.logger.log(

--- a/sustainable-explorer/src/worker/project-mapper/document-type-classifier.ts
+++ b/sustainable-explorer/src/worker/project-mapper/document-type-classifier.ts
@@ -1,0 +1,47 @@
+import { DocumentType } from './types';
+
+/**
+ * Classifies a schema into a coarse Guardian document type by NAME (the reliable
+ * signal). `schemaId` and `fieldTitles` are weak secondary signals used ONLY to
+ * disambiguate pdd vs registration — never to trigger the
+ * validation/monitoring/verification categories, where a false positive would
+ * wrongly suppress field extraction downstream.
+ *
+ * Verification is checked BEFORE validation so a combined "Validation &
+ * Verification" report resolves to the non-suppressing 'verificationReport'.
+ */
+export function classifyDocumentType(
+    schemaName: string | undefined | null,
+    schemaId: string | undefined | null,
+    fieldTitles: string[] = [],
+): DocumentType {
+    const name = (schemaName ?? '').toLowerCase();
+
+    if (name.includes('monitoring')) return 'monitoringReport';
+    if (name.includes('verification') || name.includes('verify')) return 'verificationReport';
+    if (name.includes('validation') || name.includes('validate')) return 'validationReport';
+    if (
+        name.includes('pdd') ||
+        name.includes('design document') ||
+        name.includes('project design') ||
+        name.includes('project description')
+    ) {
+        return 'pdd';
+    }
+    if (
+        name.includes('registration') ||
+        name.includes('registry request') ||
+        name.includes('information note') ||
+        name.includes('project information')
+    ) {
+        return 'registration';
+    }
+
+    // Name was generic — consult weak signals for the benign pdd/registration split only.
+    const id = (schemaId ?? '').toLowerCase();
+    if (id.includes('pdd')) return 'pdd';
+    const titles = fieldTitles.join(' ').toLowerCase();
+    if (titles.includes('design document') || titles.includes('project design')) return 'pdd';
+
+    return 'unknown';
+}

--- a/sustainable-explorer/src/worker/project-mapper/mint-project-linker.ts
+++ b/sustainable-explorer/src/worker/project-mapper/mint-project-linker.ts
@@ -2,13 +2,15 @@ import { Logger } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 
 /**
- * Resolves each unlinked MintToken VC to its specific project and upserts
- * the result into project_mint_link.
+ * Resolves each unlinked or stale-linked MintToken VC to its specific project
+ * and upserts the result into project_mint_link.
  *
  * Called from BusinessViewBuilderProcessor after registry/methodology/credit
- * views are built. The function is incremental — only unlinked mints are
- * processed on each run, so subsequent calls are near-free when no new
- * MintToken VCs have arrived.
+ * views are built. The function is incremental: it processes mints that have
+ * NO link at all, AND mints whose existing link's project_key no longer matches
+ * any PROJECT row in business_view (stale links that arise after a project is
+ * re-keyed during M1 re-processing). The ON CONFLICT DO UPDATE upsert repairs
+ * the stale row when the mint is successfully re-resolved.
  *
  * Resolution strategy:
  *   1. Walk options.relationships via recursive CTE (up to 15 hops) until an
@@ -21,6 +23,12 @@ import { DataSource } from 'typeorm';
  *      ref ("I am a report FOR this project"), making it a more semantically
  *      precise link than topic-scope. Only used when exactly one project is
  *      referenced to avoid misattribution in shared PoA topics.
+ *   1.75 Ref-root match: walk the relationship ancestors for the mint and
+ *      look for a PROJECT row whose projectKey equals an ancestor VC's own
+ *      cs.id OR its cs.ref. This decouples mint linking from linkedVcs
+ *      completeness — the relationship walk often reaches lifecycle VCs
+ *      whose cs.ref IS the project key even when those VCs are not yet in
+ *      linkedVcs.
  *   2. Topic-scope fallback: only when the instance topic contains exactly
  *      one project. Grouped topics without a resolved chain are skipped to
  *      avoid misattribution.
@@ -46,7 +54,10 @@ export async function buildMintProjectLinks(
         WHERE m.type = 'VC-Document'
           AND m.documents->'credentialSubject'->0->>'type' LIKE 'MintToken%'
           AND NOT EXISTS (
-              SELECT 1 FROM project_mint_link pml
+              SELECT 1
+              FROM project_mint_link pml
+              JOIN business_view bv
+                ON bv."projectKey" = pml.project_key AND bv."viewType" = 'PROJECT'
               WHERE pml.mint_consensus_timestamp = m."consensusTimestamp"
           )
         ORDER BY m."consensusTimestamp"
@@ -58,6 +69,7 @@ export async function buildMintProjectLinks(
 
     let linked = 0;
     let csRef = 0;
+    let refRoot = 0;
     let fallback = 0;
     let skipped = 0;
 
@@ -144,6 +156,52 @@ export async function buildMintProjectLinks(
                 linkMethod = 'cs_ref';
                 csRef++;
             } else {
+                // Step 1.75 — ref-root match: walk relationship ancestors for this mint
+                // and match a PROJECT row whose projectKey equals an ancestor VC's own
+                // cs.id OR its cs.ref. This decouples mint linking from linkedVcs
+                // completeness — the relationship walk often lands on lifecycle VCs
+                // whose cs.ref IS the project key even when those VCs are not (yet)
+                // in linkedVcs.
+                const refRootRows: Array<{ project_key: string; project_topic_id: string }> =
+                    await dataSource.query(`
+                        WITH RECURSIVE rel_chain(ts, depth) AS (
+                            SELECT
+                                jsonb_array_elements_text(m.options->'relationships')::varchar AS ts,
+                                1 AS depth
+                            FROM message m
+                            WHERE m."consensusTimestamp" = $1
+                              AND m.options->'relationships' IS NOT NULL
+                              AND jsonb_typeof(m.options->'relationships') = 'array'
+                              AND jsonb_array_length(m.options->'relationships') > 0
+
+                            UNION ALL
+
+                            SELECT
+                                jsonb_array_elements_text(p.options->'relationships')::varchar,
+                                rc.depth + 1
+                            FROM rel_chain rc
+                            JOIN message p ON p."consensusTimestamp" = rc.ts
+                            WHERE rc.depth < 15
+                              AND p.options->'relationships' IS NOT NULL
+                              AND p.options->'relationships' != 'null'::jsonb
+                              AND jsonb_typeof(p.options->'relationships') = 'array'
+                        )
+                        SELECT bv."projectKey" AS project_key, bv."relatedTopicId" AS project_topic_id
+                        FROM rel_chain rc
+                        JOIN message a ON a."consensusTimestamp" = rc.ts AND a.type = 'VC-Document'
+                        JOIN business_view bv ON bv."viewType" = 'PROJECT'
+                            AND (bv."projectKey" = a.documents->'credentialSubject'->0->>'id'
+                                 OR bv."projectKey" = a.documents->'credentialSubject'->0->>'ref')
+                        ORDER BY rc.depth ASC
+                        LIMIT 1
+                    `, [mint.consensusTimestamp]);
+
+                if (refRootRows.length > 0) {
+                    projectKey = refRootRows[0].project_key;
+                    projectTopicId = refRootRows[0].project_topic_id;
+                    linkMethod = 'ref_root';
+                    refRoot++;
+                } else {
                 // Step 2 — topic-scope fallback: safe only for unambiguous single-project topics.
                 const fallbackRows: Array<{ project_key: string; relatedTopicId: string }> =
                     await dataSource.query(`
@@ -168,7 +226,8 @@ export async function buildMintProjectLinks(
                 projectTopicId = fallbackRows[0].relatedTopicId;
                 linkMethod = 'topic_scope';
                 fallback++;
-            }
+                } // end else (Step 2)
+            } // end else (Step 1.75 miss)
         }
 
         // amount arrives as a JSONB string; parseFloat handles decimal values
@@ -197,6 +256,6 @@ export async function buildMintProjectLinks(
     }
 
     logger.log(
-        `MintProjectLinker: ${linked} via relationship, ${csRef} via cs.ref, ${fallback} via topic-scope, ${skipped} skipped`,
+        `MintProjectLinker: ${linked} via relationship, ${csRef} via cs.ref, ${refRoot} via ref-root, ${fallback} via topic-scope, ${skipped} skipped`,
     );
 }

--- a/sustainable-explorer/src/worker/project-mapper/mint-project-linker.ts
+++ b/sustainable-explorer/src/worker/project-mapper/mint-project-linker.ts
@@ -96,7 +96,9 @@ export async function buildMintProjectLinks(
                 bv."relatedTopicId" AS project_topic_id
             FROM rel_chain rc
             JOIN business_view bv
-                ON bv."sourceTimestamp" = rc.ts
+                ON (bv."sourceTimestamp" = rc.ts
+                    OR bv."businessData"->'linkedVcs' @>
+                       jsonb_build_array(jsonb_build_object('consensusTimestamp', rc.ts)))
                AND bv."viewType" = 'PROJECT'
             ORDER BY rc.depth ASC
             LIMIT 1
@@ -125,7 +127,10 @@ export async function buildMintProjectLinks(
                         bv."relatedTopicId" AS project_topic_id
                     FROM message m
                     JOIN business_view bv
-                        ON bv."projectKey" = m.documents->'credentialSubject'->0->>'ref'
+                        ON (bv."projectKey" = m.documents->'credentialSubject'->0->>'ref'
+                            OR bv."businessData"->'linkedVcs' @>
+                               jsonb_build_array(jsonb_build_object('csId',
+                                   m.documents->'credentialSubject'->0->>'ref')))
                        AND bv."viewType" = 'PROJECT'
                     WHERE m."topicId" = $1
                       AND m.type = 'VC-Document'

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/base-resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/base-resolver.ts
@@ -1,0 +1,325 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { PolicyMapping } from '../../mapping/policy-pipeline.types';
+import { TopicClassifierService } from '../topic-classifier';
+import { ResolutionContext, ResolutionOutcome } from './resolver.types';
+
+@Injectable()
+export abstract class BaseProjectKeyResolver {
+    protected abstract readonly method: string;
+
+    constructor(
+        protected readonly dataSource: DataSource,
+        protected readonly topicClassifier: TopicClassifierService,
+    ) {}
+
+    abstract resolve(ctx: ResolutionContext): Promise<ResolutionOutcome>;
+
+    // ---- outcome factory helpers (used by subclasses) ----
+    protected resolved(projectKey: string): ResolutionOutcome {
+        return { status: 'resolved', projectKey, method: this.method };
+    }
+    protected pass(): ResolutionOutcome {
+        return { status: 'pass' };
+    }
+    protected reject(reason: string): ResolutionOutcome {
+        return { status: 'reject', reason };
+    }
+
+    // ---- ported graph helpers + new helpers below ----
+
+    /**
+     * Follows `credentialSubject[0].ref` (a DID pointing to the project's
+     * identity VC) to find the canonical project key. Each hop: find the VC
+     * whose `cs.id` equals the current ref, take ITS `cs.id` as the new
+     * candidate, and if THAT VC also carries a ref, recurse. Stops at the
+     * first VC without a `ref` (the project root).
+     *
+     * Returns null when:
+     *   - The starting VC has no `ref` (caller falls back to the HCS walk),
+     *   - The ref points to a cs.id that hasn't been ingested yet (defer to
+     *     HCS walk so we still produce *some* projectKey).
+     *
+     * Loop guard via visited refs; capped at 8 hops.
+     */
+    protected async resolveViaRef(
+        startTs: string,
+        startCsId: string,
+    ): Promise<{ projectKey: string } | null> {
+        const startRow: Array<{ ref: string | null }> = await this.dataSource.query(
+            `SELECT documents->'credentialSubject'->0->>'ref' AS ref
+             FROM message
+             WHERE "consensusTimestamp" = $1
+             LIMIT 1`,
+            [startTs],
+        );
+        const startRef = startRow[0]?.ref;
+        if (!startRef || typeof startRef !== 'string') return null;
+        if (startRef === startCsId) return null;     // self-ref → no useful pointer
+
+        let currentRef = startRef;
+        const visited = new Set<string>([startCsId, currentRef]);
+
+        for (let i = 0; i < 8; i++) {
+            const targetRow: Array<{ cs_id: string | null; next_ref: string | null }> =
+                await this.dataSource.query(
+                    `SELECT documents->'credentialSubject'->0->>'id'  AS cs_id,
+                            documents->'credentialSubject'->0->>'ref' AS next_ref
+                     FROM message
+                     WHERE type = 'VC-Document'
+                       AND documents->'credentialSubject'->0->>'id' = $1
+                     ORDER BY "consensusTimestamp" ASC
+                     LIMIT 1`,
+                    [currentRef],
+                );
+            if (targetRow.length === 0 || !targetRow[0].cs_id) {
+                // Ref doesn't resolve to any ingested VC. Let the HCS walk
+                // produce a fallback projectKey rather than returning a
+                // dangling ref.
+                return null;
+            }
+            const { cs_id, next_ref } = targetRow[0];
+            if (!next_ref || typeof next_ref !== 'string' || visited.has(next_ref)) {
+                return { projectKey: cs_id };
+            }
+            visited.add(next_ref);
+            currentRef = next_ref;
+        }
+        return { projectKey: currentRef };
+    }
+
+    /**
+     * Walk `message.options.relationships` backwards from a VC to find the root
+     * cs.id-carrying VC in the chain. The root is treated as the project's
+     * identity, so monitoring / verification VCs merge into the project rather
+     * than creating phantom rows keyed by their own cs.id.
+     *
+     * Stops at the first ancestor that has no relationships (or no cs.id-
+     * carrying VC among its relationships). Up to 12 hops. Skips
+     * Role-Documents and other non-VC referenced messages.
+     */
+    protected async resolveViaRelationships(
+        startTs: string,
+        startCsId: string,
+    ): Promise<{ projectKey: string; walked: boolean; hadRelationships: boolean }> {
+        // Content-level link (preferred). Many Guardian VCs (monitoring,
+        // verification, etc.) carry `credentialSubject[0].ref` pointing to the
+        // project's identity DID. That's a deterministic intra-policy link
+        // independent of HCS message relationships, which can branch through
+        // registry-side artifacts and produce sibling cs.id winners on
+        // different walks of the same logical project.
+        const refResolved = await this.resolveViaRef(startTs, startCsId);
+        if (refResolved) {
+            return {
+                projectKey: refResolved.projectKey,
+                walked: refResolved.projectKey !== startCsId,
+                hadRelationships: true,
+            };
+        }
+
+        // If THIS VC's cs.id is the target of other VCs' `ref` fields, it is
+        // the canonical project root — other monitoring/verification VCs in
+        // the policy explicitly point to it as the project identity. Don't
+        // walk past it to an older sibling registration just because the HCS
+        // relationship graph has one (Guardian sometimes publishes multiple
+        // registration VCs with different DIDs for the same logical project).
+        if (await this.isCsIdReferencedByOtherVcs(startCsId, startTs)) {
+            return { projectKey: startCsId, walked: false, hadRelationships: false };
+        }
+
+        // Fall back to BFS the ancestor tree via `options.relationships`. We
+        // must walk THROUGH cs.id-less intermediate VCs (e.g. wrapper / system
+        // VCs in some Guardian policies) — they don't claim a project
+        // identity but their parents do. Stopping at the first cs.id-less hop
+        // misses the real Project Registration VC further up.
+        //
+        // The winner is the OLDEST cs.id-carrying VC found anywhere in the
+        // reachable tree (oldest == closest to chain root == Project VC).
+        let oldestTs = startTs;
+        let oldestCsId = startCsId;
+        let walked = false;
+        let hadRelationships = false;
+
+        const visited = new Set<string>([startTs]);
+        const queue: string[] = [startTs];
+        let hops = 0;
+
+        while (queue.length > 0 && hops < 24) {
+            const currentTs = queue.shift()!;
+            hops++;
+
+            const relsRow: Array<{ rels: string[] | null }> = await this.dataSource.query(
+                `SELECT
+                    CASE
+                        WHEN jsonb_typeof(options->'relationships') = 'array'
+                            THEN ARRAY(SELECT jsonb_array_elements_text(options->'relationships'))
+                        ELSE NULL
+                    END AS rels
+                 FROM message
+                 WHERE "consensusTimestamp" = $1
+                 LIMIT 1`,
+                [currentTs],
+            );
+            const rels = relsRow[0]?.rels ?? [];
+            if (currentTs === startTs) hadRelationships = rels.length > 0;
+            if (rels.length === 0) continue;
+
+            const fresh = rels.filter(r => !visited.has(r));
+            if (fresh.length === 0) continue;
+
+            // Fetch all VC-Document parents in this hop (with or without
+            // cs.id) so we can both record candidates AND continue walking
+            // through cs.id-less ones.
+            const parents: Array<{ consensusTimestamp: string; cs_id: string | null }> =
+                await this.dataSource.query(
+                    `SELECT "consensusTimestamp",
+                            documents->'credentialSubject'->0->>'id' AS cs_id
+                     FROM message
+                     WHERE "consensusTimestamp" = ANY($1::text[])
+                       AND type = 'VC-Document'
+                     ORDER BY "consensusTimestamp" ASC`,
+                    [fresh],
+                );
+
+            for (const p of parents) {
+                visited.add(p.consensusTimestamp);
+                queue.push(p.consensusTimestamp);
+                if (p.cs_id && p.consensusTimestamp < oldestTs) {
+                    oldestTs = p.consensusTimestamp;
+                    oldestCsId = p.cs_id;
+                    walked = true;
+                }
+            }
+        }
+
+        return { projectKey: oldestCsId, walked, hadRelationships };
+    }
+
+    /**
+     * Returns true when any OTHER VC's `credentialSubject[0].ref` equals the
+     * given csId. The presence of such a reference means downstream VCs
+     * explicitly treat this cs.id as the project's identity — we should not
+     * walk past it via HCS relationships to an older sibling.
+     */
+    protected async isCsIdReferencedByOtherVcs(
+        csId: string,
+        selfTs: string,
+    ): Promise<boolean> {
+        const row: Array<{ exists: boolean }> = await this.dataSource.query(
+            `SELECT 1 AS exists
+             FROM message
+             WHERE type = 'VC-Document'
+               AND documents->'credentialSubject'->0->>'ref' = $1
+               AND "consensusTimestamp" <> $2
+             LIMIT 1`,
+            [csId, selfTs],
+        );
+        return row.length > 0;
+    }
+
+    /**
+     * Check if a given cs.id belongs to a VC whose schema is classified as
+     * the project schema for its policy. Used to verify that a cs.ref chain
+     * resolves to an actual project VC, not an intermediate artifact.
+     */
+    protected async isCsIdOnProjectSchema(
+        csId: string,
+        policyMapping: PolicyMapping,
+    ): Promise<boolean> {
+        const projectSchemaUuids = this.projectSchemaUuids(policyMapping);
+        if (projectSchemaUuids.size === 0) return true;
+
+        const rows: Array<{ schema_type: string | null }> = await this.dataSource.query(
+            `SELECT documents->'credentialSubject'->0->>'type' AS schema_type
+             FROM message
+             WHERE type = 'VC-Document'
+               AND documents->'credentialSubject'->0->>'id' = $1
+             ORDER BY "consensusTimestamp" ASC
+             LIMIT 1`,
+            [csId],
+        );
+        if (rows.length === 0) return false;
+        const rawType = rows[0].schema_type ?? '';
+        const uuid = rawType.split('&')[0].trim().replace(/^#/, '');
+        return projectSchemaUuids.has(uuid);
+    }
+
+    // ---- new helpers ----
+
+    /**
+     * Collects all project-schema UUIDs from the policy mapping (synchronous).
+     */
+    protected projectSchemaUuids(policyMapping: PolicyMapping): Set<string> {
+        const uuids = new Set<string>();
+        for (const entries of Object.values(policyMapping)) {
+            if (!Array.isArray(entries)) continue;
+            for (const entry of entries) {
+                if (entry?.isProjectSchema === true && entry.schemaIri) {
+                    uuids.add(entry.schemaIri.split('&')[0].trim().replace(/^#/, ''));
+                }
+            }
+        }
+        return uuids;
+    }
+
+    /**
+     * Returns true when a PROJECT row keyed by projectKey already exists in
+     * business_view (used as a last-resort confirmation signal).
+     */
+    protected async isKnownProjectRow(projectKey: string): Promise<boolean> {
+        const rows: unknown[] = await this.dataSource.query(
+            `SELECT 1 FROM business_view
+             WHERE "viewType" = 'PROJECT' AND "projectKey" = $1
+             LIMIT 1`,
+            [projectKey],
+        );
+        return rows.length > 0;
+    }
+
+    /**
+     * Independently verifies a candidate ancestor cs.id and returns the
+     * CONFIRMED projectKey, or null.
+     *
+     * Order of checks:
+     *   1. Classify the topic that hosts the earliest VC for this csId.
+     *      dynamic-project → return the topic-id (topic-keyed).
+     *   2. If the VC's schema UUID is in the policy's project-schema set →
+     *      return csId (project-schema → cs.id-keyed).
+     *   3. If a PROJECT business_view row already exists for csId →
+     *      return csId (known row → cs.id-keyed).
+     *   4. Otherwise null.
+     */
+    protected async confirmProjectKey(
+        csId: string,
+        policyMapping: PolicyMapping,
+    ): Promise<string | null> {
+        const rows: Array<{ topic_id: string | null; schema_type: string | null }> =
+            await this.dataSource.query(
+                `SELECT "topicId" AS topic_id,
+                        documents->'credentialSubject'->0->>'type' AS schema_type
+                 FROM message
+                 WHERE type = 'VC-Document'
+                   AND documents->'credentialSubject'->0->>'id' = $1
+                 ORDER BY "consensusTimestamp" ASC
+                 LIMIT 1`,
+                [csId],
+            );
+
+        if (rows.length > 0 && rows[0].topic_id) {
+            const cls = await this.topicClassifier.classifyTopic(this.dataSource, rows[0].topic_id);
+            if (cls.kind === 'dynamic-project') {
+                return rows[0].topic_id;
+            }
+            const uuid = (rows[0].schema_type ?? '').split('&')[0].trim().replace(/^#/, '');
+            if (this.projectSchemaUuids(policyMapping).has(uuid)) {
+                return csId;
+            }
+        }
+
+        if (await this.isKnownProjectRow(csId)) {
+            return csId;
+        }
+
+        return null;
+    }
+}

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/base-resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/base-resolver.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { PolicyMapping } from '../../mapping/policy-pipeline.types';
 import { TopicClassifierService } from '../topic-classifier';
-import { ResolutionContext, ResolutionOutcome } from './resolver.types';
+import { ResolutionContext, ResolutionOutcome, ResolutionMetadata } from './resolver.types';
 
 @Injectable()
 export abstract class BaseProjectKeyResolver {
@@ -16,14 +16,69 @@ export abstract class BaseProjectKeyResolver {
     abstract resolve(ctx: ResolutionContext): Promise<ResolutionOutcome>;
 
     // ---- outcome factory helpers (used by subclasses) ----
-    protected resolved(projectKey: string): ResolutionOutcome {
-        return { status: 'resolved', projectKey, method: this.method };
+    protected resolved(projectKey: string, metadata: ResolutionMetadata = {}): ResolutionOutcome {
+        return { status: 'resolved', projectKey, method: this.method, metadata };
     }
     protected pass(): ResolutionOutcome {
         return { status: 'pass' };
     }
     protected reject(reason: string): ResolutionOutcome {
         return { status: 'reject', reason };
+    }
+
+    /**
+     * Earliest (chain-root) consensus timestamp of the VC carrying a given cs.id.
+     * Recorded as metadata.rootVcTimestamp so a cs.id key is traceable to the
+     * transaction that anchors it. Returns '' when the cs.id has no ingested VC.
+     */
+    protected async earliestTimestampForCsId(csId: string): Promise<string> {
+        const rows: Array<{ ts: string }> = await this.dataSource.query(
+            `SELECT "consensusTimestamp" AS ts
+             FROM message
+             WHERE type = 'VC-Document'
+               AND documents->'credentialSubject'->0->>'id' = $1
+             ORDER BY "consensusTimestamp" ASC
+             LIMIT 1`,
+            [csId],
+        );
+        return rows[0]?.ts ?? '';
+    }
+
+    /**
+     * Canonical cs.id for a (per-project) dynamic topic: the EARLIEST
+     * project-schema VC's cs.id in the topic, so every VC in the topic resolves
+     * to one stable key. Falls back to the earliest cs.id-carrying VC in the
+     * topic, then to null. Used by M1 so dynamic-topic projects are keyed by a
+     * cs.id (with the topic recorded in metadata) — not by the topic id.
+     */
+    protected async canonicalCsIdInTopic(topicId: string, policyMapping: PolicyMapping): Promise<string | null> {
+        const uuids = [...this.projectSchemaUuids(policyMapping)];
+        if (uuids.length > 0) {
+            const rows: Array<{ cs_id: string | null }> = await this.dataSource.query(
+                `SELECT documents->'credentialSubject'->0->>'id' AS cs_id
+                 FROM message
+                 WHERE type = 'VC-Document'
+                   AND "topicId" = $1
+                   AND documents IS NOT NULL
+                   AND documents->'credentialSubject'->0->>'id' IS NOT NULL
+                   AND regexp_replace(split_part(documents->'credentialSubject'->0->>'type','&',1),'^#','') = ANY($2::text[])
+                 ORDER BY "consensusTimestamp" ASC
+                 LIMIT 1`,
+                [topicId, uuids],
+            );
+            if (rows[0]?.cs_id) return rows[0].cs_id;
+        }
+        const any: Array<{ cs_id: string | null }> = await this.dataSource.query(
+            `SELECT documents->'credentialSubject'->0->>'id' AS cs_id
+             FROM message
+             WHERE type = 'VC-Document'
+               AND "topicId" = $1
+               AND documents->'credentialSubject'->0->>'id' IS NOT NULL
+             ORDER BY "consensusTimestamp" ASC
+             LIMIT 1`,
+            [topicId],
+        );
+        return any[0]?.cs_id ?? null;
     }
 
     // ---- ported graph helpers + new helpers below ----

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/circuit-breaker.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/circuit-breaker.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-strategy circuit breaker. State is implicit in `openedAt`:
+ *   - null              → CLOSED (or a HALF-OPEN probe is in flight after cooldown)
+ *   - non-null, elapsed < cooldownMs → OPEN: short-circuit to fallback
+ *   - non-null, elapsed >= cooldownMs → HALF-OPEN: allow one probe
+ *
+ * `openedAt` uses null (never 0) as the CLOSED sentinel because Date.now() can
+ * legitimately return 0 in tests, making 0 indistinguishable from "never opened".
+ */
+
+export interface CircuitBreakerLogger {
+    log(message: string): void;
+    warn(message: string): void;
+}
+
+export class CircuitBreaker {
+    private consecutiveFailures = 0;
+    // CLOSED sentinel MUST be null, never 0: Date.now() can legitimately be 0
+    // (mocked in tests), and 0 would be indistinguishable from "never opened".
+    private openedAt: number | null = null;
+
+    constructor(
+        private readonly name: string,
+        private readonly threshold: number,
+        private readonly cooldownMs: number,
+        private readonly logger?: CircuitBreakerLogger,
+    ) {}
+
+    async run<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
+        // OPEN within cooldown → short-circuit to fallback WITHOUT calling fn.
+        if (this.openedAt !== null) {
+            const elapsed = Date.now() - this.openedAt;
+            if (elapsed < this.cooldownMs) {
+                return fallback;
+            }
+            // cooldown elapsed → allow one HALF-OPEN probe (log it)
+            this.logger?.log(`circuit[${this.name}] HALF-OPEN: probing after cooldown`);
+        }
+
+        try {
+            const result = await fn();
+            // Success while a probe was in flight closes the breaker (log it).
+            if (this.openedAt !== null) {
+                this.logger?.log(`circuit[${this.name}] CLOSED: probe succeeded`);
+            }
+            this.consecutiveFailures = 0;
+            this.openedAt = null;
+            return result;
+        } catch (err) {
+            this.consecutiveFailures++;
+            this.logger?.warn(
+                `circuit[${this.name}] failure ${this.consecutiveFailures}/${this.threshold}: ${String(err)}`,
+            );
+            if (this.consecutiveFailures >= this.threshold) {
+                this.openedAt = Date.now();
+                this.logger?.warn(`circuit[${this.name}] OPEN for ${this.cooldownMs}ms`);
+            }
+            // A thrown strategy is absorbed as a no-op: return fallback, never rethrow.
+            return fallback;
+        }
+    }
+}

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/cs-ref.resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/cs-ref.resolver.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { TopicClassifierService } from '../topic-classifier';
+import { BaseProjectKeyResolver } from './base-resolver';
+import { ResolutionContext, ResolutionOutcome } from './resolver.types';
+
+@Injectable()
+export class CsRefResolver extends BaseProjectKeyResolver {
+    protected readonly method = 'csRef';
+
+    constructor(dataSource: DataSource, topicClassifier: TopicClassifierService) {
+        super(dataSource, topicClassifier);
+    }
+
+    async resolve(ctx: ResolutionContext): Promise<ResolutionOutcome> {
+        if (!ctx.csRef) return this.pass();
+        const refWalked = await this.resolveViaRef(ctx.consensusTimestamp, ctx.csId);
+        const resolvedKey = refWalked?.projectKey ?? ctx.csRef;
+        // Classified policy + this VC isn't itself the project schema → the chain
+        // terminus must land on a project-schema VC, else this references an
+        // intermediate artifact and must not seed a project.
+        if (ctx.policyHasProjectSchemaClassification && !ctx.isProjectSchemaVc) {
+            const onProjectSchema = await this.isCsIdOnProjectSchema(resolvedKey, ctx.policyMapping);
+            if (!onProjectSchema) {
+                return this.reject('cs.ref resolves to non-project-schema VC');
+            }
+        }
+        return this.resolved(resolvedKey);
+    }
+}

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/cs-ref.resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/cs-ref.resolver.ts
@@ -17,14 +17,23 @@ export class CsRefResolver extends BaseProjectKeyResolver {
         const refWalked = await this.resolveViaRef(ctx.consensusTimestamp, ctx.csId);
         const resolvedKey = refWalked?.projectKey ?? ctx.csRef;
         // Classified policy + this VC isn't itself the project schema → the chain
-        // terminus must land on a project-schema VC, else this references an
-        // intermediate artifact and must not seed a project.
+        // terminus must land on a project-schema VC OR an already-known PROJECT row.
+        // Roots that already key a PROJECT row are accepted even when their schema
+        // isn't the designated project schema — Guardian policies often anchor the
+        // chain on a registration doc (ELV case); requiring the project schema
+        // force-dropped the whole lifecycle.
+        //
+        // Order-dependence note: the PROJECT row must exist before this resolver
+        // is reached. Resolution passes are iterative, so on the first pass the
+        // row may not exist yet and the mint will be deferred; on a later pass
+        // (after the project view is built) this branch succeeds.
         if (ctx.policyHasProjectSchemaClassification && !ctx.isProjectSchemaVc) {
             const onProjectSchema = await this.isCsIdOnProjectSchema(resolvedKey, ctx.policyMapping);
-            if (!onProjectSchema) {
-                return this.reject('cs.ref resolves to non-project-schema VC');
+            if (!onProjectSchema && !(await this.isKnownProjectRow(resolvedKey))) {
+                return this.reject('cs.ref resolves to non-project-schema VC with no known project row');
             }
         }
-        return this.resolved(resolvedKey);
+        const rootVcTimestamp = await this.earliestTimestampForCsId(resolvedKey);
+        return this.resolved(resolvedKey, { rootVcTimestamp });
     }
 }

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/dynamic-topic.resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/dynamic-topic.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { TopicClassifierService } from '../topic-classifier';
+import { BaseProjectKeyResolver } from './base-resolver';
+import { ResolutionContext, ResolutionOutcome } from './resolver.types';
+
+// NO over-merge guard is intentional — one Guardian dynamic topic == one
+// project; collapsing all VCs on it into one key is the whole point.
+@Injectable()
+export class DynamicTopicResolver extends BaseProjectKeyResolver {
+    protected readonly method = 'topic';
+
+    constructor(dataSource: DataSource, topicClassifier: TopicClassifierService) {
+        super(dataSource, topicClassifier);
+    }
+
+    async resolve(ctx: ResolutionContext): Promise<ResolutionOutcome> {
+        const classification = await this.topicClassifier.classifyTopic(this.dataSource, ctx.topicId);
+        if (classification.kind !== 'dynamic-project') return this.pass();
+        return this.resolved(ctx.topicId);
+    }
+}

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/dynamic-topic.resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/dynamic-topic.resolver.ts
@@ -17,6 +17,10 @@ export class DynamicTopicResolver extends BaseProjectKeyResolver {
     async resolve(ctx: ResolutionContext): Promise<ResolutionOutcome> {
         const classification = await this.topicClassifier.classifyTopic(this.dataSource, ctx.topicId);
         if (classification.kind !== 'dynamic-project') return this.pass();
-        return this.resolved(ctx.topicId);
+        // Key by the topic's canonical project cs.id (uniform cs.id keys across
+        // all methods); record the dynamic topic in metadata. Every VC in the
+        // topic resolves to the same canonical cs.id, so they still merge.
+        const csId = (await this.canonicalCsIdInTopic(ctx.topicId, ctx.policyMapping)) ?? ctx.csId;
+        return this.resolved(csId, { dynamicTopicId: ctx.topicId });
     }
 }

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/project-schema.resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/project-schema.resolver.ts
@@ -13,7 +13,10 @@ export class ProjectSchemaResolver extends BaseProjectKeyResolver {
     }
 
     async resolve(ctx: ResolutionContext): Promise<ResolutionOutcome> {
-        if (ctx.isProjectSchemaVc) return this.resolved(ctx.csId);
+        if (ctx.isProjectSchemaVc) {
+            const rootVcTimestamp = await this.earliestTimestampForCsId(ctx.csId);
+            return this.resolved(ctx.csId, { rootVcTimestamp });
+        }
         if (ctx.policyHasProjectSchemaClassification) {
             return this.reject('not the project schema, no cs.ref/ancestor');
         }

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/project-schema.resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/project-schema.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { TopicClassifierService } from '../topic-classifier';
+import { BaseProjectKeyResolver } from './base-resolver';
+import { ResolutionContext, ResolutionOutcome } from './resolver.types';
+
+@Injectable()
+export class ProjectSchemaResolver extends BaseProjectKeyResolver {
+    protected readonly method = 'projectSchema';
+
+    constructor(dataSource: DataSource, topicClassifier: TopicClassifierService) {
+        super(dataSource, topicClassifier);
+    }
+
+    async resolve(ctx: ResolutionContext): Promise<ResolutionOutcome> {
+        if (ctx.isProjectSchemaVc) return this.resolved(ctx.csId);
+        if (ctx.policyHasProjectSchemaClassification) {
+            return this.reject('not the project schema, no cs.ref/ancestor');
+        }
+        return this.pass();
+    }
+}

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/relationships.resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/relationships.resolver.ts
@@ -22,6 +22,7 @@ export class RelationshipsResolver extends BaseProjectKeyResolver {
         // an ungated relationships walk can mis-key (e.g. VVB chains).
         const confirmed = await this.confirmProjectKey(walked.projectKey, ctx.policyMapping);
         if (!confirmed) return this.pass();
-        return this.resolved(confirmed);
+        const rootVcTimestamp = await this.earliestTimestampForCsId(confirmed);
+        return this.resolved(confirmed, { rootVcTimestamp });
     }
 }

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/relationships.resolver.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/relationships.resolver.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { TopicClassifierService } from '../topic-classifier';
+import { BaseProjectKeyResolver } from './base-resolver';
+import { ResolutionContext, ResolutionOutcome } from './resolver.types';
+
+@Injectable()
+export class RelationshipsResolver extends BaseProjectKeyResolver {
+    protected readonly method = 'relationships';
+
+    constructor(dataSource: DataSource, topicClassifier: TopicClassifierService) {
+        super(dataSource, topicClassifier);
+    }
+
+    async resolve(ctx: ResolutionContext): Promise<ResolutionOutcome> {
+        // Project-schema VCs ARE the root; M4 keys them by their own cs.id.
+        if (ctx.isProjectSchemaVc) return this.pass();
+        const walked = await this.resolveViaRelationships(ctx.consensusTimestamp, ctx.csId);
+        if (!walked.walked) return this.pass();
+        // Gate: only accept when confirmProjectKey independently verifies the
+        // ancestor. If unconfirmed, PASS (do NOT reject) so M4 can decide —
+        // an ungated relationships walk can mis-key (e.g. VVB chains).
+        const confirmed = await this.confirmProjectKey(walked.projectKey, ctx.policyMapping);
+        if (!confirmed) return this.pass();
+        return this.resolved(confirmed);
+    }
+}

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/resolver-chain.service.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/resolver-chain.service.ts
@@ -46,7 +46,7 @@ export class ProjectKeyResolverChain {
         for (const { name, resolver, breaker } of this.chain) {
             const outcome = await breaker.run(() => resolver.resolve(ctx), PASS);
             if (outcome.status === 'resolved') {
-                return { projectKey: outcome.projectKey, method: outcome.method };
+                return { projectKey: outcome.projectKey, method: outcome.method, metadata: outcome.metadata };
             }
             if (outcome.status === 'reject') {
                 this.logger.debug(`${name} rejected projectKey for ts=${ctx.consensusTimestamp}: ${outcome.reason}`);

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/resolver-chain.service.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/resolver-chain.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CircuitBreaker } from './circuit-breaker';
+import { BaseProjectKeyResolver } from './base-resolver';
+import { DynamicTopicResolver } from './dynamic-topic.resolver';
+import { CsRefResolver } from './cs-ref.resolver';
+import { RelationshipsResolver } from './relationships.resolver';
+import { ProjectSchemaResolver } from './project-schema.resolver';
+import { ResolutionContext, ResolutionOutcome, ResolvedProjectKey } from './resolver.types';
+
+@Injectable()
+export class ProjectKeyResolverChain {
+    private readonly logger = new Logger(ProjectKeyResolverChain.name);
+    private readonly chain: ReadonlyArray<{
+        name: string;
+        resolver: BaseProjectKeyResolver;
+        breaker: CircuitBreaker;
+    }>;
+
+    constructor(
+        m1: DynamicTopicResolver,
+        m2: CsRefResolver,
+        m3: RelationshipsResolver,
+        m4: ProjectSchemaResolver,
+    ) {
+        const make = (name: string, resolver: BaseProjectKeyResolver) => ({
+            name,
+            resolver,
+            breaker: new CircuitBreaker(name, 5, 30_000, this.logger),
+        });
+        this.chain = [
+            make('M1:topic', m1),
+            make('M2:csRef', m2),
+            make('M3:relationships', m3),
+            make('M4:projectSchema', m4),
+        ];
+    }
+
+    /**
+     * Runs the resolver chain M1→M4. First 'resolved' wins (short-circuit).
+     * A 'reject' short-circuits to null (VC is skipped). A strategy that throws
+     * is absorbed by its breaker as a 'pass' (the breaker logs the error), and the
+     * chain continues. All-pass → null.
+     */
+    async resolve(ctx: ResolutionContext): Promise<ResolvedProjectKey | null> {
+        const PASS: ResolutionOutcome = { status: 'pass' };
+        for (const { name, resolver, breaker } of this.chain) {
+            const outcome = await breaker.run(() => resolver.resolve(ctx), PASS);
+            if (outcome.status === 'resolved') {
+                return { projectKey: outcome.projectKey, method: outcome.method };
+            }
+            if (outcome.status === 'reject') {
+                this.logger.debug(`${name} rejected projectKey for ts=${ctx.consensusTimestamp}: ${outcome.reason}`);
+                return null;
+            }
+            // 'pass' → try next strategy
+        }
+        return null;
+    }
+}

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/resolver.types.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/resolver.types.ts
@@ -10,12 +10,23 @@ export interface ResolutionContext {
     policyMapping: PolicyMapping;
 }
 
+/**
+ * Per-method resolution anchor, persisted to businessData.metadata so the chain
+ * is traceable: M1 records the dynamic topic it merged on; M2/M3/M4 record the
+ * root VC's consensus timestamp that the cs.id key was derived from.
+ */
+export interface ResolutionMetadata {
+    dynamicTopicId?: string;
+    rootVcTimestamp?: string;
+}
+
 export type ResolutionOutcome =
-    | { status: 'resolved'; projectKey: string; method: string }
+    | { status: 'resolved'; projectKey: string; method: string; metadata: ResolutionMetadata }
     | { status: 'pass' }
     | { status: 'reject'; reason: string };
 
 export interface ResolvedProjectKey {
     projectKey: string;
     method: string;         // logged to debug output for observability
+    metadata: ResolutionMetadata;
 }

--- a/sustainable-explorer/src/worker/project-mapper/resolvers/resolver.types.ts
+++ b/sustainable-explorer/src/worker/project-mapper/resolvers/resolver.types.ts
@@ -1,0 +1,21 @@
+import { PolicyMapping } from '../../mapping/policy-pipeline.types';
+
+export interface ResolutionContext {
+    consensusTimestamp: string;
+    topicId: string;
+    csId: string;           // credentialSubject[0].id — always present (callers guard)
+    csRef: string;          // credentialSubject[0].ref, trimmed, '' when absent
+    isProjectSchemaVc: boolean;
+    policyHasProjectSchemaClassification: boolean;
+    policyMapping: PolicyMapping;
+}
+
+export type ResolutionOutcome =
+    | { status: 'resolved'; projectKey: string; method: string }
+    | { status: 'pass' }
+    | { status: 'reject'; reason: string };
+
+export interface ResolvedProjectKey {
+    projectKey: string;
+    method: string;         // logged to debug output for observability
+}

--- a/sustainable-explorer/src/worker/project-mapper/topic-classifier.ts
+++ b/sustainable-explorer/src/worker/project-mapper/topic-classifier.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+export type TopicKind = 'dynamic-project' | 'instance' | 'other';
+
+export interface TopicClassification {
+    kind: TopicKind;
+    name: string | null;
+    instancePolicyTopicId: string | null;
+}
+
+@Injectable()
+export class TopicClassifierService {
+    // in-process cache keyed by topicId. Only DEFINITIVE results are cached
+    // (kind !== 'other' || instancePolicyTopicId !== null), because an 'other'
+    // result with a null instancePolicyTopicId can be a TEMPORARY miss caused by
+    // ingest ordering (the parent Topic / Instance-Policy message not synced yet).
+    private readonly cache = new Map<string, TopicClassification>();
+
+    async classifyTopic(dataSource: DataSource, topicId: string): Promise<TopicClassification> {
+        if (this.cache.has(topicId)) {
+            return this.cache.get(topicId)!;
+        }
+
+        // Step 2 — instance check first
+        if (await this.isInstanceTopic(dataSource, topicId)) {
+            const result: TopicClassification = { kind: 'instance', name: null, instancePolicyTopicId: topicId };
+            this.cacheIfDefinitive(topicId, result);
+            return result;
+        }
+
+        // Step 3 — load this topic's own Topic message
+        const rows: Array<{ parent_id: string | null; name: string | null }> = await dataSource.query(
+            `SELECT options->>'parentId' AS parent_id, options->>'name' AS name
+             FROM message
+             WHERE type = 'Topic' AND "topicId" = $1 AND options->>'parentId' IS NOT NULL
+             ORDER BY "consensusTimestamp" ASC
+             LIMIT 1`,
+            [topicId],
+        );
+
+        const parentId = rows.length > 0 ? rows[0].parent_id : null;
+        const name = rows.length > 0 ? rows[0].name : null;
+
+        // Step 4 — dynamic-project check
+        if (parentId !== null && name !== null && /project/i.test(name)) {
+            const instanceAncestor = await this.findAncestorInstanceTopic(dataSource, parentId);
+            if (instanceAncestor !== null) {
+                const result: TopicClassification = {
+                    kind: 'dynamic-project',
+                    name,
+                    instancePolicyTopicId: instanceAncestor,
+                };
+                this.cacheIfDefinitive(topicId, result);
+                return result;
+            }
+        }
+
+        // Step 5 — default: other (not cached when instancePolicyTopicId is null)
+        const result: TopicClassification = { kind: 'other', name, instancePolicyTopicId: null };
+        this.cacheIfDefinitive(topicId, result);
+        return result;
+    }
+
+    private async isInstanceTopic(dataSource: DataSource, topicId: string): Promise<boolean> {
+        const rows: unknown[] = await dataSource.query(
+            `SELECT 1 FROM message
+             WHERE type = 'Instance-Policy' AND options->>'instanceTopicId' = $1
+             LIMIT 1`,
+            [topicId],
+        );
+        return rows.length > 0;
+    }
+
+    // Checks startTopicId itself first, then walks up via Topic.options->>'parentId'.
+    // Bounded to 12 hops with a visited-set loop guard.
+    private async findAncestorInstanceTopic(dataSource: DataSource, startTopicId: string): Promise<string | null> {
+        const visited = new Set<string>();
+        let current: string = startTopicId;
+        let hops = 0;
+
+        while (hops < 12) {
+            if (visited.has(current)) break;
+            visited.add(current);
+
+            if (await this.isInstanceTopic(dataSource, current)) {
+                return current;
+            }
+
+            // Walk one level up
+            const rows: Array<{ parent_id: string | null }> = await dataSource.query(
+                `SELECT options->>'parentId' AS parent_id
+                 FROM message
+                 WHERE type = 'Topic' AND "topicId" = $1
+                 LIMIT 1`,
+                [current],
+            );
+
+            const nextParent = rows.length > 0 ? rows[0].parent_id : null;
+            if (nextParent === null) break;
+
+            current = nextParent;
+            hops++;
+        }
+
+        return null;
+    }
+
+    private cacheIfDefinitive(topicId: string, classification: TopicClassification): void {
+        if (classification.kind !== 'other' || classification.instancePolicyTopicId !== null) {
+            this.cache.set(topicId, classification);
+        }
+    }
+}

--- a/sustainable-explorer/src/worker/project-mapper/types.ts
+++ b/sustainable-explorer/src/worker/project-mapper/types.ts
@@ -70,3 +70,11 @@ export type ProjectRecord = {
     vcCount: number;
     projectSchemaUuids: string[];
 };
+
+export type DocumentType =
+    | 'pdd'
+    | 'monitoringReport'
+    | 'validationReport'
+    | 'verificationReport'
+    | 'registration'
+    | 'unknown';

--- a/sustainable-explorer/src/worker/schedulers/sync-scheduler.service.ts
+++ b/sustainable-explorer/src/worker/schedulers/sync-scheduler.service.ts
@@ -57,6 +57,7 @@ export class SyncSchedulerService implements OnModuleInit, OnModuleDestroy {
         await this.scheduleTopicSyncs();
         await this.scheduleTokenSyncs();
         await this.schedulePolicyDecodeJobs();
+        await this.rescheduleOrphanedTopics();
 
         // Backfill IPFS fetches for VCs whose parent policy is now decoded but whose
         // fetch was skipped (they arrived before their policy was decoded).
@@ -261,7 +262,7 @@ export class SyncSchedulerService implements OnModuleInit, OnModuleDestroy {
             cid: string;
         }> = await this.dataSource.query(`
                 SELECT
-                    m."topicId"                                  AS policy_topic_id,
+                    COALESCE(NULLIF(m.options->>'topicId', ''), m."topicId") AS policy_topic_id,
                     COALESCE(m.options->>'instanceTopicId', '')  AS instance_topic_id,
                     m."consensusTimestamp"                       AS consensus_timestamp,
                     f.cid
@@ -273,7 +274,7 @@ export class SyncSchedulerService implements OnModuleInit, OnModuleDestroy {
                   AND array_length(m.files, 1) > 0
                   AND NOT EXISTS (
                       SELECT 1 FROM policy p
-                      WHERE p."policyTopicId" = m."topicId"
+                      WHERE p."policyTopicId" = COALESCE(NULLIF(m.options->>'topicId', ''), m."topicId")
                         AND COALESCE(p."instanceTopicId", '') =
                             COALESCE(m.options->>'instanceTopicId', '')
                         AND p."decodeStatus" = 'decoded'
@@ -295,6 +296,55 @@ export class SyncSchedulerService implements OnModuleInit, OnModuleDestroy {
         }
 
         this.logger.log(`Enqueued ${rows.length} missing policy decode job(s)`);
+    }
+
+    /**
+     * Boot-time rescue for orphaned topics: topic IDs that other messages
+     * reference (Topic.options.childId or Instance-Policy.options.instanceTopicId)
+     * but which never made it into topic_cache — typically because their
+     * topic-sync job failed and left the whole subtree unreachable. Re-enqueue a
+     * fresh topic-sync (from watermark 0) for each, removing any stale job first.
+     */
+    private async rescheduleOrphanedTopics(): Promise<void> {
+        const rows: Array<{ topic_id: string }> = await this.dataSource.query(`
+            SELECT DISTINCT refs.topic_id
+            FROM (
+                SELECT m.options->>'childId' AS topic_id
+                FROM message m
+                WHERE m.type = 'Topic'
+                  AND m.options->>'childId' IS NOT NULL
+                UNION
+                SELECT m.options->>'instanceTopicId' AS topic_id
+                FROM message m
+                WHERE m.type = 'Instance-Policy'
+                  AND m.options->>'instanceTopicId' IS NOT NULL
+            ) refs
+            WHERE refs.topic_id IS NOT NULL
+              AND refs.topic_id <> ''
+              AND NOT EXISTS (
+                  SELECT 1 FROM topic_cache tc WHERE tc."topicId" = refs.topic_id
+              )
+        `);
+
+        let enqueued = 0;
+        for (const row of rows) {
+            const jobId = `topic-${row.topic_id}-0`;
+            try {
+                await this.topicQueue.remove(jobId);
+            } catch {
+                // Job didn't exist — fine.
+            }
+            await this.topicQueue.add('sync', {
+                topicId: row.topic_id,
+                fromSequenceNumber: 0,
+                isOrgTopic: false,
+            }, { jobId });
+            enqueued++;
+        }
+
+        if (enqueued > 0) {
+            this.logger.log(`Rescued ${enqueued} orphaned topic(s) missing from topic_cache`);
+        }
     }
 
     /**

--- a/sustainable-explorer/src/worker/services/project-mapper.service.ts
+++ b/sustainable-explorer/src/worker/services/project-mapper.service.ts
@@ -15,6 +15,17 @@ import {
 import { PROJECT_EXTRACT_FIELDS } from '../project-mapper/project-fields';
 import { isNonProjectCsType } from '../project-mapper/non-project-credential';
 import { ReverseGeoService } from './reverse-geo.service';
+import { ProjectKeyResolverChain } from '../project-mapper/resolvers/resolver-chain.service';
+import { PolicyMapping } from '../mapping/policy-pipeline.types';
+
+/**
+ * Fields a "date-only" source VC (monitoring/verification report) is allowed to
+ * contribute. All other PROJECT_EXTRACT_FIELDS are skipped for such VCs so their
+ * noisy descriptive fields never seed/fill project descriptive data.
+ */
+const DATE_ONLY_FIELD_KEYS = new Set<string>([
+    'vintageRaw', 'creditingPeriod', 'creditingPeriodStart', 'creditingPeriodEnd',
+]);
 
 /**
  * Per-VC project upsert service.
@@ -40,6 +51,7 @@ export class ProjectMapperService {
     constructor(
         private readonly dataSource: DataSource,
         private readonly reverseGeoService: ReverseGeoService,
+        private readonly resolverChain: ProjectKeyResolverChain,
     ) {}
 
     async upsertProjectFromVc(messageConsensusTimestamp: string): Promise<void> {
@@ -122,14 +134,7 @@ export class ProjectMapperService {
 
         const policyRow = policyRows[0];
         const { policyTopicId, instanceTopicId } = policyRow;
-        const policyMapping = (policyRow.policyMapping ?? {}) as Record<string, Array<{
-            source: string;
-            schemaIri?: string;
-            schemaType?: string;
-            fieldPath?: string;
-            isProjectSchema?: boolean;
-            score?: number;
-        }>>;
+        const policyMapping = (policyRow.policyMapping ?? {}) as PolicyMapping;
 
         // Build the cross-schema field map from policyMapping entries.
         // For each project extract field, pick the highest-scoring entry whose
@@ -198,78 +203,31 @@ export class ProjectMapperService {
             }
         }
 
-        let projectKey: string;
-        if (csRef) {
-            // Downstream VC pointing at a parent via cs.ref. Walk the chain
-            // to find the root cs.id. Then verify the root is actually a
-            // project-schema VC — if not, this VC is referencing an
-            // intermediate artifact (e.g., Estimated Removals) and should
-            // not seed a project row.
-            const refWalked = await this.resolveProjectKeyViaRef(vc.consensusTimestamp, csId);
-            const resolvedKey = refWalked?.projectKey ?? csRef;
-
-            if (policyHasProjectSchemaClassification && !isProjectSchemaVc) {
-                const isRefAProject = await this.isCsIdOnProjectSchema(resolvedKey, policyMapping);
-                if (!isRefAProject) {
-                    this.logger.debug(
-                        `vc=${messageConsensusTimestamp} cs.ref resolves to ${resolvedKey} which is not a project-schema VC — skipping`,
-                    );
-                    return;
-                }
-            }
-            projectKey = resolvedKey;
-        } else if (isProjectSchemaVc) {
-            // Project-schema VC with no cs.ref. Use this VC's own cs.id as the
-            // projectKey. Multiple project-schema VCs from the same signer share
-            // the same DID, so they merge naturally. VCs from different signers
-            // (e.g., VVB vs Registry) have different cs.id values but downstream
-            // monitoring/verification VCs carry cs.ref pointing to the correct
-            // project DID, which merges them via the csRef branch above.
-            //
-            // Relationship walks are NOT used here because they can resolve to
-            // non-project VCs (e.g., Role-Documents) whose cs.id is meaningless.
-            projectKey = csId;
-        } else if (policyHasProjectSchemaClassification) {
-            // Strict mode for classified policies: the decode pipeline knows
-            // which schema is the project schema, and this VC isn't on it
-            // (handled above) and carries no `cs.ref` to one. Therefore it's
-            // not a project artifact — drop without consulting the relationship
-            // walk. The walk would otherwise happily return another non-project
-            // ancestor's cs.id (e.g. a VVB chain that walks to another VVB),
-            // seeding a phantom row.
+        // Resolve the project key via the M1→M4 resolver chain (dynamic topic →
+        // cs.ref → gated relationships → project schema). The chain returns null
+        // when the VC is not a project artifact (rejected or all-pass) → skip it.
+        const resolvedProject = await this.resolverChain.resolve({
+            consensusTimestamp: vc.consensusTimestamp,
+            topicId: vc.topicId,
+            csId,
+            csRef,
+            isProjectSchemaVc,
+            policyHasProjectSchemaClassification,
+            policyMapping,
+        });
+        if (!resolvedProject) {
             this.logger.debug(
-                `vc=${messageConsensusTimestamp} schema=${vcSchemaUuid} not project schema, ` +
-                `no cs.ref; policy has a classified project schema → skipping`,
+                `vc=${messageConsensusTimestamp} schema=${vcSchemaUuid} → no projectKey resolved; skipping`,
             );
             return;
-        } else {
-            // Legacy / unclassified policy. Try the relationship walk for
-            // policies whose schemas weren't classified (older decodes or
-            // schemas that don't carry isProjectSchema markers). If that
-            // doesn't find an ancestor project, drop this VC.
-            const resolved =
-                await this.resolveProjectKeyViaRelationships(vc.consensusTimestamp, csId);
-
-            if (!resolved.walked) {
-                if (resolved.hadRelationships) {
-                    this.logger.debug(
-                        `vc=${messageConsensusTimestamp} schema=${vcSchemaUuid} has relationships but no VC parent → skipping`,
-                    );
-                    return;
-                }
-                if (await this.isDownstreamTopic(vc.topicId)) {
-                    this.logger.debug(
-                        `vc=${messageConsensusTimestamp} schema=${vcSchemaUuid} in downstream topic ${vc.topicId} with no relationships → skipping`,
-                    );
-                    return;
-                }
-                this.logger.debug(
-                    `vc=${messageConsensusTimestamp} schema=${vcSchemaUuid} is not a project schema and carries no ref/ancestor → skipping`,
-                );
-                return;
-            }
-            projectKey = resolved.projectKey;
         }
+        const projectKey = resolvedProject.projectKey;
+
+        // Coarse document type of THIS VC's schema (stamped at decode time).
+        // Validation reports contribute nothing; monitoring/verification reports
+        // contribute only dates + credits (descriptive fields are suppressed).
+        const vcDocType = this.docTypeForSchema(vcSchemaUuid, policyMapping);
+        const isDateOnlySource = vcDocType === 'monitoringReport' || vcDocType === 'verificationReport';
 
         // ── Per-VC field extraction from policyMapping ───────────────────────────
         // crossSchemaFieldMap[fieldKey] = fieldPath (only entries for this VC's
@@ -278,6 +236,8 @@ export class ProjectMapperService {
         let geoLngLat: [number, number] | null = null;
 
         for (const field of PROJECT_EXTRACT_FIELDS) {
+            if (vcDocType === 'validationReport') break;                          // contributes nothing
+            if (isDateOnlySource && !DATE_ONLY_FIELD_KEYS.has(field.key)) continue; // only dates/credits
             const path = crossSchemaFieldMap[field.key];
             if (!path) continue;
 
@@ -301,7 +261,7 @@ export class ProjectMapperService {
         // would require linking the MintToken to a project, which is done by
         // the credit query, not the project mapper.
         let creditsToAdd = 0;
-        {
+        if (vcDocType !== 'validationReport') {
             const er = cs['emission_reduction'] as Record<string, any> | undefined;
             if (er) {
                 const ery = parseFloat(String(er['ER_y'] ?? '0'));
@@ -560,9 +520,8 @@ export class ProjectMapperService {
         //
         // During fresh ingest IPFS fetches arrive in order, so an early
         // project-schema VC (e.g. cs.id=Yn886) gets processed BEFORE the
-        // newer canonical (cs.id=A9oX7) lands. At that moment
-        // findCanonicalProjectSchemaCsIdInTopic returns Yn886 (the only
-        // project-schema VC in the topic so far) and seeds a Yn886 row.
+        // newer canonical (cs.id=A9oX7) lands. At that moment a Yn886 row
+        // gets seeded (the only project-schema VC in the topic so far).
         // When A9oX7 arrives later, its row is created — but the Yn886
         // orphan stays behind. Sweep it here, scoped to project-schema VCs
         // only: delete any sibling PROJECT row in the same topic whose
@@ -586,287 +545,25 @@ export class ProjectMapperService {
         }
 
         this.logger.debug(
-            `vc=${messageConsensusTimestamp} schema=${vcSchemaUuid} key=${projectKey} ` +
+            `vc=${messageConsensusTimestamp} schema=${vcSchemaUuid} key=${projectKey} via=${resolvedProject.method} ` +
             `fields=[${Object.keys(extracted).join(',')}] credits=${creditsToAdd}`,
         );
     }
 
     /**
-     * Follows `credentialSubject[0].ref` (a DID pointing to the project's
-     * identity VC) to find the canonical project key. Each hop: find the VC
-     * whose `cs.id` equals the current ref, take ITS `cs.id` as the new
-     * candidate, and if THAT VC also carries a ref, recurse. Stops at the
-     * first VC without a `ref` (the project root).
-     *
-     * Returns null when:
-     *   - The starting VC has no `ref` (caller falls back to the HCS walk),
-     *   - The ref points to a cs.id that hasn't been ingested yet (defer to
-     *     HCS walk so we still produce *some* projectKey).
-     *
-     * Loop guard via visited refs; capped at 8 hops.
+     * Returns the coarse document type stamped (at decode time) on the policy
+     * mapping entry for the given schema UUID, or 'unknown' if none.
      */
-    private async resolveProjectKeyViaRef(
-        startTs: string,
-        startCsId: string,
-    ): Promise<{ projectKey: string } | null> {
-        const startRow: Array<{ ref: string | null }> = await this.dataSource.query(
-            `SELECT documents->'credentialSubject'->0->>'ref' AS ref
-             FROM message
-             WHERE "consensusTimestamp" = $1
-             LIMIT 1`,
-            [startTs],
-        );
-        const startRef = startRow[0]?.ref;
-        if (!startRef || typeof startRef !== 'string') return null;
-        if (startRef === startCsId) return null;     // self-ref → no useful pointer
-
-        let currentRef = startRef;
-        const visited = new Set<string>([startCsId, currentRef]);
-
-        for (let i = 0; i < 8; i++) {
-            const targetRow: Array<{ cs_id: string | null; next_ref: string | null }> =
-                await this.dataSource.query(
-                    `SELECT documents->'credentialSubject'->0->>'id'  AS cs_id,
-                            documents->'credentialSubject'->0->>'ref' AS next_ref
-                     FROM message
-                     WHERE type = 'VC-Document'
-                       AND documents->'credentialSubject'->0->>'id' = $1
-                     ORDER BY "consensusTimestamp" ASC
-                     LIMIT 1`,
-                    [currentRef],
-                );
-            if (targetRow.length === 0 || !targetRow[0].cs_id) {
-                // Ref doesn't resolve to any ingested VC. Let the HCS walk
-                // produce a fallback projectKey rather than returning a
-                // dangling ref.
-                return null;
-            }
-            const { cs_id, next_ref } = targetRow[0];
-            if (!next_ref || typeof next_ref !== 'string' || visited.has(next_ref)) {
-                return { projectKey: cs_id };
-            }
-            visited.add(next_ref);
-            currentRef = next_ref;
-        }
-        return { projectKey: currentRef };
-    }
-
-    /**
-     * Check if a given cs.id belongs to a VC whose schema is classified as
-     * the project schema for its policy. Used to verify that a cs.ref chain
-     * resolves to an actual project VC, not an intermediate artifact.
-     */
-    private async isCsIdOnProjectSchema(
-        csId: string,
-        policyMapping: Record<string, Array<{ isProjectSchema?: boolean; schemaIri?: string }>>,
-    ): Promise<boolean> {
-        const projectSchemaUuids = new Set<string>();
+    private docTypeForSchema(schemaUuid: string, policyMapping: PolicyMapping): string {
         for (const entries of Object.values(policyMapping)) {
             if (!Array.isArray(entries)) continue;
             for (const entry of entries) {
-                if (entry?.isProjectSchema === true && entry.schemaIri) {
-                    projectSchemaUuids.add(entry.schemaIri.split('&')[0].trim().replace(/^#/, ''));
-                }
+                if (entry.source !== 'schema' || !entry.schemaIri || !entry.docType) continue;
+                const uuid = entry.schemaIri.split('&')[0].trim().replace(/^#/, '');
+                if (uuid === schemaUuid) return entry.docType;
             }
         }
-        if (projectSchemaUuids.size === 0) return true;
-
-        const rows: Array<{ schema_type: string | null }> = await this.dataSource.query(
-            `SELECT documents->'credentialSubject'->0->>'type' AS schema_type
-             FROM message
-             WHERE type = 'VC-Document'
-               AND documents->'credentialSubject'->0->>'id' = $1
-             ORDER BY "consensusTimestamp" ASC
-             LIMIT 1`,
-            [csId],
-        );
-        if (rows.length === 0) return false;
-        const rawType = rows[0].schema_type ?? '';
-        const uuid = rawType.split('&')[0].trim().replace(/^#/, '');
-        return projectSchemaUuids.has(uuid);
-    }
-
-    /**
-     * Returns true when any OTHER VC's `credentialSubject[0].ref` equals the
-     * given csId. The presence of such a reference means downstream VCs
-     * explicitly treat this cs.id as the project's identity — we should not
-     * walk past it via HCS relationships to an older sibling.
-     */
-    private async isCsIdReferencedByOtherVcs(
-        csId: string,
-        selfTs: string,
-    ): Promise<boolean> {
-        const row: Array<{ exists: boolean }> = await this.dataSource.query(
-            `SELECT 1 AS exists
-             FROM message
-             WHERE type = 'VC-Document'
-               AND documents->'credentialSubject'->0->>'ref' = $1
-               AND "consensusTimestamp" <> $2
-             LIMIT 1`,
-            [csId, selfTs],
-        );
-        return row.length > 0;
-    }
-
-    /**
-     * Returns the cs.id of the LATEST project-schema VC (matched by schema
-     * UUID prefix on cs.type) in the given topic. Used as the canonical
-     * projectKey when multiple project-schema VCs in the same topic carry
-     * different cs.id values — they all collapse onto the latest registration's
-     * DID. Returns null when no project-schema VC exists in the topic.
-     *
-     * Query is bounded by the topicId index, then filters cs.type by prefix
-     * on the already-narrow result set. One round trip per project-schema VC.
-     */
-    private async findCanonicalProjectSchemaCsIdInTopic(
-        topicId: string,
-        schemaUuid: string,
-    ): Promise<string | null> {
-        const rows: Array<{ cs_id: string | null }> = await this.dataSource.query(
-            `SELECT documents->'credentialSubject'->0->>'id' AS cs_id
-             FROM message
-             WHERE type = 'VC-Document'
-               AND "topicId" = $1
-               AND documents->'credentialSubject'->0->>'type' LIKE $2 || '&%'
-               AND documents->'credentialSubject'->0->>'id' IS NOT NULL
-             ORDER BY "consensusTimestamp" DESC
-             LIMIT 1`,
-            [topicId, schemaUuid],
-        );
-        return rows[0]?.cs_id ?? null;
-    }
-
-    /**
-     * Walk `message.options.relationships` backwards from a VC to find the root
-     * cs.id-carrying VC in the chain. The root is treated as the project's
-     * identity, so monitoring / verification VCs merge into the project rather
-     * than creating phantom rows keyed by their own cs.id.
-     *
-     * Stops at the first ancestor that has no relationships (or no cs.id-
-     * carrying VC among its relationships). Up to 12 hops. Skips
-     * Role-Documents and other non-VC referenced messages.
-     */
-    private async resolveProjectKeyViaRelationships(
-        startTs: string,
-        startCsId: string,
-    ): Promise<{ projectKey: string; walked: boolean; hadRelationships: boolean }> {
-        // Content-level link (preferred). Many Guardian VCs (monitoring,
-        // verification, etc.) carry `credentialSubject[0].ref` pointing to the
-        // project's identity DID. That's a deterministic intra-policy link
-        // independent of HCS message relationships, which can branch through
-        // registry-side artifacts and produce sibling cs.id winners on
-        // different walks of the same logical project.
-        const refResolved = await this.resolveProjectKeyViaRef(startTs, startCsId);
-        if (refResolved) {
-            return {
-                projectKey: refResolved.projectKey,
-                walked: refResolved.projectKey !== startCsId,
-                hadRelationships: true,
-            };
-        }
-
-        // If THIS VC's cs.id is the target of other VCs' `ref` fields, it is
-        // the canonical project root — other monitoring/verification VCs in
-        // the policy explicitly point to it as the project identity. Don't
-        // walk past it to an older sibling registration just because the HCS
-        // relationship graph has one (Guardian sometimes publishes multiple
-        // registration VCs with different DIDs for the same logical project).
-        if (await this.isCsIdReferencedByOtherVcs(startCsId, startTs)) {
-            return { projectKey: startCsId, walked: false, hadRelationships: false };
-        }
-
-        // Fall back to BFS the ancestor tree via `options.relationships`. We
-        // must walk THROUGH cs.id-less intermediate VCs (e.g. wrapper / system
-        // VCs in some Guardian policies) — they don't claim a project
-        // identity but their parents do. Stopping at the first cs.id-less hop
-        // misses the real Project Registration VC further up.
-        //
-        // The winner is the OLDEST cs.id-carrying VC found anywhere in the
-        // reachable tree (oldest == closest to chain root == Project VC).
-        let oldestTs = startTs;
-        let oldestCsId = startCsId;
-        let walked = false;
-        let hadRelationships = false;
-
-        const visited = new Set<string>([startTs]);
-        const queue: string[] = [startTs];
-        let hops = 0;
-
-        while (queue.length > 0 && hops < 24) {
-            const currentTs = queue.shift()!;
-            hops++;
-
-            const relsRow: Array<{ rels: string[] | null }> = await this.dataSource.query(
-                `SELECT
-                    CASE
-                        WHEN jsonb_typeof(options->'relationships') = 'array'
-                            THEN ARRAY(SELECT jsonb_array_elements_text(options->'relationships'))
-                        ELSE NULL
-                    END AS rels
-                 FROM message
-                 WHERE "consensusTimestamp" = $1
-                 LIMIT 1`,
-                [currentTs],
-            );
-            const rels = relsRow[0]?.rels ?? [];
-            if (currentTs === startTs) hadRelationships = rels.length > 0;
-            if (rels.length === 0) continue;
-
-            const fresh = rels.filter(r => !visited.has(r));
-            if (fresh.length === 0) continue;
-
-            // Fetch all VC-Document parents in this hop (with or without
-            // cs.id) so we can both record candidates AND continue walking
-            // through cs.id-less ones.
-            const parents: Array<{ consensusTimestamp: string; cs_id: string | null }> =
-                await this.dataSource.query(
-                    `SELECT "consensusTimestamp",
-                            documents->'credentialSubject'->0->>'id' AS cs_id
-                     FROM message
-                     WHERE "consensusTimestamp" = ANY($1::text[])
-                       AND type = 'VC-Document'
-                     ORDER BY "consensusTimestamp" ASC`,
-                    [fresh],
-                );
-
-            for (const p of parents) {
-                visited.add(p.consensusTimestamp);
-                queue.push(p.consensusTimestamp);
-                if (p.cs_id && p.consensusTimestamp < oldestTs) {
-                    oldestTs = p.consensusTimestamp;
-                    oldestCsId = p.cs_id;
-                    walked = true;
-                }
-            }
-        }
-
-        return { projectKey: oldestCsId, walked, hadRelationships };
-    }
-
-    /**
-     * Downstream topic-name conventions used across Guardian policies. VCs in
-     * these topics describe monitoring / verification / minting artifacts and
-     * should not seed a project keyed by their own cs.id when they carry no
-     * `options.relationships` to walk back to a Project VC.
-     */
-    private static readonly DOWNSTREAM_TOPIC_NAMES = new Set<string>([
-        'Token_Minting',
-        'Verification',
-        'Validation',
-    ]);
-
-
-    private async isDownstreamTopic(topicId: string): Promise<boolean> {
-        const rows: Array<{ name: string | null }> = await this.dataSource.query(
-            `SELECT options->>'name' AS name
-             FROM message
-             WHERE type='Topic' AND "topicId"=$1
-             ORDER BY "consensusTimestamp" ASC
-             LIMIT 1`,
-            [topicId],
-        );
-        const name = rows[0]?.name;
-        return !!name && ProjectMapperService.DOWNSTREAM_TOPIC_NAMES.has(name);
+        return 'unknown';
     }
 
     private async queryPolicyByPolicyId(policyId: string): Promise<Array<{

--- a/sustainable-explorer/src/worker/services/project-mapper.service.ts
+++ b/sustainable-explorer/src/worker/services/project-mapper.service.ts
@@ -237,8 +237,13 @@ export class ProjectMapperService {
         let geoLngLat: [number, number] | null = null;
 
         for (const field of PROJECT_EXTRACT_FIELDS) {
-            if (vcDocType === 'validationReport') break;                          // contributes nothing
-            if (isDateOnlySource && !DATE_ONLY_FIELD_KEYS.has(field.key)) continue; // only dates/credits
+            // `name` is always allowed (it only ever GAP-FILLS via the merge SQL —
+            // a non-project VC never overwrites an existing name). This lets a
+            // project whose project-schema VC never landed still show a real
+            // title from a data-bearing schema instead of falling back to the DID.
+            const alwaysAllowed = field.key === 'name';
+            if (vcDocType === 'validationReport' && !alwaysAllowed) continue;       // validation: only name
+            if (isDateOnlySource && !DATE_ONLY_FIELD_KEYS.has(field.key) && !alwaysAllowed) continue; // else dates only
             const path = crossSchemaFieldMap[field.key];
             if (!path) continue;
 
@@ -348,12 +353,17 @@ export class ProjectMapperService {
         // store the rest in `countries[]` for future multi-country UI work.
         // The 200-char guard still rejects mis-mapped narrative paragraphs.
         const rawCountry = extracted['country'];
+        // Reject values that are clearly not places — URLs, IPFS/file URIs, or a
+        // raw CID — which leak in when the country field path lands on a geo/file
+        // attribute (e.g. a KML file reference).
+        const isNonLocation = (s: string): boolean =>
+            /:\/\//.test(s) || /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-z0-9]{20,})$/i.test(s.trim());
         let countries: string[] = [];
-        if (rawCountry && rawCountry.length <= 200) {
+        if (rawCountry && rawCountry.length <= 200 && !isNonLocation(rawCountry)) {
             countries = rawCountry
                 .split(',')
                 .map(s => resolveCountryName(s.trim()))
-                .filter(s => s.length > 0);
+                .filter(s => s.length > 0 && !isNonLocation(s));
         }
         let country = countries[0] ?? null;
 
@@ -445,6 +455,13 @@ export class ProjectMapperService {
         if (creditingPeriodStart) newFields.creditingPeriodStart = creditingPeriodStart;
         if (creditingPeriodEnd) newFields.creditingPeriodEnd = creditingPeriodEnd;
         newFields.status = 'Issuing';
+        newFields.decodeMethod = resolvedProject.method;
+        // Method-specific resolution anchor (M1: dynamic topic id; M2/M3/M4: root
+        // VC timestamp the cs.id key was derived from). Merge-friendly: only
+        // non-empty keys are written so later VCs don't clobber it with {}.
+        if (resolvedProject.metadata && Object.keys(resolvedProject.metadata).length > 0) {
+            newFields.metadata = resolvedProject.metadata;
+        }
 
         // Track this VC's contribution. The SQL UPDATE below dedupes by
         // consensusTimestamp so re-running upsert for the same VC is idempotent.

--- a/sustainable-explorer/src/worker/worker.module.ts
+++ b/sustainable-explorer/src/worker/worker.module.ts
@@ -15,6 +15,12 @@ import { MappingModule } from './mapping/mapping.module';
 import { HederaService } from './services/hedera.service';
 import { IpfsService } from './services/ipfs.service';
 import { ProjectMapperService } from './services/project-mapper.service';
+import { TopicClassifierService } from './project-mapper/topic-classifier';
+import { DynamicTopicResolver } from './project-mapper/resolvers/dynamic-topic.resolver';
+import { CsRefResolver } from './project-mapper/resolvers/cs-ref.resolver';
+import { RelationshipsResolver } from './project-mapper/resolvers/relationships.resolver';
+import { ProjectSchemaResolver } from './project-mapper/resolvers/project-schema.resolver';
+import { ProjectKeyResolverChain } from './project-mapper/resolvers/resolver-chain.service';
 import { ReverseGeoService } from './services/reverse-geo.service';
 import { POLICY_ZIP_STORAGE } from './services/storage/policy-zip-storage.interface';
 import { LocalPolicyZipStorage } from './services/storage/local-policy-zip-storage.service';
@@ -117,6 +123,13 @@ export class WorkerModule {
                 IpfsService,
                 ReverseGeoService,
                 ProjectMapperService,
+                // Project-key resolver chain (M1→M4) + its dependencies.
+                TopicClassifierService,
+                DynamicTopicResolver,
+                CsRefResolver,
+                RelationshipsResolver,
+                ProjectSchemaResolver,
+                ProjectKeyResolverChain,
                 { provide: POLICY_ZIP_STORAGE, useClass: LocalPolicyZipStorage },
 
                 // Only processors for active queues

--- a/sustainable-explorer/src/worker/worker.module.ts
+++ b/sustainable-explorer/src/worker/worker.module.ts
@@ -6,7 +6,7 @@ import Redis from 'ioredis';
 import configuration from '@shared/config/configuration';
 import { getDatabaseConfig } from '@shared/config/database.config';
 import { getRedictConfig } from '@shared/config/redict.config';
-import { QUEUE_NAMES, getActiveQueues } from '@shared/config/bullmq.config';
+import { QUEUE_NAMES, getActiveQueues, getQueueConfigs } from '@shared/config/bullmq.config';
 
 // Modules
 import { MappingModule } from './mapping/mapping.module';
@@ -62,6 +62,18 @@ export class WorkerModule {
         const activeQueues = getActiveQueues();
         const allQueueNames = Object.values(QUEUE_NAMES);
 
+        // Per-queue retention defaults. Without these, BullMQ keeps EVERY
+        // completed/failed job forever — the continuous topic-sync poll loop then
+        // grows the completed set unbounded until Redict OOMs. Apply only the
+        // retention fields (not attempts/backoff) so existing retry behaviour is
+        // unchanged. Per-job opts can still override (poll jobs use `true`).
+        const retentionByName = new Map(
+            getQueueConfigs().map(q => [q.name, {
+                removeOnComplete: q.defaultJobOptions.removeOnComplete,
+                removeOnFail: q.defaultJobOptions.removeOnFail,
+            }]),
+        );
+
         // Only register processors for queues this instance handles
         const activeProcessors = activeQueues
             .map(q => PROCESSOR_MAP[q])
@@ -95,7 +107,10 @@ export class WorkerModule {
 
                 // Register ALL queues (so processors can enqueue to any queue)
                 BullModule.registerQueue(
-                    ...allQueueNames.map(name => ({ name })),
+                    ...allQueueNames.map(name => ({
+                        name,
+                        defaultJobOptions: retentionByName.get(name),
+                    })),
                 ),
 
                 // Mapping pipeline module

--- a/sustainable-explorer/test/unit/api/policy-graph.builder.spec.ts
+++ b/sustainable-explorer/test/unit/api/policy-graph.builder.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from '@jest/globals';
+import { buildPolicyWorkflowGraph } from '@api/services/policy-graph.builder';
+
+describe('buildPolicyWorkflowGraph', () => {
+    const rawSchemaJson = {
+        '#uuidA&1.0.0': { name: 'Project' },
+        '#uuidB&1.0.0': { name: 'Validation' },
+    };
+
+    // A small but realistic policy: each role's document + its plumbing live in
+    // a step "screen"; the screen's sendToGuardianBlock RunEvent hands off to the
+    // next screen (the flow event is on a SIBLING of the document, like real
+    // Guardian policies). One RefreshEvent must be ignored.
+    const rawPolicyJson = {
+        policyRoles: ['Proponent', 'VVB'],
+        config: {
+            blockType: 'interfaceContainerBlock',
+            tag: 'root',
+            children: [
+                {
+                    blockType: 'interfaceStepBlock',
+                    tag: 'Proponent_step',
+                    permissions: ['Proponent'],
+                    children: [
+                        {
+                            blockType: 'requestVcDocumentBlock',
+                            tag: 'Proponent_req_1',
+                            permissions: ['Proponent'],
+                            schema: '#uuidA&1.0.0',
+                        },
+                        {
+                            blockType: 'sendToGuardianBlock',
+                            tag: 'Proponent_send_1',
+                            events: [
+                                { source: 'Proponent_send_1', target: 'some_table', output: 'RefreshEvent' },
+                                { source: 'Proponent_send_1', target: 'VVB_step', output: 'RunEvent' },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    blockType: 'interfaceStepBlock',
+                    tag: 'VVB_step',
+                    permissions: ['VVB'],
+                    children: [
+                        {
+                            blockType: 'requestVcDocumentBlock',
+                            tag: 'VVB_req_1',
+                            permissions: ['VVB'],
+                            schema: '#uuidB&1.0.0',
+                        },
+                        {
+                            blockType: 'sendToGuardianBlock',
+                            tag: 'VVB_send_1',
+                            events: [
+                                { source: 'VVB_send_1', target: 'Registry_mint_1', output: 'RunEvent' },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    blockType: 'mintDocumentBlock',
+                    tag: 'Registry_mint_1',
+                    permissions: ['Registry'],
+                },
+            ],
+        },
+    };
+
+    it('emits one node per document/action block with correct labels & categories', () => {
+        const g = buildPolicyWorkflowGraph(rawPolicyJson, rawSchemaJson);
+        expect(g.nodes).toHaveLength(3);
+
+        const byTag = Object.fromEntries(g.nodes.map(n => [n.tag, n]));
+        expect(byTag['Proponent_req_1']).toMatchObject({ role: 'Proponent', category: 'document', label: 'Project', schemaUuid: 'uuidA' });
+        expect(byTag['VVB_req_1']).toMatchObject({ role: 'VVB', category: 'document', label: 'Validation', schemaUuid: 'uuidB' });
+        expect(byTag['Registry_mint_1']).toMatchObject({ role: 'Registry', category: 'action', label: 'Mint Token', schemaUuid: null });
+    });
+
+    it('orders roles by policyRoles then appends extras', () => {
+        const g = buildPolicyWorkflowGraph(rawPolicyJson, rawSchemaJson);
+        expect(g.roles).toEqual(['Proponent', 'VVB', 'Registry']);
+    });
+
+    it('emits flow edges that collapse plumbing and drop RefreshEvents', () => {
+        const g = buildPolicyWorkflowGraph(rawPolicyJson, rawSchemaJson);
+        const flow = g.edges.filter(e => e.kind === 'flow').map(e => `${e.source}->${e.target}`).sort();
+        // Proponent screen send → VVB screen (entry doc); VVB screen send → mint.
+        expect(flow).toEqual(['Proponent_req_1->VVB_req_1', 'VVB_req_1->Registry_mint_1']);
+        // The RefreshEvent target ('some_table') must not appear as any edge.
+        expect(g.edges.some(e => e.target === 'some_table')).toBe(false);
+        // No self-edges.
+        expect(g.edges.some(e => e.source === e.target)).toBe(false);
+    });
+
+    it('assigns authored order and per-role sequence edges (no dup of flow pairs)', () => {
+        const g = buildPolicyWorkflowGraph(rawPolicyJson, rawSchemaJson);
+        // order is the pre-order authored index.
+        const order = Object.fromEntries(g.nodes.map(n => [n.tag, n.order]));
+        expect(order['Proponent_req_1']).toBeLessThan(order['VVB_req_1']);
+        expect(order['VVB_req_1']).toBeLessThan(order['Registry_mint_1']);
+        // Each role here has a single node, so there are no intra-lane sequence
+        // edges; the cross-lane links are the genuine 'flow' edges.
+        expect(g.edges.every(e => e.kind === 'flow')).toBe(true);
+    });
+
+    it('collapses repeated blocks that submit the same document schema into one node', () => {
+        const dupPolicy = {
+            policyRoles: ['Proponent'],
+            config: {
+                blockType: 'interfaceContainerBlock',
+                tag: 'root',
+                children: [
+                    { blockType: 'requestVcDocumentBlock', tag: 'submit_dmrv', permissions: ['Proponent'], schema: '#uuidA&1.0.0' },
+                    { blockType: 'requestVcDocumentBlock', tag: 'edit_dmrv', permissions: ['Proponent'], schema: '#uuidA&1.0.0' },
+                ],
+            },
+        };
+        const g = buildPolicyWorkflowGraph(dupPolicy, { '#uuidA&1.0.0': { name: 'dMRV' } });
+        // Both blocks use the same schema → a single deduped node.
+        expect(g.nodes).toHaveLength(1);
+        expect(g.nodes[0]).toMatchObject({ tag: 'submit_dmrv', label: 'dMRV', schemaUuid: 'uuidA' });
+        // No edge (single node) and certainly no self-loop on the duplicate.
+        expect(g.edges).toEqual([]);
+    });
+
+    it('returns an empty graph for malformed/empty input', () => {
+        expect(buildPolicyWorkflowGraph(null, null)).toEqual({ roles: [], nodes: [], edges: [] });
+        expect(buildPolicyWorkflowGraph({}, {})).toEqual({ roles: [], nodes: [], edges: [] });
+        expect(buildPolicyWorkflowGraph({ config: {} }, {})).toEqual({ roles: [], nodes: [], edges: [] });
+    });
+});

--- a/sustainable-explorer/test/unit/worker/project-mapper/resolvers/circuit-breaker.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/resolvers/circuit-breaker.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+import { CircuitBreaker } from '@worker/project-mapper/resolvers/circuit-breaker';
+
+describe('CircuitBreaker', () => {
+    afterEach(() => { jest.restoreAllMocks(); });
+
+    it('runs fn and returns its result when closed', async () => {
+        const cb = new CircuitBreaker('t', 3, 1000);
+        const fn = jest.fn(async () => 'ok');
+        await expect(cb.run(fn, 'fb')).resolves.toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('absorbs a thrown fn as the fallback (never rethrows)', async () => {
+        const cb = new CircuitBreaker('t', 3, 1000);
+        const fn = jest.fn(async () => { throw new Error('boom'); });
+        await expect(cb.run(fn, 'fb')).resolves.toBe('fb');
+    });
+
+    it('opens after `threshold` consecutive failures and short-circuits without calling fn', async () => {
+        const cb = new CircuitBreaker('t', 2, 10_000);
+        const failing = jest.fn(async () => { throw new Error('x'); });
+        await cb.run(failing, 'fb');
+        await cb.run(failing, 'fb');
+        const probe = jest.fn(async () => 'live');
+        await expect(cb.run(probe, 'fb')).resolves.toBe('fb');
+        expect(probe).not.toHaveBeenCalled();
+    });
+
+    it('half-opens after cooldown, probes, and closes on success', async () => {
+        const nowSpy = jest.spyOn(Date, 'now');
+        nowSpy.mockReturnValue(1_000);
+        const cb = new CircuitBreaker('t', 1, 5_000);
+        await cb.run(async () => { throw new Error('x'); }, 'fb');   // opens at t=1000
+        nowSpy.mockReturnValue(2_000);                               // still in cooldown
+        const blocked = jest.fn(async () => 'live');
+        await expect(cb.run(blocked, 'fb')).resolves.toBe('fb');
+        expect(blocked).not.toHaveBeenCalled();
+        nowSpy.mockReturnValue(7_001);                              // cooldown elapsed
+        const probe = jest.fn(async () => 'live');
+        await expect(cb.run(probe, 'fb')).resolves.toBe('live');
+        expect(probe).toHaveBeenCalledTimes(1);
+        const after = jest.fn(async () => 'ok2');                   // closed: counter reset
+        await expect(cb.run(after, 'fb')).resolves.toBe('ok2');
+        expect(after).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses a null sentinel: a circuit opened at Date.now()===0 is still OPEN', async () => {
+        jest.spyOn(Date, 'now').mockReturnValue(0);
+        const cb = new CircuitBreaker('t', 2, 1_000);
+        const failing = async () => { throw new Error('x'); };
+        await cb.run(failing, 'fb');   // failure 1 at t=0
+        await cb.run(failing, 'fb');   // failure 2 at t=0 → openedAt = 0
+        const probe = jest.fn(async () => 'live');
+        // 0 - 0 = 0 < cooldown. A `0` sentinel would read as "closed" and call probe.
+        await expect(cb.run(probe, 'fb')).resolves.toBe('fb');
+        expect(probe).not.toHaveBeenCalled();
+    });
+});

--- a/sustainable-explorer/test/unit/worker/project-mapper/resolvers/cs-ref.resolver.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/resolvers/cs-ref.resolver.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { DataSource } from 'typeorm';
+import { CsRefResolver } from '@worker/project-mapper/resolvers/cs-ref.resolver';
+import { TopicClassifierService } from '@worker/project-mapper/topic-classifier';
+import { ResolutionContext } from '@worker/project-mapper/resolvers/resolver.types';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a mock DataSource whose `query` method dispatches on SQL shape.
+ *
+ * Each handler is keyed by a substring that uniquely identifies the query:
+ *   'AS ref'          → resolveViaRef start (fetch the ref field from start VC)
+ *   'AS cs_id'        → resolveViaRef hop   (follow ref chain)
+ *   'AS schema_type'  → isCsIdOnProjectSchema
+ *   'FROM business_view' → isKnownProjectRow
+ *   'AS ts'           → earliestTimestampForCsId
+ */
+function makeDs(
+    handlers: Record<string, () => unknown[]>,
+): DataSource {
+    const query = jest.fn(async (sql: string) => {
+        for (const [key, handler] of Object.entries(handlers)) {
+            if (sql.includes(key)) return handler();
+        }
+        return [];
+    });
+    return { query } as unknown as DataSource;
+}
+
+const baseCtx: ResolutionContext = {
+    consensusTimestamp: '1700000000.0',
+    topicId: '0.0.999',
+    csId: 'did:hedera:testnet:self',
+    csRef: 'did:hedera:testnet:root',
+    isProjectSchemaVc: false,
+    policyHasProjectSchemaClassification: false,
+    policyMapping: {},
+};
+
+const classifiedCtx: ResolutionContext = {
+    ...baseCtx,
+    policyHasProjectSchemaClassification: true,
+    isProjectSchemaVc: false,
+};
+
+// Mapping that declares one project schema UUID so isCsIdOnProjectSchema has
+// something to compare against. Required PolicyMappingEntry fields (source,
+// title, description) are included to satisfy the type.
+const policyMappingWithSchema = {
+    someStep: [{
+        source: 'schema' as const,
+        title: 'Project',
+        description: 'Project schema',
+        isProjectSchema: true,
+        schemaIri: '#abc-uuid&1.0.0',
+    }],
+};
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('CsRefResolver (M2)', () => {
+    it('passes when ctx.csRef is empty (no ref present on this VC)', async () => {
+        const ds = makeDs({});
+        const resolver = new CsRefResolver(ds, {} as unknown as TopicClassifierService);
+        const result = await resolver.resolve({ ...baseCtx, csRef: '' });
+        expect(result).toEqual({ status: 'pass' });
+    });
+
+    it('resolves with rootVcTimestamp when cs.ref chain lands on a project-schema VC', async () => {
+        // resolveViaRef: start VC has no further ref → returns null (cs.ref used as-is)
+        // isCsIdOnProjectSchema: root VC type matches the schema UUID → true
+        // earliestTimestampForCsId: returns a root timestamp
+        const ds = makeDs({
+            'AS ref': () => [{ ref: null }],           // resolveViaRef start — no ref field
+            'AS schema_type': () => [{ schema_type: '#abc-uuid&1.0.0' }], // on project schema
+            'AS ts': () => [{ ts: '1699000000.0' }],   // earliestTimestampForCsId
+        });
+        const resolver = new CsRefResolver(ds, {} as unknown as TopicClassifierService);
+        const result = await resolver.resolve({
+            ...classifiedCtx,
+            csRef: 'did:hedera:testnet:root',
+            policyMapping: policyMappingWithSchema,
+        });
+        expect(result).toEqual({
+            status: 'resolved',
+            projectKey: 'did:hedera:testnet:root',
+            method: 'csRef',
+            metadata: { rootVcTimestamp: '1699000000.0' },
+        });
+    });
+
+    it('resolves when root is NOT on project schema but IS a known PROJECT row (new behaviour)', async () => {
+        // resolveViaRef: start VC has no further ref → resolvedKey = ctx.csRef
+        // isCsIdOnProjectSchema: schema_type does NOT match → onProjectSchema = false
+        // isKnownProjectRow: business_view returns a row → true  ← new gate
+        // earliestTimestampForCsId: returns a root timestamp
+        const ds = makeDs({
+            'AS ref': () => [{ ref: null }],           // resolveViaRef start — no ref field
+            'AS schema_type': () => [{ schema_type: '#other-uuid&1.0.0' }], // NOT project schema
+            'FROM business_view': () => [{ '?column?': 1 }],               // IS known PROJECT row
+            'AS ts': () => [{ ts: '1699000001.0' }],   // earliestTimestampForCsId
+        });
+        const resolver = new CsRefResolver(ds, {} as unknown as TopicClassifierService);
+        const result = await resolver.resolve({
+            ...classifiedCtx,
+            csRef: 'did:hedera:testnet:root',
+            policyMapping: policyMappingWithSchema,
+        });
+        expect(result).toEqual({
+            status: 'resolved',
+            projectKey: 'did:hedera:testnet:root',
+            method: 'csRef',
+            metadata: { rootVcTimestamp: '1699000001.0' },
+        });
+    });
+
+    it('rejects when root is neither on project schema nor a known PROJECT row', async () => {
+        // resolveViaRef: start VC has no further ref → resolvedKey = ctx.csRef
+        // isCsIdOnProjectSchema: schema_type does NOT match → false
+        // isKnownProjectRow: business_view returns empty → false
+        const ds = makeDs({
+            'AS ref': () => [{ ref: null }],           // resolveViaRef start — no ref field
+            'AS schema_type': () => [{ schema_type: '#other-uuid&1.0.0' }], // NOT project schema
+            'FROM business_view': () => [],             // NOT a known PROJECT row
+        });
+        const resolver = new CsRefResolver(ds, {} as unknown as TopicClassifierService);
+        const result = await resolver.resolve({
+            ...classifiedCtx,
+            csRef: 'did:hedera:testnet:root',
+            policyMapping: policyMappingWithSchema,
+        });
+        expect(result).toEqual({
+            status: 'reject',
+            reason: 'cs.ref resolves to non-project-schema VC with no known project row',
+        });
+    });
+});

--- a/sustainable-explorer/test/unit/worker/project-mapper/resolvers/dynamic-topic.resolver.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/resolvers/dynamic-topic.resolver.spec.ts
@@ -14,15 +14,29 @@ const ctx: ResolutionContext = {
     policyMapping: {},
 };
 
-const makeResolver = (classification: TopicClassification): DynamicTopicResolver => {
+const makeResolver = (
+    classification: TopicClassification,
+    canonicalCsId: string | null = null,
+): DynamicTopicResolver => {
     const classifier = { classifyTopic: jest.fn(async () => classification) } as unknown as TopicClassifierService;
-    return new DynamicTopicResolver({} as unknown as DataSource, classifier);
+    // canonicalCsIdInTopic issues queries; return the canonical cs.id (or none).
+    const ds = { query: jest.fn(async () => (canonicalCsId ? [{ cs_id: canonicalCsId }] : [])) } as unknown as DataSource;
+    return new DynamicTopicResolver(ds, classifier);
 };
 
 describe('DynamicTopicResolver (M1)', () => {
-    it('resolves by topicId for a dynamic-project topic', async () => {
-        const r = makeResolver({ kind: 'dynamic-project', name: 'Project', instancePolicyTopicId: '0.0.1' });
-        await expect(r.resolve(ctx)).resolves.toEqual({ status: 'resolved', projectKey: '0.0.999', method: 'topic' });
+    it('resolves by the topic canonical cs.id, recording the topic in metadata', async () => {
+        const r = makeResolver({ kind: 'dynamic-project', name: 'Project', instancePolicyTopicId: '0.0.1' }, 'did:root');
+        await expect(r.resolve(ctx)).resolves.toEqual({
+            status: 'resolved', projectKey: 'did:root', method: 'topic', metadata: { dynamicTopicId: '0.0.999' },
+        });
+    });
+
+    it('falls back to the VC cs.id when the topic has no canonical project VC yet', async () => {
+        const r = makeResolver({ kind: 'dynamic-project', name: 'Project', instancePolicyTopicId: '0.0.1' }, null);
+        await expect(r.resolve(ctx)).resolves.toEqual({
+            status: 'resolved', projectKey: 'did:hedera:testnet:abc', method: 'topic', metadata: { dynamicTopicId: '0.0.999' },
+        });
     });
 
     it('passes for an instance topic', async () => {

--- a/sustainable-explorer/test/unit/worker/project-mapper/resolvers/dynamic-topic.resolver.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/resolvers/dynamic-topic.resolver.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { DataSource } from 'typeorm';
+import { DynamicTopicResolver } from '@worker/project-mapper/resolvers/dynamic-topic.resolver';
+import { TopicClassifierService, TopicClassification } from '@worker/project-mapper/topic-classifier';
+import { ResolutionContext } from '@worker/project-mapper/resolvers/resolver.types';
+
+const ctx: ResolutionContext = {
+    consensusTimestamp: '1700000000.0',
+    topicId: '0.0.999',
+    csId: 'did:hedera:testnet:abc',
+    csRef: '',
+    isProjectSchemaVc: false,
+    policyHasProjectSchemaClassification: false,
+    policyMapping: {},
+};
+
+const makeResolver = (classification: TopicClassification): DynamicTopicResolver => {
+    const classifier = { classifyTopic: jest.fn(async () => classification) } as unknown as TopicClassifierService;
+    return new DynamicTopicResolver({} as unknown as DataSource, classifier);
+};
+
+describe('DynamicTopicResolver (M1)', () => {
+    it('resolves by topicId for a dynamic-project topic', async () => {
+        const r = makeResolver({ kind: 'dynamic-project', name: 'Project', instancePolicyTopicId: '0.0.1' });
+        await expect(r.resolve(ctx)).resolves.toEqual({ status: 'resolved', projectKey: '0.0.999', method: 'topic' });
+    });
+
+    it('passes for an instance topic', async () => {
+        const r = makeResolver({ kind: 'instance', name: null, instancePolicyTopicId: '0.0.999' });
+        await expect(r.resolve(ctx)).resolves.toEqual({ status: 'pass' });
+    });
+
+    it('passes for an "other" topic', async () => {
+        const r = makeResolver({ kind: 'other', name: null, instancePolicyTopicId: null });
+        await expect(r.resolve(ctx)).resolves.toEqual({ status: 'pass' });
+    });
+});

--- a/sustainable-explorer/test/unit/worker/project-mapper/resolvers/project-schema.resolver.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/resolvers/project-schema.resolver.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@jest/globals';
+import { DataSource } from 'typeorm';
+import { ProjectSchemaResolver } from '@worker/project-mapper/resolvers/project-schema.resolver';
+import { TopicClassifierService } from '@worker/project-mapper/topic-classifier';
+import { ResolutionContext } from '@worker/project-mapper/resolvers/resolver.types';
+
+const baseCtx: ResolutionContext = {
+    consensusTimestamp: '1700000000.0',
+    topicId: '0.0.999',
+    csId: 'did:hedera:testnet:proj',
+    csRef: '',
+    isProjectSchemaVc: false,
+    policyHasProjectSchemaClassification: false,
+    policyMapping: {},
+};
+
+const resolver = new ProjectSchemaResolver(
+    {} as unknown as DataSource,
+    {} as unknown as TopicClassifierService,
+);
+
+describe('ProjectSchemaResolver (M4)', () => {
+    it('keys a project-schema VC by its own cs.id', async () => {
+        await expect(resolver.resolve({ ...baseCtx, isProjectSchemaVc: true })).resolves.toEqual({
+            status: 'resolved', projectKey: 'did:hedera:testnet:proj', method: 'projectSchema',
+        });
+    });
+
+    it('rejects a non-project-schema VC in a classified policy', async () => {
+        await expect(resolver.resolve({ ...baseCtx, isProjectSchemaVc: false, policyHasProjectSchemaClassification: true })).resolves.toEqual({
+            status: 'reject', reason: 'not the project schema, no cs.ref/ancestor',
+        });
+    });
+
+    it('passes in an unclassified policy', async () => {
+        await expect(resolver.resolve({ ...baseCtx, isProjectSchemaVc: false, policyHasProjectSchemaClassification: false })).resolves.toEqual({
+            status: 'pass',
+        });
+    });
+});

--- a/sustainable-explorer/test/unit/worker/project-mapper/resolvers/project-schema.resolver.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/resolvers/project-schema.resolver.spec.ts
@@ -14,15 +14,15 @@ const baseCtx: ResolutionContext = {
     policyMapping: {},
 };
 
-const resolver = new ProjectSchemaResolver(
-    {} as unknown as DataSource,
-    {} as unknown as TopicClassifierService,
-);
+// earliestTimestampForCsId issues one query; return the root VC's timestamp.
+const ds = { query: async () => [{ ts: '1699999999.0' }] } as unknown as DataSource;
+const resolver = new ProjectSchemaResolver(ds, {} as unknown as TopicClassifierService);
 
 describe('ProjectSchemaResolver (M4)', () => {
-    it('keys a project-schema VC by its own cs.id', async () => {
+    it('keys a project-schema VC by its own cs.id, recording rootVcTimestamp', async () => {
         await expect(resolver.resolve({ ...baseCtx, isProjectSchemaVc: true })).resolves.toEqual({
             status: 'resolved', projectKey: 'did:hedera:testnet:proj', method: 'projectSchema',
+            metadata: { rootVcTimestamp: '1699999999.0' },
         });
     });
 

--- a/sustainable-explorer/test/unit/worker/project-mapper/resolvers/resolver-chain.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/resolvers/resolver-chain.spec.ts
@@ -30,10 +30,10 @@ const build = (r1: ReturnType<typeof fake>, r2: ReturnType<typeof fake>, r3: Ret
 
 describe('ProjectKeyResolverChain', () => {
     it('returns the first resolved result and short-circuits', async () => {
-        const r1 = fake(async () => ({ status: 'resolved', projectKey: 'K1', method: 'topic' }));
+        const r1 = fake(async () => ({ status: 'resolved', projectKey: 'K1', method: 'topic', metadata: { dynamicTopicId: '0.0.123' } }));
         const r2 = fake(pass);
         const chain = build(r1, r2, fake(pass), fake(pass));
-        await expect(chain.resolve(ctx)).resolves.toEqual({ projectKey: 'K1', method: 'topic' });
+        await expect(chain.resolve(ctx)).resolves.toEqual({ projectKey: 'K1', method: 'topic', metadata: { dynamicTopicId: '0.0.123' } });
         expect(r2.resolve).not.toHaveBeenCalled();
     });
 
@@ -47,10 +47,10 @@ describe('ProjectKeyResolverChain', () => {
     it('absorbs a throwing strategy as pass and continues the chain', async () => {
         const chain = build(
             fake(async () => { throw new Error('boom'); }),
-            fake(async () => ({ status: 'resolved', projectKey: 'K2', method: 'csRef' })),
+            fake(async () => ({ status: 'resolved', projectKey: 'K2', method: 'csRef', metadata: { rootVcTimestamp: '1699999999.0' } })),
             fake(pass), fake(pass),
         );
-        await expect(chain.resolve(ctx)).resolves.toEqual({ projectKey: 'K2', method: 'csRef' });
+        await expect(chain.resolve(ctx)).resolves.toEqual({ projectKey: 'K2', method: 'csRef', metadata: { rootVcTimestamp: '1699999999.0' } });
     });
 
     it('returns null when every strategy passes', async () => {

--- a/sustainable-explorer/test/unit/worker/project-mapper/resolvers/resolver-chain.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/resolvers/resolver-chain.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { ProjectKeyResolverChain } from '@worker/project-mapper/resolvers/resolver-chain.service';
+import { ResolutionContext, ResolutionOutcome } from '@worker/project-mapper/resolvers/resolver.types';
+import { DynamicTopicResolver } from '@worker/project-mapper/resolvers/dynamic-topic.resolver';
+import { CsRefResolver } from '@worker/project-mapper/resolvers/cs-ref.resolver';
+import { RelationshipsResolver } from '@worker/project-mapper/resolvers/relationships.resolver';
+import { ProjectSchemaResolver } from '@worker/project-mapper/resolvers/project-schema.resolver';
+
+const ctx: ResolutionContext = {
+    consensusTimestamp: '1700000000.0',
+    topicId: '0.0.123',
+    csId: 'did:hedera:testnet:abc',
+    csRef: '',
+    isProjectSchemaVc: false,
+    policyHasProjectSchemaClassification: false,
+    policyMapping: {},
+};
+
+type ResolveFn = (c: ResolutionContext) => Promise<ResolutionOutcome>;
+const fake = (resolve: ResolveFn) => ({ resolve: jest.fn(resolve) });
+const pass: ResolveFn = async () => ({ status: 'pass' });
+
+const build = (r1: ReturnType<typeof fake>, r2: ReturnType<typeof fake>, r3: ReturnType<typeof fake>, r4: ReturnType<typeof fake>) =>
+    new ProjectKeyResolverChain(
+        r1 as unknown as DynamicTopicResolver,
+        r2 as unknown as CsRefResolver,
+        r3 as unknown as RelationshipsResolver,
+        r4 as unknown as ProjectSchemaResolver,
+    );
+
+describe('ProjectKeyResolverChain', () => {
+    it('returns the first resolved result and short-circuits', async () => {
+        const r1 = fake(async () => ({ status: 'resolved', projectKey: 'K1', method: 'topic' }));
+        const r2 = fake(pass);
+        const chain = build(r1, r2, fake(pass), fake(pass));
+        await expect(chain.resolve(ctx)).resolves.toEqual({ projectKey: 'K1', method: 'topic' });
+        expect(r2.resolve).not.toHaveBeenCalled();
+    });
+
+    it('returns null and short-circuits on reject', async () => {
+        const r3 = fake(pass);
+        const chain = build(fake(pass), fake(async () => ({ status: 'reject', reason: 'nope' })), r3, fake(pass));
+        await expect(chain.resolve(ctx)).resolves.toBeNull();
+        expect(r3.resolve).not.toHaveBeenCalled();
+    });
+
+    it('absorbs a throwing strategy as pass and continues the chain', async () => {
+        const chain = build(
+            fake(async () => { throw new Error('boom'); }),
+            fake(async () => ({ status: 'resolved', projectKey: 'K2', method: 'csRef' })),
+            fake(pass), fake(pass),
+        );
+        await expect(chain.resolve(ctx)).resolves.toEqual({ projectKey: 'K2', method: 'csRef' });
+    });
+
+    it('returns null when every strategy passes', async () => {
+        const chain = build(fake(pass), fake(pass), fake(pass), fake(pass));
+        await expect(chain.resolve(ctx)).resolves.toBeNull();
+    });
+});

--- a/sustainable-explorer/test/unit/worker/project-mapper/topic-classifier.spec.ts
+++ b/sustainable-explorer/test/unit/worker/project-mapper/topic-classifier.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { DataSource } from 'typeorm';
+import { TopicClassifierService } from '@worker/project-mapper/topic-classifier';
+
+interface MockSpec {
+    instanceTopics: Set<string>;
+    topicMessages: Map<string, { parentId: string | null; name: string | null }>;
+}
+
+function mockDs(spec: MockSpec): { ds: DataSource; query: jest.Mock } {
+    const query = jest.fn(async (...args: unknown[]) => {
+        const sql = args[0] as string;
+        const params = args[1] as unknown[] | undefined;
+        const id = (params?.[0] as string) ?? '';
+        if (sql.includes("type = 'Instance-Policy'") && sql.includes('instanceTopicId')) {
+            return spec.instanceTopics.has(id) ? [{ ok: 1 }] : [];
+        }
+        if (sql.includes('AS parent_id') && sql.includes('AS name')) {
+            const tm = spec.topicMessages.get(id);
+            return tm && tm.parentId !== null ? [{ parent_id: tm.parentId, name: tm.name }] : [];
+        }
+        if (sql.includes('AS parent_id')) {
+            const tm = spec.topicMessages.get(id);
+            return [{ parent_id: tm?.parentId ?? null }];
+        }
+        return [];
+    });
+    return { ds: { query } as unknown as DataSource, query };
+}
+
+describe('TopicClassifierService', () => {
+    it('classifies an instance topic', async () => {
+        const { ds } = mockDs({ instanceTopics: new Set(['0.0.inst']), topicMessages: new Map() });
+        const svc = new TopicClassifierService();
+        await expect(svc.classifyTopic(ds, '0.0.inst')).resolves.toEqual({
+            kind: 'instance', name: null, instancePolicyTopicId: '0.0.inst',
+        });
+    });
+
+    it('classifies a dynamic-project topic whose parent is an instance topic', async () => {
+        const { ds } = mockDs({
+            instanceTopics: new Set(['0.0.parent']),
+            topicMessages: new Map([['0.0.child', { parentId: '0.0.parent', name: 'Project' }]]),
+        });
+        const svc = new TopicClassifierService();
+        await expect(svc.classifyTopic(ds, '0.0.child')).resolves.toEqual({
+            kind: 'dynamic-project', name: 'Project', instancePolicyTopicId: '0.0.parent',
+        });
+    });
+
+    it('classifies a non-matching topic as other', async () => {
+        const { ds } = mockDs({
+            instanceTopics: new Set(),
+            topicMessages: new Map([['0.0.x', { parentId: '0.0.p', name: 'Random' }]]),
+        });
+        const svc = new TopicClassifierService();
+        await expect(svc.classifyTopic(ds, '0.0.x')).resolves.toEqual({
+            kind: 'other', name: 'Random', instancePolicyTopicId: null,
+        });
+    });
+
+    it('caches definitive results but re-queries "other"', async () => {
+        const { ds, query } = mockDs({
+            instanceTopics: new Set(['0.0.inst']),
+            topicMessages: new Map([['0.0.x', { parentId: '0.0.p', name: 'Random' }]]),
+        });
+        const svc = new TopicClassifierService();
+        await svc.classifyTopic(ds, '0.0.inst');
+        const afterInstance = query.mock.calls.length;
+        await svc.classifyTopic(ds, '0.0.inst');
+        expect(query.mock.calls.length).toBe(afterInstance);            // definitive → cached
+        await svc.classifyTopic(ds, '0.0.x');
+        const afterOther = query.mock.calls.length;
+        await svc.classifyTopic(ds, '0.0.x');
+        expect(query.mock.calls.length).toBeGreaterThan(afterOther);    // other → re-queried
+    });
+});


### PR DESCRIPTION
## 1. Project-key resolution ladder (M1–M4)

Every VC is attributed to a project by a strategy chain
(`src/worker/project-mapper/resolvers/`), built as an abstract base resolver
(shared DB graph helpers) + four injectable strategies, orchestrated by
`ProjectKeyResolverChain` with a per-strategy circuit breaker (5 consecutive
failures → open 30s → half-open probe). First `resolved` wins; a `reject` skips
the VC; a throw is absorbed as `pass`.

| Method | Strategy | Project key | Metadata anchor |
|---|---|---|---|
| **M1** `topic` (primary) | VC sits in a per-project **dynamic topic** (classified via `TopicClassifierService`: named child topic whose parent chain reaches an Instance-Policy) | canonical **cs.id** — earliest project-schema VC in the topic | `dynamicTopicId` |
| **M2** `csRef` | Walk the `credentialSubject.ref` chain (≤8 hops, cycle-guarded) to the root identity VC | root **cs.id** | `rootVcTimestamp` |
| **M3** `relationships` | Gated BFS over HCS `options.relationships` (≤24 hops, walks through cs.id-less wrappers, oldest ancestor wins) — accepted **only** when the ancestor is independently confirmed (dynamic-project topic, project schema, or known PROJECT row) | confirmed **cs.id** | `rootVcTimestamp` |
| **M4** `projectSchema` (last resort) | The VC is the policy's designated project schema → keys itself; non-project-schema VCs with no link in a classified policy are discarded | own **cs.id** | `rootVcTimestamp` |

All projects are now uniformly **cs.id-keyed**; the resolution method is persisted as
`businessData.decodeMethod` and its anchor as `businessData.metadata`, both exposed
through the API and shown on the project page (decode badge + project key + anchor).

**M2 gate relaxation:** a ref-chain root that is an *already-known PROJECT row* is now
accepted even when it isn't the designated project schema. Previously, lifecycles
anchored on a registration doc (e.g. the ELV policy) were force-dropped, leaving
projects with one linked VC and "Awaiting data" everywhere.

**Policy mapping context:** schemas are classified at policy-decode time
(`policyMapping`: project-schema designation by field-match tally, coarse `docType`
per schema). A docType field guard prevents monitoring/verification VCs from
overwriting descriptive fields (only dates/credits), validation reports contribute
nothing, and `name` may gap-fill from any data-bearing schema (no more DID titles;
plus an API-level fallback to the project-schema/methodology name).

## 2. Late-arriving VCs

VC fetches are deferred until the owning policy is `decoded`; backfills re-enqueue
missing documents on policy decode and on every worker boot. When a VC lands later:

1. The resolver chain re-derives the **same deterministic project key** (same topic /
   same ref-root), so it converges on the existing row.
2. The upsert is `INSERT … ON CONFLICT ("projectKey") DO UPDATE` with an idempotent
   merge: project-schema VCs override descriptive fields, other VCs only gap-fill;
   `linkedVcs` is deduplicated by consensusTimestamp; `credits`/`vcCount` increment
   only for VCs not already linked. Re-processing the same VC is a no-op; a new VC
   adds exactly one entry — no re-key, no duplicate row, no double counting.

## 3. Issuance (MintToken) → project linkage

`project_mint_link` is rebuilt to be **self-healing and complete**:

- **Self-heal:** the linker now re-processes mints whose linked project no longer
  exists (e.g. after re-keying) — 302 stale topic-keyed links repair automatically
  each business-view build cycle.
- **Resolution ladder:** relationship-chain CTE → same-topic cs.ref → **new
  `ref_root` step** (relationship ancestors' cs.id/cs.ref matched directly against
  project keys — independent of `linkedVcs` completeness) → single-project
  topic-scope fallback.
- **Per-event issuance history:** new `issuanceEvents` on the project detail API
  (one entry per MintToken VC: timestamp, token, type, amount, date, link method,
  raw VC). The Issuances tab shows the event history with per-token totals;
  the raw-VC viewer accepts mint timestamps attributed via `project_mint_link`.

## 4. Pipeline visualization (project page → Advanced tab)

- **Policy Flowchart**: interactive role-swimlane canvas (@vue-flow/core) built from
  the real `policy.json` block tree via `GET /:id/policy-graph` — document/action
  nodes per role (from block `permissions`), authored step-order spine + genuine
  event edges (UI `RefreshEvent` noise filtered), VC availability overlay
  (`×N · latest <date>`), Mint Token node lit from issuance events, decode-method
  badge, project key + anchor, and a raw policy.json inspector.
- **Methodology Pipeline**: collapsible per-schema checklist with data-present
  status and document counts.
- **Raw VC drawer**: fields labeled with schema descriptions (incl. nested
  sub-schemas via dotted paths) instead of `field0/field19`.

## 5. Infrastructure & data-quality fixes

- **Redict OOM**: queue retention (`removeOnComplete/removeOnFail`) was never applied
  (missing `defaultJobOptions`) and the topic-sync poll loop enqueued uniquely-named
  keep-alive jobs forever — 1.2M completed jobs filled `maxmemory`. Retention is now
  wired globally and on the poll loop.
- **Country guard**: URLs / IPFS URIs / bare CIDs can no longer be stored or shown
  as a project location.
- **Dedup fixes** retained from earlier in the branch: Standard Registry rows,
  METHODOLOGY rows (same policy topic version + same registry+name), orphaned-topic
  rescue, Instance-Policy `topicId` source correction.

## Testing

- Unit: resolver strategies (M1/M2/M4 + chain + circuit breaker + topic classifier),
  policy-graph builder, cs-ref gate relaxation — `jest`: 76 passed
  (5 pre-existing frozen failures unrelated to this branch).
- `tsc --noEmit` clean; frontend typecheck at frozen baseline (no new errors);
  production build + SSR preview verified.
- Live-verified on mainnet dev data: stale mint links re-resolve (e.g. Amines
  Recycling: 150 mints, incl. `ref_root` links), ELV-class lifecycles attach after
  reparse, mint evidence viewable from the canvas.
