### PR TITLE
feat: add CSV download functionality for credits, methodologies, projects, and registries; update localization for download prompts

### DIFF
--- a/sustainable-explorer/frontend/composables/useApiDownload.ts
+++ b/sustainable-explorer/frontend/composables/useApiDownload.ts
@@ -1,0 +1,36 @@
+const PAGE_LIMIT = 1000;
+
+export function useApiDownload() {
+    const config = useRuntimeConfig();
+    const baseURL = import.meta.server
+        ? (config.apiBaseUrl as string)
+        : (config.public.apiBaseUrl as string);
+
+    async function fetchAllPages<T extends { data: any[]; meta?: Record<string, any> }>(
+        endpoint: string,
+        query: Record<string, string | number | boolean> = {},
+    ): Promise<any[]> {
+        const baseQuery = { ...query, limit: PAGE_LIMIT };
+
+        const first = await $fetch<T>(endpoint, { baseURL, query: { ...baseQuery, page: 1 } });
+        const meta = first?.meta ?? {};
+        const total: number = meta['total'] ?? (first?.data?.length ?? 0);
+        const totalPages: number = meta['totalPages'] ?? (Math.ceil(total / PAGE_LIMIT) || 1);
+
+        let allData: any[] = [...(first?.data ?? [])];
+
+        if (totalPages > 1) {
+            const rest = await Promise.all(
+                Array.from({ length: totalPages - 1 }, (_, i) =>
+                    $fetch<T>(endpoint, { baseURL, query: { ...baseQuery, page: i + 2 } })
+                        .then(r => r?.data ?? []),
+                ),
+            );
+            allData = [...allData, ...rest.flat()];
+        }
+
+        return allData;
+    }
+
+    return { fetchAllPages };
+}

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -210,6 +210,7 @@
         "subtitle": "Verified sustainability projects on the Guardian network",
         "searchPlaceholder": "Search projects...",
         "quickFilters": "Quick filters:",
+        "downloadData": "Download Data",
         "projectsFound": "{count} projects found",
         "totalIssuances": "Total issuances:",
         "countries": "Countries:",
@@ -315,6 +316,7 @@
         "subtitle": "Tokens issued on Hedera",
         "searchPlaceholder": "Search issuances...",
         "quickFilters": "Quick filters:",
+        "downloadData": "Download Data",
         "presets": {
             "fungible": "Fungible tokens",
             "nonFungible": "Non-Fungible (NFTs)",
@@ -363,6 +365,7 @@
         "subtitle": "Published policy workflows for sustainability verification",
         "searchPlaceholder": "Search methodologies...",
         "noMatch": "No methodologies match your filters",
+        "downloadData": "Download Data",
         "columns": {
             "methodology": "Methodology",
             "name": "Name",
@@ -606,6 +609,7 @@
         "subtitle": "Standard Registries operating on the Guardian network",
         "searchPlaceholder": "Search registries...",
         "noMatch": "No registries match your filters",
+        "downloadData": "Download Data",
         "columns": {
             "name": "Name",
             "id": "ID",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -210,6 +210,7 @@
         "subtitle": "Proyectos de sostenibilidad verificados en la red de Guardian",
         "searchPlaceholder": "Buscar proyectos...",
         "quickFilters": "Filtros rápidos:",
+        "downloadData": "Descargar datos",
         "projectsFound": "{count} proyectos encontrados",
         "totalIssuances": "Emisiones totales:",
         "countries": "Países:",
@@ -310,6 +311,7 @@
         "subtitle": "Tokens emitidos en Hedera",
         "searchPlaceholder": "Buscar emisiones...",
         "quickFilters": "Filtros rápidos:",
+        "downloadData": "Descargar datos",
         "presets": {
             "fungible": "Tokens fungibles",
             "nonFungible": "No fungibles (NFTs)",
@@ -358,6 +360,7 @@
         "subtitle": "Flujos de trabajo de políticas publicados para la verificación de sostenibilidad",
         "searchPlaceholder": "Buscar metodologías...",
         "noMatch": "Ninguna metodología coincide con tus filtros",
+        "downloadData": "Descargar datos",
         "columns": {
             "methodology": "Metodología",
             "name": "Nombre",
@@ -601,6 +604,7 @@
         "subtitle": "Registros Estándar que operan en la red de Guardian",
         "searchPlaceholder": "Buscar registros...",
         "noMatch": "Ningún registro coincide con tus filtros",
+        "downloadData": "Descargar Datos",
         "columns": {
             "name": "Nombre",
             "id": "ID",

--- a/sustainable-explorer/frontend/lib/csv-export.ts
+++ b/sustainable-explorer/frontend/lib/csv-export.ts
@@ -1,0 +1,148 @@
+function escapeCsv(val: unknown): string {
+    const s = val == null ? '' : String(val);
+    if (s.includes(',') || s.includes('"') || s.includes('\n') || s.includes('\r')) {
+        return `"${s.replace(/"/g, '""')}"`;
+    }
+    return s;
+}
+
+function toCsvRow(fields: unknown[]): string {
+    return fields.map(escapeCsv).join(',');
+}
+
+export function downloadCsv(filename: string, rows: string[][]): void {
+    const content = rows.map(r => toCsvRow(r)).join('\r\n');
+    const blob = new Blob(['﻿' + content], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+export function csvDateStamp(): string {
+    return new Date().toISOString().slice(0, 10);
+}
+
+export function isoDate(val: string | null | undefined): string {
+    if (!val) return '';
+    const d = new Date(val);
+    if (isNaN(d.getTime())) return val;
+    return d.toISOString().slice(0, 10);
+}
+
+export function buildProjectCsvRows(projects: any[], network: string = ''): string[][] {
+    const header = [
+        'Network', 'Name', 'Description', 'Country', 'Latitude', 'Longitude',
+        'Methodology', 'Registry Name', 'Developer', 'Credits', 'Status', 'Vintage',
+        'SDGs', 'Co-benefits', 'Category', 'Sector', 'Sectoral Scope', 'Created At',
+        'Crediting Period Start', 'Crediting Period End', 'Issuance Count',
+        'Total Issued', 'Total Retired', 'Total Active',
+    ];
+    const rows = projects.map(p => [
+        network,
+        p.name ?? '',
+        p.description ?? '',
+        p.country ?? '',
+        p.lat ?? '',
+        p.lng ?? '',
+        p.methodology ?? '',
+        p.registry ?? '',
+        p.developer ?? '',
+        p.credits ?? 0,
+        p.status ?? '',
+        p.vintage ?? '',
+        Array.isArray(p.sdgs) ? p.sdgs.join(';') : (p.sdgs ?? ''),
+        (p as any).cobenefits ?? '',
+        p.category ?? '',
+        p.sector ?? '',
+        p.sectoralScope ?? '',
+        isoDate(p.createdAt),
+        isoDate(p.creditingPeriodStart),
+        isoDate(p.creditingPeriodEnd),
+        p.issuanceCount ?? 0,
+        p.totalIssued ?? 0,
+        p.totalRetired ?? 0,
+        p.totalActive ?? 0,
+    ]);
+    return [header, ...rows];
+}
+
+export function buildCreditCsvRows(credits: any[], network: string = ''): string[][] {
+    const header = [
+        'Network', 'Name', 'Symbol', 'Type', 'Mint Amount',
+        'Project', 'Methodology', 'Registry', 'Mint Date',
+    ];
+    const rows = credits.map(c => [
+        network,
+        c.name ?? '',
+        c.symbol ?? '',
+        c.type ?? '',
+        c.supply ?? 0,
+        c.projectDisplay ?? c.project ?? '',
+        c.methodologyDisplay ?? c.methodology ?? '',
+        c.registry ?? '',
+        isoDate(c.mintDate),
+    ]);
+    return [header, ...rows];
+}
+
+export function hederaTimestampToIsoDate(ts: string | null | undefined): string {
+    if (!ts) return '';
+    const seconds = parseFloat(ts);
+    if (isNaN(seconds)) return ts;
+    return new Date(seconds * 1000).toISOString().slice(0, 10);
+}
+
+export function buildRegistryCsvRows(registries: any[], network: string = ''): string[][] {
+    const header = [
+        'Network', 'Name', 'ID', 'Geography', 'Website',
+        'Methodologies', 'Projects', 'Users', 'Issuances', 'Tags', 'Created',
+    ];
+    const rows = registries.map(r => [
+        network,
+        r.name ?? '',
+        r.relatedTopicId ?? '',
+        r.geography ?? '',
+        r.website ?? '',
+        r.stats?.policyCount ?? 0,
+        r.stats?.projectCount ?? 0,
+        r.stats?.userCount ?? 0,
+        r.stats?.issuanceCount ?? 0,
+        r.tags ?? '',
+        hederaTimestampToIsoDate(r.sourceTimestamp),
+    ]);
+    return [header, ...rows];
+}
+
+export function buildMethodologyCsvRows(methodologies: any[], network: string = ''): string[][] {
+    const header = [
+        'Network', 'Methodology Name', 'ID', 'Description', 'Status', 'Registry Name',
+        'Version', 'Sectoral Scopes', 'Emission Reduction Approach',
+        'Source Timestamp', 'Created At', 'Updated At',
+        'Project Count', 'Issuances', 'Total Issued', 'Total Retired', 'Total Active',
+    ];
+    const rows = methodologies.map(m => [
+        network,
+        m.name ?? '',
+        m.topicId ?? '',
+        m.description ?? '',
+        m.status ?? '',
+        m.registryName ?? '',
+        m.version ?? '',
+        Array.isArray(m.sectoralScopes) ? m.sectoralScopes.join(';') : (m.sectoralScopes ?? ''),
+        m.emissionReductionApproach ?? '',
+        isoDate(m.sourceTimestamp),
+        isoDate(m.createdAt),
+        isoDate(m.updatedAt),
+        m.stats?.instanceProjectCount ?? 0,
+        m.stats?.instanceIssuanceCount ?? 0,
+        m.totalIssued ?? 0,
+        m.totalRetired ?? 0,
+        m.totalActive ?? 0,
+    ]);
+    return [header, ...rows];
+}

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { FileJson, Sparkles } from 'lucide-vue-next';
+import { FileJson, Sparkles, Download, Loader2 } from 'lucide-vue-next';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import { formatCredits } from '~/lib/format';
+import { downloadCsv, csvDateStamp, buildCreditCsvRows } from '~/lib/csv-export';
 
 const { t, locale } = useI18n();
 const { network } = useNetwork();
@@ -107,6 +108,20 @@ const summaryStats = computed(() => {
 });
 
 const typeColor: Record<string, string> = { Fungible: 'bg-stat-blue/10 text-stat-blue', 'Non-Fungible': 'bg-stat-amber/10 text-stat-amber' };
+
+const downloading = ref(false);
+
+async function downloadCredits() {
+    if (downloading.value) return;
+    downloading.value = true;
+    await nextTick();
+    try {
+        const rows = buildCreditCsvRows(filtered.value, network.value);
+        downloadCsv(`issuances_export_${csvDateStamp()}.csv`, rows);
+    } finally {
+        downloading.value = false;
+    }
+}
 </script>
 
 <template>
@@ -189,6 +204,17 @@ const typeColor: Record<string, string> = { Fungible: 'bg-stat-blue/10 text-stat
         </div>
 
         <div class="px-6 pb-6">
+            <div class="flex justify-end mb-2">
+                <button
+                    :disabled="downloading"
+                    class="inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    @click="downloadCredits"
+                >
+                    <Loader2 v-if="downloading" class="h-3.5 w-3.5 animate-spin" />
+                    <Download v-else class="h-3.5 w-3.5" />
+                    {{ $t('credits.downloadData') }}
+                </button>
+            </div>
             <div class="rounded-xl border bg-card overflow-hidden">
                 <div class="overflow-x-auto">
                 <table class="text-sm w-full">

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -114,9 +114,48 @@ const downloading = ref(false);
 async function downloadCredits() {
     if (downloading.value) return;
     downloading.value = true;
-    await nextTick();
     try {
-        const rows = buildCreditCsvRows(filtered.value, network.value);
+        const { fetchAllPages } = useApiDownload();
+        const af = activeFilters.value;
+        const query: Record<string, string | number> = {};
+        const search = searchQuery.value?.trim();
+        if (search) query.search = search;
+        // type: API only handles single value; multi-select applied client-side below
+        if (af.type && !af.type.includes(',')) query.type = af.type;
+        if (af.registry) query.registry = af.registry;
+        if (projectKeyFilter.value) query.projectKey = projectKeyFilter.value;
+        if (methodologyIdFilter.value) query.methodologyId = methodologyIdFilter.value;
+        if (registryDidFilter.value) query.registryDid = registryDidFilter.value;
+        const API_SORT_KEYS = new Set(['name', 'symbol', 'type', 'supply', 'registry', 'mintDate']);
+        if (sortKey.value && sortDir.value && API_SORT_KEYS.has(String(sortKey.value))) {
+            query.sortBy = String(sortKey.value);
+            query.sortDir = sortDir.value;
+        }
+
+        let allData = await fetchAllPages(`/api/v1/${network.value}/credits`, query);
+
+        // Apply client-side-only hideUnlinked filter
+        if (hideUnlinked.value) allData = allData.filter(c => c.projectId);
+
+        // type multi-select (backend only handles single value; OR match across selected types)
+        if (af.type && af.type.includes(',')) {
+            const types = af.type.split(',').map((s: string) => s.trim());
+            allData = allData.filter(c => types.includes(c.type ?? ''));
+        }
+        // supply range stored as "min|max"
+        if (af.supply) {
+            const [min, max] = af.supply.split('|');
+            if (min) allData = allData.filter(c => (c.supply ?? 0) >= parseFloat(min));
+            if (max) allData = allData.filter(c => (c.supply ?? 0) <= parseFloat(max));
+        }
+        // mintDate range stored as "from|to" (YYYY-MM-DD)
+        if (af.mintDate) {
+            const [from, to] = af.mintDate.split('|');
+            if (from) allData = allData.filter(c => (c.mintDate ?? '') >= from);
+            if (to) allData = allData.filter(c => (c.mintDate ?? '') <= to);
+        }
+
+        const rows = buildCreditCsvRows(allData, network.value);
         downloadCsv(`issuances_export_${csvDateStamp()}.csv`, rows);
     } finally {
         downloading.value = false;

--- a/sustainable-explorer/frontend/pages/methodologies/index.vue
+++ b/sustainable-explorer/frontend/pages/methodologies/index.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
-import { BookOpen, Copy, Check } from "lucide-vue-next";
+import { BookOpen, Copy, Check, Download, Loader2 } from "lucide-vue-next";
 import { useDebounceFn } from '@vueuse/core';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import type {
   MethodologySortKey,
   MethodologySortDir,
+  MethodologiesResponse,
 } from "~/composables/api/useMethodologiesApi";
 import type { SortDirection } from "~/composables/useFilteredPagination";
 import { formatCredits } from "~/lib/format";
 import { useRegistriesApi } from "~/composables/api/useRegistriesApi";
+import { downloadCsv, csvDateStamp, buildMethodologyCsvRows } from '~/lib/csv-export';
 
 const { t } = useI18n();
 
@@ -284,6 +286,60 @@ const decodeStatusI18nKey = (status: string | null | undefined): string => {
 const skeletonRows = computed(() =>
   Array.from({ length: pageSize.value }, (_, i) => i),
 );
+
+const downloading = ref(false);
+
+async function downloadMethodologies() {
+    if (downloading.value) return;
+    downloading.value = true;
+    try {
+        const config = useRuntimeConfig();
+        const baseURL = import.meta.server
+            ? (config.apiBaseUrl as string)
+            : (config.public.apiBaseUrl as string);
+
+        const PAGE_LIMIT = 1000;
+        const baseQuery: Record<string, string | number> = { limit: PAGE_LIMIT };
+        const search = searchQuery.value?.trim();
+        if (search) baseQuery.search = search;
+        if (apiSortBy.value && apiSortDir.value) {
+            baseQuery.sortBy = apiSortBy.value;
+            baseQuery.sortDir = apiSortDir.value;
+        }
+        const FILTER_KEYS = ['name', 'id', 'description', 'decodeStatus', 'registryDid', 'registryName', 'version', 'policyTopicId'] as const;
+        for (const key of FILTER_KEYS) {
+            const raw = filters.value[key];
+            if (raw == null) continue;
+            const trimmed = String(raw).trim();
+            if (trimmed) baseQuery[key] = trimmed;
+        }
+
+        // Fetch page 1 to get total, then fetch remaining pages in parallel
+        const first = await $fetch<MethodologiesResponse>(
+            `/api/v1/${network.value}/methodologies`,
+            { baseURL, query: { ...baseQuery, page: 1 } },
+        );
+        const totalPages = first?.meta?.totalPages ?? 1;
+        let allData = first?.data ?? [];
+
+        if (totalPages > 1) {
+            const rest = await Promise.all(
+                Array.from({ length: totalPages - 1 }, (_, i) =>
+                    $fetch<MethodologiesResponse>(
+                        `/api/v1/${network.value}/methodologies`,
+                        { baseURL, query: { ...baseQuery, page: i + 2 } },
+                    ).then(r => r?.data ?? []),
+                ),
+            );
+            allData = [...allData, ...rest.flat()];
+        }
+
+        const rows = buildMethodologyCsvRows(allData, network.value);
+        downloadCsv(`methodologies_export_${csvDateStamp()}.csv`, rows);
+    } finally {
+        downloading.value = false;
+    }
+}
 </script>
 
 <template>
@@ -325,6 +381,17 @@ const skeletonRows = computed(() =>
     </div>
 
     <div class="px-6 pb-6">
+      <div class="flex justify-end mb-2">
+        <button
+          :disabled="downloading"
+          class="inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          @click="downloadMethodologies"
+        >
+          <Loader2 v-if="downloading" class="h-3.5 w-3.5 animate-spin" />
+          <Download v-else class="h-3.5 w-3.5" />
+          {{ $t('methodologies.downloadData') }}
+        </button>
+      </div>
       <div class="rounded-xl border bg-card overflow-hidden">
         <div class="overflow-x-auto">
         <table class="w-full text-sm table-fixed min-w-[1100px]">

--- a/sustainable-explorer/frontend/pages/methodologies/index.vue
+++ b/sustainable-explorer/frontend/pages/methodologies/index.vue
@@ -5,7 +5,6 @@ import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import type {
   MethodologySortKey,
   MethodologySortDir,
-  MethodologiesResponse,
 } from "~/composables/api/useMethodologiesApi";
 import type { SortDirection } from "~/composables/useFilteredPagination";
 import { formatCredits } from "~/lib/format";
@@ -293,47 +292,23 @@ async function downloadMethodologies() {
     if (downloading.value) return;
     downloading.value = true;
     try {
-        const config = useRuntimeConfig();
-        const baseURL = import.meta.server
-            ? (config.apiBaseUrl as string)
-            : (config.public.apiBaseUrl as string);
-
-        const PAGE_LIMIT = 1000;
-        const baseQuery: Record<string, string | number> = { limit: PAGE_LIMIT };
+        const { fetchAllPages } = useApiDownload();
+        const query: Record<string, string | number> = {};
         const search = searchQuery.value?.trim();
-        if (search) baseQuery.search = search;
+        if (search) query.search = search;
         if (apiSortBy.value && apiSortDir.value) {
-            baseQuery.sortBy = apiSortBy.value;
-            baseQuery.sortDir = apiSortDir.value;
+            query.sortBy = apiSortBy.value;
+            query.sortDir = apiSortDir.value;
         }
         const FILTER_KEYS = ['name', 'id', 'description', 'decodeStatus', 'registryDid', 'registryName', 'version', 'policyTopicId'] as const;
         for (const key of FILTER_KEYS) {
             const raw = filters.value[key];
             if (raw == null) continue;
             const trimmed = String(raw).trim();
-            if (trimmed) baseQuery[key] = trimmed;
+            if (trimmed) query[key] = trimmed;
         }
 
-        // Fetch page 1 to get total, then fetch remaining pages in parallel
-        const first = await $fetch<MethodologiesResponse>(
-            `/api/v1/${network.value}/methodologies`,
-            { baseURL, query: { ...baseQuery, page: 1 } },
-        );
-        const totalPages = first?.meta?.totalPages ?? 1;
-        let allData = first?.data ?? [];
-
-        if (totalPages > 1) {
-            const rest = await Promise.all(
-                Array.from({ length: totalPages - 1 }, (_, i) =>
-                    $fetch<MethodologiesResponse>(
-                        `/api/v1/${network.value}/methodologies`,
-                        { baseURL, query: { ...baseQuery, page: i + 2 } },
-                    ).then(r => r?.data ?? []),
-                ),
-            );
-            allData = [...allData, ...rest.flat()];
-        }
-
+        const allData = await fetchAllPages(`/api/v1/${network.value}/methodologies`, query);
         const rows = buildMethodologyCsvRows(allData, network.value);
         downloadCsv(`methodologies_export_${csvDateStamp()}.csv`, rows);
     } finally {

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { FolderKanban, FileJson, Sparkles, CheckSquare, Square, X, Columns2 } from 'lucide-vue-next';
+import { FolderKanban, FileJson, Sparkles, CheckSquare, Square, X, Columns2, Download, Loader2 } from 'lucide-vue-next';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import { formatCredits } from '~/lib/format';
 import { SDG_LIST } from '~/lib/sdgs';
@@ -7,8 +7,10 @@ import { generateProjectVc } from '~/lib/mock-vc';
 import { MOCK_TRANSFERS, MOCK_RETIREMENTS } from '~/data';
 import { getMethodologyLongName } from '~/lib/methodologies';
 import type { Project } from '~/types/models';
+import { downloadCsv, csvDateStamp, buildProjectCsvRows } from '~/lib/csv-export';
 
 const { t } = useI18n();
+const { network } = useNetwork();
 const { projects, total, filterOptions } = useProjects();
 const { selectedEntries, canAdd, isSelected, toggleProject, removeProject, clearAll, goToCompare } = useProjectComparison();
 const { resolvedCode, resolvedName } = useGeocodedCountries(projects);
@@ -159,6 +161,20 @@ const statusColor: Record<string, string> = {
     Issuing: 'bg-stat-green/10 text-stat-green',
     Completed: 'bg-purple-50 text-purple-600',
 };
+
+const downloading = ref(false);
+
+async function downloadProjects() {
+    if (downloading.value) return;
+    downloading.value = true;
+    await nextTick();
+    try {
+        const rows = buildProjectCsvRows(filtered.value, network.value);
+        downloadCsv(`projects_export_${csvDateStamp()}.csv`, rows);
+    } finally {
+        downloading.value = false;
+    }
+}
 </script>
 
 <template>
@@ -215,6 +231,17 @@ const statusColor: Record<string, string> = {
         </div>
 
         <div class="px-6 pb-6">
+            <div class="flex justify-end mb-2">
+                <button
+                    :disabled="downloading"
+                    class="inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    @click="downloadProjects"
+                >
+                    <Loader2 v-if="downloading" class="h-3.5 w-3.5 animate-spin" />
+                    <Download v-else class="h-3.5 w-3.5" />
+                    {{ $t('projects.downloadData') }}
+                </button>
+            </div>
             <div class="rounded-xl border bg-card overflow-hidden">
                 <div class="overflow-x-auto">
                 <table class="table-fixed text-sm" style="min-width: 1360px; width: 100%">

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -8,6 +8,7 @@ import { MOCK_TRANSFERS, MOCK_RETIREMENTS } from '~/data';
 import { getMethodologyLongName } from '~/lib/methodologies';
 import type { Project } from '~/types/models';
 import { downloadCsv, csvDateStamp, buildProjectCsvRows } from '~/lib/csv-export';
+import { mapApiProject } from '~/composables/useProjects';
 
 const { t } = useI18n();
 const { network } = useNetwork();
@@ -167,9 +168,43 @@ const downloading = ref(false);
 async function downloadProjects() {
     if (downloading.value) return;
     downloading.value = true;
-    await nextTick();
     try {
-        const rows = buildProjectCsvRows(filtered.value, network.value);
+        const { fetchAllPages } = useApiDownload();
+        const af = activeFilters.value;
+        const query: Record<string, string | number> = {};
+        const search = searchQuery.value?.trim();
+        if (search)       query.search   = search;
+        if (af.status)    query.status   = af.status;
+        if (af.registry)  query.registry = af.registry;
+        if (af.country)   query.country  = af.country;
+        if (af.developer) query.developer = af.developer;
+        // sector, sectoralScope, sdgs, vintage range — applied client-side below
+
+        let mapped = (await fetchAllPages(`/api/v1/${network.value}/projects`, query)).map(mapApiProject);
+
+        if (af.sector) {
+            const sectors = af.sector.split(',').map((s: string) => s.trim().toLowerCase());
+            mapped = mapped.filter(p => sectors.some(s => (p.sector ?? '').toLowerCase().includes(s)));
+        }
+        if (af.sectoralScope) {
+            const scope = af.sectoralScope.toLowerCase();
+            mapped = mapped.filter(p => (p.sectoralScope ?? '').toLowerCase().includes(scope));
+        }
+        if (af.sdgs) {
+            const selectedSdgs = af.sdgs.split(',').map((s: string) => s.trim());
+            mapped = mapped.filter(p => Array.isArray(p.sdgs) && selectedSdgs.some(s => p.sdgs.map(String).includes(s)));
+        }
+        if (af.vintage) {
+            const [from, to] = af.vintage.split('|');
+            mapped = mapped.filter(p => {
+                const v = String(p.vintage ?? '');
+                if (from && v < from) return false;
+                if (to && v > to) return false;
+                return true;
+            });
+        }
+
+        const rows = buildProjectCsvRows(mapped, network.value);
         downloadCsv(`projects_export_${csvDateStamp()}.csv`, rows);
     } finally {
         downloading.value = false;

--- a/sustainable-explorer/frontend/pages/registries/index.vue
+++ b/sustainable-explorer/frontend/pages/registries/index.vue
@@ -2,7 +2,7 @@
 import { Building2, Copy, Check, FileJson, Download, Loader2 } from 'lucide-vue-next';
 import { useDebounceFn } from '@vueuse/core';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
-import type { RegistrySortKey, RegistrySortDir, RegistryDto, RegistriesResponse } from '~/composables/api/useRegistriesApi';
+import type { RegistrySortKey, RegistrySortDir, RegistryDto } from '~/composables/api/useRegistriesApi';
 import { downloadCsv, csvDateStamp, buildRegistryCsvRows } from '~/lib/csv-export';
 import type { SortDirection } from '~/composables/useFilteredPagination';
 
@@ -238,52 +238,29 @@ async function downloadRegistries() {
     if (downloading.value) return;
     downloading.value = true;
     try {
-        const config = useRuntimeConfig();
-        const baseURL = import.meta.server
-            ? (config.apiBaseUrl as string)
-            : (config.public.apiBaseUrl as string);
-
-        const PAGE_LIMIT = 1000;
-        const baseQuery: Record<string, string | number | boolean> = { limit: PAGE_LIMIT };
+        const { fetchAllPages } = useApiDownload();
+        const query: Record<string, string | number | boolean> = {};
         const search = searchQuery.value?.trim();
-        if (search) baseQuery.search = search;
+        if (search) query.search = search;
         if (apiSortBy.value && apiSortDir.value) {
-            baseQuery.sortBy = apiSortBy.value;
-            baseQuery.sortDir = apiSortDir.value;
+            query.sortBy = apiSortBy.value;
+            query.sortDir = apiSortDir.value;
         }
         const FILTER_KEYS = ['displayName', 'did', 'id', 'tags', 'geography', 'law'] as const;
         for (const key of FILTER_KEYS) {
             const raw = filters.value[key];
             if (raw == null) continue;
             const trimmed = String(raw).trim();
-            if (trimmed) baseQuery[key] = trimmed;
+            if (trimmed) query[key] = trimmed;
         }
-        if (filters.value.hideEmpty === true) baseQuery.hideEmpty = true;
+        if (filters.value.hideEmpty === true) query.hideEmpty = true;
         const ts = filters.value.sourceTimestamp;
         if (ts && typeof ts === 'object') {
-            if (ts.from) baseQuery.createdAtFrom = ts.from;
-            if (ts.to) baseQuery.createdAtTo = ts.to;
+            if (ts.from) query.createdAtFrom = ts.from;
+            if (ts.to) query.createdAtTo = ts.to;
         }
 
-        const first = await $fetch<RegistriesResponse>(
-            `/api/v1/${network.value}/registries`,
-            { baseURL, query: { ...baseQuery, page: 1 } },
-        );
-        const totalPagesCount = first?.meta?.totalPages ?? 1;
-        let allData = first?.data ?? [];
-
-        if (totalPagesCount > 1) {
-            const rest = await Promise.all(
-                Array.from({ length: totalPagesCount - 1 }, (_, i) =>
-                    $fetch<RegistriesResponse>(
-                        `/api/v1/${network.value}/registries`,
-                        { baseURL, query: { ...baseQuery, page: i + 2 } },
-                    ).then(r => r?.data ?? []),
-                ),
-            );
-            allData = [...allData, ...rest.flat()];
-        }
-
+        const allData = await fetchAllPages(`/api/v1/${network.value}/registries`, query);
         const rows = buildRegistryCsvRows(allData, network.value);
         downloadCsv(`registries_export_${csvDateStamp()}.csv`, rows);
     } finally {

--- a/sustainable-explorer/frontend/pages/registries/index.vue
+++ b/sustainable-explorer/frontend/pages/registries/index.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { Building2, Copy, Check, FileJson } from 'lucide-vue-next';
+import { Building2, Copy, Check, FileJson, Download, Loader2 } from 'lucide-vue-next';
 import { useDebounceFn } from '@vueuse/core';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
-import type { RegistrySortKey, RegistrySortDir, RegistryDto } from '~/composables/api/useRegistriesApi';
+import type { RegistrySortKey, RegistrySortDir, RegistryDto, RegistriesResponse } from '~/composables/api/useRegistriesApi';
+import { downloadCsv, csvDateStamp, buildRegistryCsvRows } from '~/lib/csv-export';
 import type { SortDirection } from '~/composables/useFilteredPagination';
 
 
@@ -231,6 +232,65 @@ const tagsAsList = (tags: string | null): string[] => {
     return tags.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
 };
 
+const downloading = ref(false);
+
+async function downloadRegistries() {
+    if (downloading.value) return;
+    downloading.value = true;
+    try {
+        const config = useRuntimeConfig();
+        const baseURL = import.meta.server
+            ? (config.apiBaseUrl as string)
+            : (config.public.apiBaseUrl as string);
+
+        const PAGE_LIMIT = 1000;
+        const baseQuery: Record<string, string | number | boolean> = { limit: PAGE_LIMIT };
+        const search = searchQuery.value?.trim();
+        if (search) baseQuery.search = search;
+        if (apiSortBy.value && apiSortDir.value) {
+            baseQuery.sortBy = apiSortBy.value;
+            baseQuery.sortDir = apiSortDir.value;
+        }
+        const FILTER_KEYS = ['displayName', 'did', 'id', 'tags', 'geography', 'law'] as const;
+        for (const key of FILTER_KEYS) {
+            const raw = filters.value[key];
+            if (raw == null) continue;
+            const trimmed = String(raw).trim();
+            if (trimmed) baseQuery[key] = trimmed;
+        }
+        if (filters.value.hideEmpty === true) baseQuery.hideEmpty = true;
+        const ts = filters.value.sourceTimestamp;
+        if (ts && typeof ts === 'object') {
+            if (ts.from) baseQuery.createdAtFrom = ts.from;
+            if (ts.to) baseQuery.createdAtTo = ts.to;
+        }
+
+        const first = await $fetch<RegistriesResponse>(
+            `/api/v1/${network.value}/registries`,
+            { baseURL, query: { ...baseQuery, page: 1 } },
+        );
+        const totalPagesCount = first?.meta?.totalPages ?? 1;
+        let allData = first?.data ?? [];
+
+        if (totalPagesCount > 1) {
+            const rest = await Promise.all(
+                Array.from({ length: totalPagesCount - 1 }, (_, i) =>
+                    $fetch<RegistriesResponse>(
+                        `/api/v1/${network.value}/registries`,
+                        { baseURL, query: { ...baseQuery, page: i + 2 } },
+                    ).then(r => r?.data ?? []),
+                ),
+            );
+            allData = [...allData, ...rest.flat()];
+        }
+
+        const rows = buildRegistryCsvRows(allData, network.value);
+        downloadCsv(`registries_export_${csvDateStamp()}.csv`, rows);
+    } finally {
+        downloading.value = false;
+    }
+}
+
 // Raw-data viewer state — same VcJsonViewer pattern used elsewhere.
 const vcViewerOpen = ref(false);
 const vcViewerTitle = ref('');
@@ -274,6 +334,17 @@ function viewRegistry(r: RegistryDto) {
         </div>
 
         <div class="px-6 pb-6">
+            <div class="flex justify-end mb-3">
+                <button
+                    class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
+                    :disabled="downloading"
+                    @click="downloadRegistries"
+                >
+                    <Loader2 v-if="downloading" class="h-3.5 w-3.5 animate-spin" />
+                    <Download v-else class="h-3.5 w-3.5" />
+                    {{ $t('registries.downloadData') }}
+                </button>
+            </div>
             <div class="rounded-xl border bg-card overflow-hidden">
                 <div class="overflow-x-auto">
                 <table class="table-fixed text-sm" style="min-width: 1360px; width: 100%">

--- a/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
@@ -33,6 +33,9 @@ interface RawRow {
     sectoral_scopes: unknown | null;
     emission_reduction_approach: unknown | null;
     policy_source_cid: string | null;
+    // pg returns bigint columns as strings
+    total_issued: string | null;
+    total_retired: string | null;
 }
 
 /**
@@ -80,6 +83,35 @@ const EFFECTIVE_DECODE_STATUS = `
         WHEN p."decodeStatus" = 'decoded' THEN 'success'
         ELSE p."decodeStatus"
     END
+`;
+
+/**
+ * LATERAL subquery that computes totalIssued and totalRetired for each
+ * methodology in the list. Mirrors the primary path used in findById:
+ * - Joins projects to this methodology via businessData->>'instanceTopicId'
+ * - Sums mint amounts from project_mint_link for totalIssued
+ * - Counts deleted NFT serials from nft_cache for totalRetired
+ */
+const LIFECYCLE_JOIN = `
+    LEFT JOIN LATERAL (
+        SELECT
+            COALESCE(SUM(pml.amount), 0)::bigint AS total_issued,
+            COALESCE(SUM(
+                CASE WHEN tc.type = 'NON_FUNGIBLE_UNIQUE' THEN
+                    (SELECT COUNT(*) FILTER (WHERE deleted = true)::bigint
+                     FROM nft_cache nc
+                     WHERE nc."tokenId" = pml.token_id)
+                ELSE 0::bigint END
+            ), 0)::bigint AS total_retired
+        FROM project_mint_link pml
+        JOIN business_view proj
+            ON proj."viewType" = 'PROJECT'
+           AND proj."projectKey" = pml.project_key
+           AND proj."businessData"->>'instanceTopicId' = bv."relatedTopicId"
+        LEFT JOIN token_cache tc ON tc."tokenId" = pml.token_id
+        WHERE pml.token_id IS NOT NULL
+          AND bv."relatedTopicId" IS NOT NULL
+    ) lc_m ON true
 `;
 
 /**
@@ -180,12 +212,15 @@ export class PgMethodologyRepository extends MethodologyRepository {
                 (${EFFECTIVE_DECODE_STATUS}) AS decode_status,
                 p."policyMapping"->'sectoralScopes' AS sectoral_scopes,
                 p."policyMapping"->'emissionReductionApproach' AS emission_reduction_approach,
+                lc_m.total_issued,
+                lc_m.total_retired,
                 ${rankExpr} AS search_rank
             FROM business_view bv
             LEFT JOIN ${MV_METHODOLOGY_STATS_NAME} s
                 ON s."relatedTopicId" = bv."relatedTopicId"
             ${REGISTRY_NAME_JOIN}
             ${POLICY_DECODE_STATUS_JOIN}
+            ${LIFECYCLE_JOIN}
             WHERE ${whereSql}
             ORDER BY ${orderBy}
             LIMIT ${limitParam} OFFSET ${offsetParam}
@@ -365,6 +400,16 @@ export class PgMethodologyRepository extends MethodologyRepository {
         issuances?: IssuanceRow[],
         lifecycle?: { totalIssued: number; totalRetired: number; totalActive: number },
     ): MethodologyRow {
+        // findById passes lifecycle explicitly; findAll supplies it via the
+        // LIFECYCLE_JOIN lateral columns on the raw row.
+        const resolvedLifecycle = lifecycle ?? (row.total_issued != null
+            ? (() => {
+                const issued = parseInt(row.total_issued!, 10);
+                const retired = parseInt(row.total_retired ?? '0', 10);
+                return { totalIssued: issued, totalRetired: retired, totalActive: issued - retired };
+              })()
+            : undefined);
+
         const stats: MethodologyStatsRow = {
             projectCount: parseInt(row.project_count || '0', 10),
             instanceProjectCount: parseInt(row.instance_project_count || '0', 10),
@@ -422,9 +467,9 @@ export class PgMethodologyRepository extends MethodologyRepository {
             updatedAt: row.updatedAt,
             stats,
             issuances,
-            totalIssued: lifecycle?.totalIssued,
-            totalRetired: lifecycle?.totalRetired,
-            totalActive: lifecycle?.totalActive,
+            totalIssued: resolvedLifecycle?.totalIssued,
+            totalRetired: resolvedLifecycle?.totalRetired,
+            totalActive: resolvedLifecycle?.totalActive,
             decodeStatus: row.decode_status ?? null,
             policySourceCid: row.policy_source_cid ?? null,
         };

--- a/sustainable-explorer/src/api/repositories/pg-project.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-project.repository.ts
@@ -25,6 +25,9 @@ interface RawRow {
     updatedAt: Date;
     registry_name: string | null;
     issuance_count: number | null;
+    // pg returns bigint columns as strings
+    total_issued: string | null;
+    total_retired: string | null;
 }
 
 /**
@@ -56,6 +59,44 @@ const ISSUANCE_COUNT_JOIN = `
         WHERE pml.project_key = bv."projectKey"
           AND pml.token_id IS NOT NULL
     ) mint ON true
+`;
+
+/**
+ * LATERAL subquery that sums all mint amounts attributed to a project via
+ * project_mint_link. Mirrors the primary path in findById.
+ */
+const LIFECYCLE_ISSUED_JOIN = `
+    LEFT JOIN LATERAL (
+        SELECT COALESCE(SUM(pml.amount), 0)::bigint AS total_issued
+        FROM project_mint_link pml
+        WHERE pml.project_key = bv."projectKey"
+    ) lc_issued ON true
+`;
+
+/**
+ * LATERAL subquery that counts deleted NFT serials for tokens attributed to
+ * the project. Only NON_FUNGIBLE_UNIQUE tokens can have retired serials.
+ * Mirrors the NFT retirement path in findById.
+ */
+const LIFECYCLE_RETIRED_JOIN = `
+    LEFT JOIN LATERAL (
+        SELECT COALESCE(SUM(nc_agg.retired_count), 0)::bigint AS total_retired
+        FROM (
+            SELECT pml.token_id
+            FROM project_mint_link pml
+            JOIN token_cache tc
+                ON tc."tokenId" = pml.token_id
+               AND tc.type = 'NON_FUNGIBLE_UNIQUE'
+            WHERE pml.project_key = bv."projectKey"
+              AND pml.token_id IS NOT NULL
+            GROUP BY pml.token_id
+        ) nft_tok
+        JOIN LATERAL (
+            SELECT COUNT(*) FILTER (WHERE deleted = true)::bigint AS retired_count
+            FROM nft_cache
+            WHERE "tokenId" = nft_tok.token_id
+        ) nc_agg ON true
+    ) lc_retired ON true
 `;
 
 /**
@@ -140,10 +181,14 @@ export class PgProjectRepository extends ProjectRepository {
                 bv.*,
                 reg.registry_name,
                 COALESCE(mint.issuance_count, 0) AS issuance_count,
+                lc_issued.total_issued,
+                lc_retired.total_retired,
                 ${rankExpr} AS search_rank
             FROM business_view bv
             ${REGISTRY_NAME_JOIN}
             ${ISSUANCE_COUNT_JOIN}
+            ${LIFECYCLE_ISSUED_JOIN}
+            ${LIFECYCLE_RETIRED_JOIN}
             WHERE ${whereSql}
             ORDER BY ${orderBy}
             LIMIT ${limitParam} OFFSET ${offsetParam}
@@ -503,6 +548,17 @@ export class PgProjectRepository extends ProjectRepository {
         lifecycle?: { totalIssued: number; totalRetired: number; totalActive: number },
         policySchemas?: PolicySchemaRow[],
     ): ProjectRow {
+        // When called from findAll(), lifecycle totals come from the lateral
+        // subquery columns on the raw row. When called from findById(), they
+        // are passed explicitly as the lifecycle argument (which takes priority).
+        const resolvedLifecycle = lifecycle ?? (row.total_issued != null
+            ? (() => {
+                const issued = parseInt(row.total_issued!, 10);
+                const retired = parseInt(row.total_retired ?? '0', 10);
+                return { totalIssued: issued, totalRetired: retired, totalActive: issued - retired };
+              })()
+            : undefined);
+
         return {
             id: row.id,
             sourceTimestamp: row.sourceTimestamp,
@@ -518,9 +574,9 @@ export class PgProjectRepository extends ProjectRepository {
             updatedAt: row.updatedAt,
             issuances,
             issuanceCount: row.issuance_count ?? undefined,
-            totalIssued: lifecycle?.totalIssued,
-            totalRetired: lifecycle?.totalRetired,
-            totalActive: lifecycle?.totalActive,
+            totalIssued: resolvedLifecycle?.totalIssued,
+            totalRetired: resolvedLifecycle?.totalRetired,
+            totalActive: resolvedLifecycle?.totalActive,
             policySchemas,
         };
     }


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-117

Added Download Data (CSV export) buttons to the Projects, Issuances, Credits, Methodologies, and Registries listing
  pages.

  How it works:
  - The button respects all active filters, search terms, and sort order
  - Shows a loading spinner inside the button while downloading
  - Files are named {entity}_export_YYYY-MM-DD.csv

  Each export includes a Network column plus entity-specific columns:
  - Projects — Name, Description, Country, Lat/Lng, Methodology, Registry, Developer, Credits, Status, Vintage, SDGs,
  Co-benefits, Category, Sector, Sectoral Scope, dates, Issuance Count, Total Issued/Retired/Active
  - Issuances — Name, Symbol, Type, Mint Amount, Project, Methodology, Registry, Mint Date
  - Methodologies — Methodology Name, ID, Description, Status, Registry Name, Version, Sectoral Scopes, Emission
  Reduction Approach, dates, Project Count, Issuances, Total Issued/Retired/Active
  - Registries — Name, ID, Geography, Website, Methodologies, Projects, Users, Issuances, Tags, Created