### PR TITLE
feat: enhance detail label resolution and clean up breadcrumb navigation in various components

### DIFF
--- a/sustainable-explorer/frontend/components/layout/AppTopbar.vue
+++ b/sustainable-explorer/frontend/components/layout/AppTopbar.vue
@@ -39,6 +39,13 @@ async function resolveDetailLabel(parentPath: string, paramId: string) {
     let endpoint: string | null = null;
     if (parentPath === '/projects') endpoint = `projects/${paramId}`;
     else if (parentPath === '/methodologies') endpoint = `methodologies/${paramId}`;
+    else if (parentPath === '/registries') {
+        endpoint = paramId.startsWith('did:')
+            ? `registries/${encodeURIComponent(paramId)}`
+            : `registries/id/${paramId}`;
+    } else if (parentPath === '/credits') {
+        endpoint = `credits/${encodeURIComponent(paramId)}/raw`;
+    }
     if (!endpoint) return;
 
     if (!import.meta.client) return;
@@ -47,11 +54,11 @@ async function resolveDetailLabel(parentPath: string, paramId: string) {
     const baseURL = config.public.apiBaseUrl as string;
 
     try {
-        const res = await $fetch<{ name?: string; displayName?: string }>(
+        const res = await $fetch<{ name?: string; displayName?: string; credit?: { name?: string } }>(
             `/api/v1/${network.value}/${endpoint}`,
             { baseURL },
         );
-        const label = res?.name || res?.displayName;
+        const label = res?.name || res?.displayName || res?.credit?.name;
         if (label) detailLabelCache.value[cacheKey] = label;
     } catch {
         // Leave the cache untouched on error — breadcrumb shows raw id as fallback.
@@ -342,10 +349,11 @@ function onSearchKeydown(e: KeyboardEvent) {
                 </NuxtLink>
                 <span
                     v-else
-                    class="flex items-center gap-1 text-xs font-medium text-foreground truncate max-w-[140px] md:max-w-[240px]"
+                    class="flex items-center gap-1 text-xs font-medium text-foreground min-w-0 max-w-[140px] md:max-w-[240px]"
+                    :title="crumb.label"
                 >
                     <component :is="crumb.icon" v-if="crumb.icon" class="h-3.5 w-3.5 shrink-0" />
-                    {{ crumb.label }}
+                    <span class="truncate">{{ crumb.label }}</span>
                 </span>
             </template>
         </nav>

--- a/sustainable-explorer/frontend/components/project/ProjectHeader.vue
+++ b/sustainable-explorer/frontend/components/project/ProjectHeader.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-    ArrowLeft, FileJson, ExternalLink,
+    FileJson, ExternalLink,
 } from 'lucide-vue-next';
 import type { Project } from '~/types/models';
 
@@ -29,16 +29,6 @@ const statusColor: Record<string, { bg: string; text: string; dot: string }> = {
 
 <template>
     <div class="space-y-3">
-        <!-- Breadcrumb -->
-        <div class="flex items-center gap-2 text-sm text-muted-foreground">
-            <NuxtLink to="/projects" class="inline-flex items-center gap-1.5 hover:text-foreground transition-colors">
-                <ArrowLeft class="h-3.5 w-3.5" />
-                Projects
-            </NuxtLink>
-            <span>/</span>
-            <span class="text-foreground truncate max-w-[320px]">{{ project.name }}</span>
-        </div>
-
         <!-- Title row -->
         <div class="flex items-start justify-between gap-4">
             <div class="min-w-0">

--- a/sustainable-explorer/frontend/pages/credits/[id].vue
+++ b/sustainable-explorer/frontend/pages/credits/[id].vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import {
-    ArrowLeft,
     ExternalLink,
     FileJson,
     Coins,
@@ -219,15 +218,6 @@ function viewRawVc(title: string, doc: Record<string, any> | null) {
 
     <!-- Not found -->
     <div v-else-if="!credit" class="p-6">
-        <div class="flex items-center gap-2 text-sm text-muted-foreground mb-4">
-            <NuxtLink
-                to="/credits"
-                class="inline-flex items-center gap-1.5 hover:text-foreground transition-colors"
-            >
-                <ArrowLeft class="h-3.5 w-3.5" />
-                {{ $t('credits.title') }}
-            </NuxtLink>
-        </div>
         <h1 class="text-xl font-bold text-foreground">{{ $t('credits.detail.notFound') }}</h1>
         <p class="text-sm text-muted-foreground mt-1">
             {{ $t('credits.detail.notFoundDesc', { tokenId, network }) }}
@@ -238,17 +228,6 @@ function viewRawVc(title: string, doc: Record<string, any> | null) {
     <div v-else class="space-y-6 p-6">
         <!-- Header -->
         <div class="space-y-3">
-            <div class="flex items-center gap-2 text-sm text-muted-foreground">
-                <NuxtLink
-                    to="/credits"
-                    class="inline-flex items-center gap-1.5 hover:text-foreground transition-colors"
-                >
-                    <ArrowLeft class="h-3.5 w-3.5" />
-                    {{ $t('credits.title') }}
-                </NuxtLink>
-                <span>/</span>
-                <span class="text-xs text-foreground">{{ credit.name ?? credit.tokenId }}</span>
-            </div>
             <div class="flex items-start justify-between gap-4">
                 <div class="min-w-0">
                     <div class="flex items-center gap-3 flex-wrap">

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import {
-  ArrowLeft,
   BookOpen,
   Shield,
   ExternalLink,
@@ -11,7 +10,6 @@ import {
   Zap,
   Building2,
   Layers,
-  ChevronRight,
   FileText,
   FileJson,
   Copy,
@@ -859,21 +857,6 @@ function getResolvedField(fieldKey: string) {
 
 <template>
   <div class="space-y-6 p-6">
-    <!-- Breadcrumb -->
-    <div class="flex items-center gap-2 text-sm text-muted-foreground">
-      <NuxtLink
-        to="/methodologies"
-        class="hover:text-foreground transition-colors flex items-center gap-1"
-      >
-        <ArrowLeft class="h-3.5 w-3.5" />
-        {{ $t('methodologies.detail.breadcrumb') }}
-      </NuxtLink>
-      <ChevronRight class="h-3.5 w-3.5" />
-      <span class="text-foreground font-medium">{{
-        methodology?.name ?? id
-      }}</span>
-    </div>
-
     <!-- Loading skeleton -->
     <template v-if="pending">
       <div class="space-y-4">

--- a/sustainable-explorer/frontend/pages/registries/[id].vue
+++ b/sustainable-explorer/frontend/pages/registries/[id].vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
 import {
-    ArrowLeft,
     Building2,
     Globe,
     FileJson,
     Copy,
     Check,
-    ChevronRight,
     AlertCircle,
     ExternalLink,
     Shield,
@@ -268,19 +266,6 @@ function openRawData() {
 
 <template>
     <div class="space-y-6 p-6">
-        <!-- Breadcrumb -->
-        <div class="flex items-center gap-2 text-sm text-muted-foreground">
-            <NuxtLink
-                to="/registries"
-                class="hover:text-foreground transition-colors flex items-center gap-1"
-            >
-                <ArrowLeft class="h-3.5 w-3.5" />
-                {{ $t('registries.detail.breadcrumb') }}
-            </NuxtLink>
-            <ChevronRight class="h-3.5 w-3.5" />
-            <span class="text-foreground font-medium truncate">{{ registry?.name ?? registryId }}</span>
-        </div>
-
         <!-- Loading skeleton -->
         <template v-if="pending">
             <div class="space-y-4">


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-94

<img width="1192" height="243" alt="image" src="https://github.com/user-attachments/assets/44b8f34b-b7cb-46b7-bc1c-573eff741e50" />


1. Duplicate Breadcrumbs — Removed per-page breadcrumbs from all 4 detail pages

- components/project/ProjectHeader.vue — removed breadcrumb block + unused ArrowLeft import
- pages/methodologies/[id].vue — removed breadcrumb block + unused ArrowLeft, ChevronRight imports
- pages/registries/[id].vue — removed breadcrumb block + unused ArrowLeft, ChevronRight imports
- pages/credits/[id].vue — removed both breadcrumb blocks (not-found + main content) + unused ArrowLeft import

The top-level breadcrumb in AppTopbar.vue is the single source of truth for all pages.

2. Top Breadcrumb Showing ID Instead of Name — Fixed for Registry & Issuances

- components/layout/AppTopbar.vue — extended resolveDetailLabel() to fetch names for:
- Registries: hits registries/id/:id (or DID-based URL) → reads res.name
- Credits/Issuances: hits credits/:id/raw → reads res.credit.name
- Projects & Methodologies already worked; registries and credits were simply missing.

3. Long Name Truncation with Ellipsis

- components/layout/AppTopbar.vue — fixed text truncation in the final breadcrumb crumb: