### PR TITLE
fix: Add registry filtering support in projects and methodologies pages when navigating from registry details page, update localization strings

### DIFF
--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -441,6 +441,9 @@
         "searchPlaceholder": "Search projects...",
         "quickFilters": "Quick filters:",
         "downloadData": "Download Data",
+        "filteredByRegistry": "Showing projects for registry",
+        "unknownRegistry": "this registry",
+        "clearRegistryFilter": "Clear filter",
         "projectsFound": "{count} projects found",
         "totalIssuances": "Total issuances:",
         "countries": "Countries:",
@@ -565,6 +568,7 @@
         "unknownMethodology": "this methodology",
         "clearMethodologyFilter": "Clear filter",
         "filteredByRegistry": "Showing issuances for registry",
+        "unknownRegistry": "this registry",
         "clearRegistryFilter": "Clear filter",
         "supplyTooltip": "Total number of Credits Minted for the particular project. For NFTs, this is the number of unique serials.",
         "columns": {
@@ -638,6 +642,9 @@
         "searchPlaceholder": "Search methodologies...",
         "noMatch": "No methodologies match your filters",
         "downloadData": "Download Data",
+        "filteredByRegistry": "Showing methodologies for registry",
+        "unknownRegistry": "this registry",
+        "clearRegistryFilter": "Clear filter",
         "columns": {
             "methodology": "Methodology",
             "name": "Name",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -441,6 +441,9 @@
         "searchPlaceholder": "Buscar proyectos...",
         "quickFilters": "Filtros rápidos:",
         "downloadData": "Descargar datos",
+        "filteredByRegistry": "Mostrando proyectos del registro",
+        "unknownRegistry": "este registro",
+        "clearRegistryFilter": "Quitar filtro",
         "projectsFound": "{count} proyectos encontrados",
         "totalIssuances": "Emisiones totales:",
         "countries": "Países:",
@@ -560,6 +563,7 @@
         "unknownMethodology": "esta metodología",
         "clearMethodologyFilter": "Quitar filtro",
         "filteredByRegistry": "Mostrando emisiones del registro",
+        "unknownRegistry": "este registro",
         "clearRegistryFilter": "Quitar filtro",
         "supplyTooltip": "Suministro total de tokens acuñado en Hedera. Para tokens fungibles es el suministro total. Para NFTs es el número de serials únicos.",
         "columns": {
@@ -633,6 +637,9 @@
         "searchPlaceholder": "Buscar metodologías...",
         "noMatch": "Ninguna metodología coincide con tus filtros",
         "downloadData": "Descargar datos",
+        "filteredByRegistry": "Mostrando metodologías del registro",
+        "unknownRegistry": "este registro",
+        "clearRegistryFilter": "Quitar filtro",
         "columns": {
             "methodology": "Metodología",
             "name": "Nombre",

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -69,6 +69,11 @@ const methodologyFilterName = computed(() => {
     return allCredits.value[0]?.methodologyDisplay ?? null;
 });
 
+const registryFilterName = computed(() => {
+    if (!registryDidFilter.value) return null;
+    return allCredits.value[0]?.registry ?? null;
+});
+
 const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, activeFilters, sortKey, sortDir, toggleSort, setFilter, clearFilters, applyPreset } =
     useFilteredPagination(allCredits, {
         searchFields: ['name', 'symbol', 'tokenId', 'projectDisplay', 'methodologyDisplay', 'registry'],
@@ -205,7 +210,7 @@ async function downloadCredits() {
         <div v-if="registryDidFilter" class="px-6 pb-2">
             <div class="flex items-center gap-2 rounded-lg bg-primary/5 border border-primary/20 px-4 py-2 text-sm">
                 <span class="text-muted-foreground">{{ $t('credits.filteredByRegistry') }}</span>
-                <span class="font-medium text-foreground font-mono text-xs">{{ registryDidFilter }}</span>
+                <span v-if="!pending" class="font-medium text-foreground">{{ registryFilterName ?? $t('credits.unknownRegistry') }}</span>
                 <NuxtLink to="/credits" class="ml-auto text-xs text-muted-foreground hover:text-foreground transition-colors">
                     {{ $t('credits.clearRegistryFilter') }} ×
                 </NuxtLink>

--- a/sustainable-explorer/frontend/pages/methodologies/index.vue
+++ b/sustainable-explorer/frontend/pages/methodologies/index.vue
@@ -140,6 +140,31 @@ const activeFilterRecord = computed<Record<string, string>>(() => {
     return r;
 });
 
+// Separate from the manual `registryName` FilterBar filter above — this
+// reflects navigation from a registry-scoped link (e.g. the Registry detail
+// page's "Methodologies" card), which filters by DID (registries aren't
+// unique by name — see registries list, duplicate names with different DIDs)
+// while still showing a friendly name in its own banner.
+const registryDidFromQuery = computed(() =>
+    typeof route.query.registryDid === 'string' ? route.query.registryDid : null);
+const registryFilterName = computed(() => {
+    if (!registryDidFromQuery.value) return null;
+    return registriesData.value?.data.find(r => r.did === registryDidFromQuery.value)?.name ?? null;
+});
+
+// `filters.value.registryDid` is only ever seeded once at mount (from
+// `initialFilters`) and drives the actual useMethodologiesApi fetch — it
+// doesn't reactively track the URL afterward. Without this, navigating away
+// via the banner's "Clear filter" link (which clears route.query.registryDid)
+// hides the banner but leaves the list silently still scoped, and syncToUrl()
+// could even resurrect the param from this stale value on the next search.
+watch(registryDidFromQuery, (val) => {
+    const next = { ...filters.value };
+    if (val) next.registryDid = val;
+    else delete next.registryDid;
+    filters.value = next;
+});
+
 function setMethodologyFilter(key: string, value: string) {
     const next = { ...filters.value };
     if (!value || value === 'all') delete next[key];
@@ -378,6 +403,16 @@ async function downloadMethodologies() {
           statTotal
         }}</span>
       </div>
+    </div>
+
+    <div v-if="registryDidFromQuery" class="px-6 pb-2">
+        <div class="flex items-center gap-2 rounded-lg bg-primary/5 border border-primary/20 px-4 py-2 text-sm">
+            <span class="text-muted-foreground">{{ $t('methodologies.filteredByRegistry') }}</span>
+            <span v-if="registriesData" class="font-medium text-foreground">{{ registryFilterName ?? $t('methodologies.unknownRegistry') }}</span>
+            <NuxtLink to="/methodologies" class="ml-auto text-xs text-muted-foreground hover:text-foreground transition-colors">
+                {{ $t('methodologies.clearRegistryFilter') }} ×
+            </NuxtLink>
+        </div>
     </div>
 
     <div class="px-6 pb-3">

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -120,6 +120,27 @@ const countryFilterOptions = computed(() =>
   ),
 );
 
+// Navigation from a registry-scoped link (e.g. the Registry detail page's
+// "Projects" card) filters by DID — registries aren't unique by name (the
+// registries list can hold multiple entries sharing a display name with
+// different DIDs), so name-based matching would silently mix in projects
+// from the wrong registry. Narrowed here, before useFilteredPagination, so
+// the manual filters/search/sort and all result counts stay consistent with
+// the scoped set. Separate from the manual `registry` FilterBar filter below.
+const route = useRoute();
+const registryDidFilter = computed(() =>
+  typeof route.query.registryDid === "string" ? route.query.registryDid : null,
+);
+const scopedProjects = computed(() =>
+  registryDidFilter.value
+    ? allProjects.value.filter((p) => p.registryDid === registryDidFilter.value)
+    : allProjects.value,
+);
+const registryFilterName = computed(() => {
+  if (!registryDidFilter.value) return null;
+  return scopedProjects.value[0]?.registry ?? null;
+});
+
 const {
   searchQuery,
   currentPage,
@@ -134,7 +155,7 @@ const {
   setFilter,
   clearFilters,
   applyPreset,
-} = useFilteredPagination(allProjects, {
+} = useFilteredPagination(scopedProjects, {
   searchFields: [
     "name",
     "country",
@@ -147,6 +168,12 @@ const {
   pageSize: 10,
   defaultSort: { key: "createdAt", dir: "desc" },
   arrayFields: ["sdgs"],
+  // registryDid drives the separate scopedProjects narrowing above, not the
+  // manual FilterBar `registry` filter — excluding it here stops
+  // parseFiltersFromQuery from also picking it up as a generic activeFilters
+  // entry, which would persist (stuck at mount-time value) even after
+  // navigating away and silently keep the list scoped after "Clear filter".
+  excludeFromQuery: ["registryDid"],
 });
 
 const presets = computed(() => [
@@ -353,6 +380,16 @@ async function downloadProjects() {
       <p class="text-sm text-muted-foreground mt-1">
         {{ $t("projects.subtitle") }}
       </p>
+    </div>
+
+    <div v-if="registryDidFilter" class="px-6 pb-2">
+        <div class="flex items-center gap-2 rounded-lg bg-primary/5 border border-primary/20 px-4 py-2 text-sm">
+            <span class="text-muted-foreground">{{ $t('projects.filteredByRegistry') }}</span>
+            <span v-if="!pending" class="font-medium text-foreground">{{ registryFilterName ?? $t('projects.unknownRegistry') }}</span>
+            <NuxtLink to="/projects" class="ml-auto text-xs text-muted-foreground hover:text-foreground transition-colors">
+                {{ $t('projects.clearRegistryFilter') }} ×
+            </NuxtLink>
+        </div>
     </div>
 
     <div class="px-6 pb-3">

--- a/sustainable-explorer/frontend/pages/registries/[id].vue
+++ b/sustainable-explorer/frontend/pages/registries/[id].vue
@@ -367,7 +367,7 @@ function openRawData() {
                 </NuxtLink>
 
                 <NuxtLink
-                    :to="`/projects?registry=${encodeURIComponent(registry.name)}`"
+                    :to="`/projects?registryDid=${encodeURIComponent(registry.did)}`"
                     class="group rounded-xl border bg-card px-5 py-5 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md hover:border-border/80"
                 >
                     <div class="flex items-center justify-between mb-3">


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-104

<img width="1680" height="372" alt="image" src="https://github.com/user-attachments/assets/36e4c0ae-859f-4acc-bc71-35baead7e1ab" />

The fix applies when you click the stat cards on the Registry detail page (Projects, Total Issuances, Methodologies). Each of those links now scopes by the registry's DID, not its name — registries aren't unique by name in this system (the registries list can have multiple distinct entries sharing a display name), so name-based filtering would silently mix in data from the wrong registry. Each destination page (Projects, Issuances, Methodologies) resolves that DID to a friendly name purely for its own banner display, while the actual data stays correctly scoped by DID.


