### PR TITLE
feat: enable multi-select for filters in developers, methodologies, and projects pages

### DIFF
--- a/sustainable-explorer/frontend/components/shared/FilterBar.vue
+++ b/sustainable-explorer/frontend/components/shared/FilterBar.vue
@@ -12,6 +12,7 @@ export interface FilterOption {
     multiSelect?: boolean;
     searchable?: boolean;
     type?: 'select' | 'daterange' | 'yearrange' | 'numrange';
+    emptyLabel?: string;
 }
 
 const props = defineProps<{
@@ -60,20 +61,20 @@ function selectFilter(key: string, value: string) {
 
 function toggleMultiSelect(key: string, value: string) {
     const current = props.activeFilters[key] || '';
-    const values = current ? current.split(',') : [];
+    const values = (current && current !== 'all') ? current.split('|') : [];
     const idx = values.indexOf(value);
     if (idx >= 0) {
         values.splice(idx, 1);
     } else {
         values.push(value);
     }
-    emit('filter', key, values.length > 0 ? values.join(',') : 'all');
+    emit('filter', key, values.length > 0 ? values.join('|') : 'all');
 }
 
 function isMultiSelected(key: string, value: string): boolean {
     const current = props.activeFilters[key] || '';
     if (!current || current === 'all') return false;
-    return current.split(',').includes(value);
+    return current.split('|').includes(value);
 }
 
 // ── Numeric range helpers ─────────────────────────────────────────────────
@@ -210,9 +211,9 @@ function getActiveLabel(filter: FilterOption): string {
         return `${t('common.to')} ${formatShortDate(to)}`;
     }
     const active = props.activeFilters[filter.key];
-    if (!active || active === 'all') return filter.multiSelect ? filter.label : t('common.all');
+    if (!active || active === 'all') return filter.emptyLabel ?? filter.label;
     if (filter.multiSelect) {
-        const count = active.split(',').length;
+        const count = active.split('|').length;
         return `${filter.label} (${count})`;
     }
     return filter.options.find(o => o.value === active)?.label ?? filter.label;

--- a/sustainable-explorer/frontend/components/shared/ProjectLocationMap.client.vue
+++ b/sustainable-explorer/frontend/components/shared/ProjectLocationMap.client.vue
@@ -6,25 +6,36 @@ const props = defineProps<{
     lng: number;
     name: string;
     approximate?: boolean;
+    hasLocation: boolean;
 }>();
 
 const mapContainer = ref<HTMLElement | null>(null);
+// mapReady is reactive so watchEffect re-evaluates its guard when initMap completes
+const mapReady = ref(false);
 let map: L.Map | null = null;
 let resizeObserver: ResizeObserver | null = null;
+let initializing = false;
 
-onMounted(async () => {
-    if (!mapContainer.value) return;
+async function initMap() {
+    // Guard against concurrent or duplicate calls during the async rAF gap
+    if (initializing || mapReady.value || !mapContainer.value) return;
+    initializing = true;
 
-    // Wait for a real browser animation frame so the container has been laid out.
-    // nextTick() only flushes Vue's microtask queue; rAF waits for the browser's
-    // actual style/layout pass, which is necessary after ClientOnly inserts nodes.
-    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+    // Capture prop values before yielding — props could change across the await
+    const lat = props.lat;
+    const lng = props.lng;
+    const approximate = props.approximate ?? false;
+    const name = props.name;
 
-    if (!mapContainer.value) return;
+    // Double-rAF: wait for the browser to complete a full layout+paint cycle so
+    // Leaflet reads the container's final dimensions, not its mid-update values.
+    await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
+    if (!mapContainer.value || mapReady.value) { initializing = false; return; }
 
     map = L.map(mapContainer.value, {
-        center: [props.lat, props.lng],
-        zoom: props.approximate ? 5 : 8,
+        center: [lat, lng],
+        zoom: approximate ? 5 : 8,
         zoomControl: true,
         scrollWheelZoom: true,
         minZoom: 2,
@@ -45,23 +56,41 @@ onMounted(async () => {
         iconAnchor: [6, 6],
     });
 
-    L.marker([props.lat, props.lng], { icon })
-        .bindPopup(`<strong style="font-size:12px">${props.name}</strong>`)
+    L.marker([lat, lng], { icon })
+        .bindPopup(`<strong style="font-size:12px">${name}</strong>`)
         .addTo(map);
 
-    setTimeout(() => { map?.invalidateSize(); }, 150);
+    map.invalidateSize();
+    setTimeout(() => { map?.invalidateSize(); }, 300);
 
     if (typeof ResizeObserver !== 'undefined') {
         resizeObserver = new ResizeObserver(() => { map?.invalidateSize(); });
         resizeObserver.observe(mapContainer.value);
     }
-});
+
+    mapReady.value = true;
+    initializing = false;
+}
+
+// watchEffect with flush:'post' runs after every DOM commit (including first
+// mount) and re-runs when any tracked reactive dependency changes.
+// mapReady is reactive so the guard short-circuits on subsequent firings once
+// the map is initialised — no duplicate L.map() calls.
+//
+// For Miller Mountain (hasLocation always true):  fires on first mount → initMap ✓
+// For Rajasthan (hasLocation starts false, Nominatim arrives later):
+//   fires on mount (false → no-op), fires again when hasLocation flips true → initMap ✓
+watchEffect(() => {
+    if (props.hasLocation && !mapReady.value) initMap();
+}, { flush: 'post' });
 
 onUnmounted(() => {
     resizeObserver?.disconnect();
     resizeObserver = null;
     map?.remove();
     map = null;
+    mapReady.value = false;
+    initializing = false;
 });
 </script>
 
@@ -69,8 +98,15 @@ onUnmounted(() => {
 <template>
     <div class="relative h-full w-full">
         <div ref="mapContainer" class="h-full w-full rounded-lg" />
+        <!-- Overlay shown while Nominatim geocoding is still in flight -->
         <div
-            v-if="approximate"
+            v-if="!hasLocation"
+            class="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground"
+        >
+            Location data unavailable
+        </div>
+        <div
+            v-if="hasLocation && approximate"
             class="absolute bottom-2 left-2 z-[1000] rounded bg-background/80 px-2 py-0.5 text-[10px] text-muted-foreground backdrop-blur-sm"
         >
             Approximate location

--- a/sustainable-explorer/frontend/composables/useFilteredPagination.ts
+++ b/sustainable-explorer/frontend/composables/useFilteredPagination.ts
@@ -116,41 +116,46 @@ export function useFilteredPagination<T>(
         for (const [key, value] of Object.entries(activeFilters.value)) {
             if (value && value !== 'all') {
                 if (arrayFieldSet.has(key)) {
-                    const selectedValues = value.split(',');
+                    // Array field (e.g. sdgs): pipe-separated list of values to match
+                    const selectedValues = value.split('|').filter(Boolean);
                     result = result.filter((item) => {
                         const arr = item[key as keyof T];
                         if (!Array.isArray(arr)) return false;
                         return selectedValues.some(v => arr.map(String).includes(v));
                     });
                 } else if (value.includes('|')) {
-                    // Range filter: value format is "from|to"
-                    // Numeric range (digits only): numeric comparison — covers both year and supply ranges
-                    // Date range (YYYY-MM-DD strings): date comparison
-                    const [from, to] = value.split('|');
-                    const isNumericRange = [from, to].filter(Boolean).every(v => /^\d+(\.\d+)?$/.test(v));
-                    result = result.filter((item) => {
-                        const rawVal = item[key as keyof T];
-                        if (rawVal === null || rawVal === undefined || rawVal === '') return false;
-                        if (isNumericRange) {
-                            const itemNum = parseFloat(String(rawVal));
-                            if (isNaN(itemNum)) return false;
-                            if (from && itemNum < parseFloat(from)) return false;
-                            if (to && itemNum > parseFloat(to)) return false;
-                        } else {
-                            const d = new Date(String(rawVal));
-                            if (isNaN(d.getTime())) return false;
-                            if (from) {
-                                if (d < new Date(from + 'T00:00:00')) return false;
+                    const parts = value.split('|');
+                    const [from, to] = parts;
+                    // A range has exactly 2 parts that are both numeric or both ISO dates.
+                    // Anything else (e.g. "Issuing|Registered") is a multi-select list.
+                    const isNumericRange = parts.length === 2
+                        && parts.filter(Boolean).every(v => /^\d+(\.\d+)?$/.test(v));
+                    const isDateRange = parts.length === 2
+                        && parts.filter(Boolean).every(v => /^\d{4}-\d{2}-\d{2}$/.test(v));
+
+                    if (isNumericRange || isDateRange) {
+                        // Range filter: numeric (year / supply) or date comparison
+                        result = result.filter((item) => {
+                            const rawVal = item[key as keyof T];
+                            if (rawVal === null || rawVal === undefined || rawVal === '') return false;
+                            if (isNumericRange) {
+                                const itemNum = parseFloat(String(rawVal));
+                                if (isNaN(itemNum)) return false;
+                                if (from && itemNum < parseFloat(from)) return false;
+                                if (to && itemNum > parseFloat(to)) return false;
+                            } else {
+                                const d = new Date(String(rawVal));
+                                if (isNaN(d.getTime())) return false;
+                                if (from && d < new Date(from + 'T00:00:00')) return false;
+                                if (to && d > new Date(to + 'T23:59:59')) return false;
                             }
-                            if (to) {
-                                if (d > new Date(to + 'T23:59:59')) return false;
-                            }
-                        }
-                        return true;
-                    });
-                } else if (value.includes(',')) {
-                    const selectedValues = value.split(',');
-                    result = result.filter((item) => selectedValues.includes(String(item[key as keyof T])));
+                            return true;
+                        });
+                    } else {
+                        // Multi-select: pipe-separated list of exact string values
+                        const selectedValues = parts.filter(Boolean);
+                        result = result.filter((item) => selectedValues.includes(String(item[key as keyof T])));
+                    }
                 } else {
                     result = result.filter((item) => String(item[key as keyof T]) === value);
                 }

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -101,8 +101,8 @@
         "title": "Dashboard",
         "subtitle": "Overview of the Hedera Guardian sustainability network",
         "filterTooltip": "Filter all dashboard data by project developer and/or registry. All cards, charts, map, and tables update to show only matching projects.",
-        "allDevelopers": "All Developers",
-        "allRegistries": "All Registries",
+        "allDevelopers": "Developers",
+        "allRegistries": "Registries",
         "stats": {
             "registries": "Registries",
             "registriesSub": "Standard Registries",
@@ -396,7 +396,7 @@
             "namePlaceholder": "Search by name",
             "id": "ID",
             "description": "Description",
-            "decoded": "Decoded",
+            "decoded": "Decode Status",
             "decodedAll": "All"
         },
         "stats": {

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -101,8 +101,8 @@
         "title": "Panel",
         "subtitle": "Resumen de la red de sostenibilidad de Hedera Guardian",
         "filterTooltip": "Filtra todos los datos del panel por desarrollador de proyecto y/o registro. Todas las tarjetas, gráficos, mapas y tablas se actualizan para mostrar solo los proyectos que coinciden.",
-        "allDevelopers": "Todos los desarrolladores",
-        "allRegistries": "Todos los registros",
+        "allDevelopers": "Desarrolladores",
+        "allRegistries": "Registros",
         "stats": {
             "registries": "Registros",
             "registriesSub": "Registros estándar",
@@ -391,7 +391,7 @@
             "namePlaceholder": "Buscar por nombre",
             "id": "ID",
             "description": "Descripción",
-            "decoded": "Decodificado",
+            "decoded": "Estado de Decode",
             "decodedAll": "Todos"
         },
         "stats": {

--- a/sustainable-explorer/frontend/pages/developers/index.vue
+++ b/sustainable-explorer/frontend/pages/developers/index.vue
@@ -22,6 +22,7 @@ const filters = computed<FilterOption[]>(() => [
     {
         key: 'status',
         label: t('developers.filters.status'),
+        multiSelect: true,
         options: filterOptions.value.statuses.map((s: string) => ({ value: s, label: s })),
     },
 ]);

--- a/sustainable-explorer/frontend/pages/methodologies/index.vue
+++ b/sustainable-explorer/frontend/pages/methodologies/index.vue
@@ -123,6 +123,7 @@ const barFilters = computed<FilterOption[]>(() => [
     {
         key: 'decodeStatus',
         label: t('methodologies.filters.decoded'),
+        multiSelect: true,
         options: [
             { value: 'success', label: t('methodologies.decodeStatus.success') },
             { value: 'failed', label: t('methodologies.decodeStatus.failed') },

--- a/sustainable-explorer/frontend/pages/projects/[id].vue
+++ b/sustainable-explorer/frontend/pages/projects/[id].vue
@@ -543,6 +543,10 @@ watch(project, async (p) => {
     countryCenterCoords.value = await nominatimCountryCenter(p.country);
 }, { immediate: true });
 
+// effectiveLocation is null while Nominatim is still fetching for zero-coord
+// projects.  The map component handles this "not yet ready" state internally
+// rather than relying on v-if to mount/unmount it — avoiding a Leaflet
+// initialisation race when the component mounts mid-hydration.
 const effectiveLocation = computed(() => {
     if (!project.value) return null;
     const hasCoords = project.value.lat !== 0 || project.value.lng !== 0;
@@ -659,16 +663,19 @@ const emissions = computed(() => {
                     </div>
                     <div class="h-[320px]">
                         <ClientOnly>
+                            <!--
+                                Mount on project (not effectiveLocation) so the component exists
+                                when ClientOnly activates.  It watches hasLocation internally and
+                                initialises Leaflet only once coordinates arrive — no mount/unmount
+                                cycle, no Leaflet size-detection race on reload.
+                            -->
                             <ProjectLocationMap
-                                v-if="effectiveLocation"
-                                :lat="effectiveLocation.lat"
-                                :lng="effectiveLocation.lng"
+                                :lat="effectiveLocation?.lat ?? 0"
+                                :lng="effectiveLocation?.lng ?? 0"
                                 :name="project.name"
-                                :approximate="effectiveLocation.approximate"
+                                :approximate="effectiveLocation?.approximate ?? false"
+                                :has-location="!!effectiveLocation"
                             />
-                            <div v-else class="h-full flex items-center justify-center text-sm text-muted-foreground">
-                                Location data unavailable
-                            </div>
                         </ClientOnly>
                     </div>
                 </div>

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -193,6 +193,7 @@ const filters = computed<FilterOption[]>(() => [
   {
     key: "status",
     label: t("projects.filters.status"),
+    multiSelect: true,
     options: filterOptions.value.statuses.map((s) => ({ value: s, label: s })),
   },
   {
@@ -227,6 +228,7 @@ const filters = computed<FilterOption[]>(() => [
   {
     key: "sectoralScope",
     label: t("projects.filters.sectoralScope"),
+    multiSelect: true,
     options: filterOptions.value.sectoralScopes.map((s) => ({
       value: s,
       label: s,

--- a/sustainable-explorer/src/api/dto/methodology.dto.ts
+++ b/sustainable-explorer/src/api/dto/methodology.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsIn } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginationQueryDto } from './pagination.dto';
 import { MethodologyRow, MethodologyStatsRow } from '../repositories/methodology.repository';
@@ -21,12 +21,12 @@ export class MethodologyQueryDto extends PaginationQueryDto {
     description?: string;
 
     @ApiPropertyOptional({
-        description: 'Filter by decode status',
-        enum: ['success', 'failed', 'pending', 'unknown'],
+        description: 'Filter by decode status. Pipe-separate multiple values (e.g. "success|failed").',
+        example: 'success|failed',
     })
     @IsOptional()
-    @IsIn(['success', 'failed', 'pending', 'unknown'])
-    decodeStatus?: 'success' | 'failed' | 'pending' | 'unknown';
+    @IsString()
+    decodeStatus?: string;
 
     @ApiPropertyOptional({ description: 'Filter by exact registry DID' })
     @IsOptional()

--- a/sustainable-explorer/src/api/dto/methodology.dto.ts
+++ b/sustainable-explorer/src/api/dto/methodology.dto.ts
@@ -1,4 +1,5 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsIn } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginationQueryDto } from './pagination.dto';
 import { MethodologyRow, MethodologyStatsRow } from '../repositories/methodology.repository';
@@ -26,8 +27,9 @@ export class MethodologyQueryDto extends PaginationQueryDto {
         example: 'success|failed',
     })
     @IsOptional()
-    @IsString()
-    decodeStatus?: string;
+    @Transform(({ value }) => String(value).split('|').filter(Boolean))
+    @IsIn(['success', 'failed', 'pending', 'unknown'], { each: true })
+    decodeStatus?: ('success' | 'failed' | 'pending' | 'unknown')[];
 
     @ApiPropertyOptional({ description: 'Filter by exact registry DID' })
     @IsOptional()

--- a/sustainable-explorer/src/api/dto/methodology.dto.ts
+++ b/sustainable-explorer/src/api/dto/methodology.dto.ts
@@ -22,6 +22,7 @@ export class MethodologyQueryDto extends PaginationQueryDto {
 
     @ApiPropertyOptional({
         description: 'Filter by decode status. Pipe-separate multiple values (e.g. "success|failed").',
+        enum: ['success', 'failed', 'pending', 'unknown'],
         example: 'success|failed',
     })
     @IsOptional()

--- a/sustainable-explorer/src/api/repositories/methodology.repository.ts
+++ b/sustainable-explorer/src/api/repositories/methodology.repository.ts
@@ -16,7 +16,7 @@ export interface MethodologyListQuery {
     name?: string;
     id?: string;
     description?: string;
-    decodeStatus?: 'success' | 'failed' | 'pending' | 'unknown';
+    decodeStatus?: string;
     registryDid?: string;
     registryName?: string;
     version?: string;

--- a/sustainable-explorer/src/api/repositories/methodology.repository.ts
+++ b/sustainable-explorer/src/api/repositories/methodology.repository.ts
@@ -16,7 +16,7 @@ export interface MethodologyListQuery {
     name?: string;
     id?: string;
     description?: string;
-    decodeStatus?: string;
+    decodeStatus?: ('success' | 'failed' | 'pending' | 'unknown')[];
     registryDid?: string;
     registryName?: string;
     version?: string;

--- a/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
@@ -152,11 +152,25 @@ export class PgMethodologyRepository extends MethodologyRepository {
         // decodeStatus filter — uses the EFFECTIVE status (CASE expression) so
         // 'success' includes policies whose schemas are imported even if a
         // recent retry flipped pds.status to 'failed'.
-        if (query.decodeStatus === 'unknown') {
-            builder.addClause(`(${EFFECTIVE_DECODE_STATUS}) IS NULL`);
-        } else if (query.decodeStatus) {
-            const p = builder.nextParam(query.decodeStatus);
-            builder.addClause(`(${EFFECTIVE_DECODE_STATUS}) = ${p}`);
+        // Supports pipe-separated multi-values (e.g. "success|failed").
+        if (query.decodeStatus) {
+            const statuses = String(query.decodeStatus).split('|').map(s => s.trim()).filter(Boolean);
+            const hasUnknown = statuses.includes('unknown');
+            const otherStatuses = statuses.filter(s => s !== 'unknown');
+
+            const clauses: string[] = [];
+            if (hasUnknown) clauses.push(`(${EFFECTIVE_DECODE_STATUS}) IS NULL`);
+            if (otherStatuses.length === 1) {
+                const p = builder.nextParam(otherStatuses[0]);
+                clauses.push(`(${EFFECTIVE_DECODE_STATUS}) = ${p}`);
+            } else if (otherStatuses.length > 1) {
+                const p = builder.nextParam(otherStatuses);
+                clauses.push(`(${EFFECTIVE_DECODE_STATUS}) = ANY(${p}::text[])`);
+            }
+
+            if (clauses.length > 0) {
+                builder.addClause(clauses.length === 1 ? clauses[0] : `(${clauses.join(' OR ')})`);
+            }
         }
 
         // Special: full-text search with ranking. The tsvector index covers

--- a/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-methodology.repository.ts
@@ -153,8 +153,8 @@ export class PgMethodologyRepository extends MethodologyRepository {
         // 'success' includes policies whose schemas are imported even if a
         // recent retry flipped pds.status to 'failed'.
         // Supports pipe-separated multi-values (e.g. "success|failed").
-        if (query.decodeStatus) {
-            const statuses = String(query.decodeStatus).split('|').map(s => s.trim()).filter(Boolean);
+        if (query.decodeStatus?.length) {
+            const statuses = query.decodeStatus;
             const hasUnknown = statuses.includes('unknown');
             const otherStatuses = statuses.filter(s => s !== 'unknown');
 

--- a/sustainable-explorer/src/api/repositories/query-builder.ts
+++ b/sustainable-explorer/src/api/repositories/query-builder.ts
@@ -161,8 +161,8 @@ export class QueryBuilder {
     private buildOperatorClause(sql: string, op: FilterOperator, value: unknown): string | null {
         switch (op) {
             case 'eq': {
-                if (typeof value === 'string' && value.includes(',')) {
-                    const parts = value.split(',').map(s => s.trim()).filter(Boolean);
+                if (typeof value === 'string' && value.includes('|')) {
+                    const parts = value.split('|').map(s => s.trim()).filter(Boolean);
                     if (parts.length > 1) {
                         this.params.push(parts);
                         return `${sql} = ANY($${this.paramIdx++}::text[])`;
@@ -173,7 +173,7 @@ export class QueryBuilder {
             }
 
             case 'ilike': {
-                const parts = String(value).split(',').map(s => s.trim()).filter(Boolean);
+                const parts = String(value).split('|').map(s => s.trim()).filter(Boolean);
                 if (parts.length > 1) {
                     const clauses = parts.map(p => {
                         this.params.push(`%${p}%`);


### PR DESCRIPTION
### Fixes for the following comments
_https://xeptagon.atlassian.net/browse/SE-83?focusedCommentId=48859
https://xeptagon.atlassian.net/browse/SE-85?focusedCommentId=48845_


<img width="1221" height="298" alt="image" src="https://github.com/user-attachments/assets/5e6e3b4e-46ae-4114-b875-2c1f93546489" />

Filter system
  - Changed the multi-select separator from , to | so registry names containing commas (e.g. "Carbonbase, GCR") are handled correctly — updated across
  frontend and backend.
  - Filters now show their own label when nothing is selected instead of "All", and show Label (N) when N values are active.
  - Enabled multi-select on Decode Status, Status, and Sectoral Scope filters across Methodologies, Projects, and Developers pages.
  - Renamed "Decoded" → "Decode Status", "All Developers" → "Developers", "All Registries" → "Registries".
  - Fixed a bug where deselecting then reselecting an option caused the count to inflate (e.g. Status(2) instead of Status(1)).

Project Location Map
  - Fixed the map going blank on hard reload for projects without coordinates (e.g. Regenerating Rajasthan). The map component is now always mounted
  alongside the project, and initialises Leaflet reactively when coordinates arrive — eliminating the mount/unmount race that caused Leaflet's size
  detection to misfire.