### PR TITLE
feat: add Advanced tab to credit detail page with HashScan links

### DIFF
--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -596,11 +596,19 @@
             "overview": "Overview",
             "tokenId": "Token ID",
             "connectedProject": "Project",
-            "firstMintDate": "First Mint Date",
+            "lastMintDate": "Last Mint Date",
             "tabs": {
                 "details": "Details",
                 "mintEvents": "Transactions",
-                "linkage": "Linkage"
+                "linkage": "Linkage",
+                "advanced": "Advanced"
+            },
+            "advanced": {
+                "title": "Advanced",
+                "tokenPolicy": "Token Policy Id",
+                "mintTokenId": "Mint Token",
+                "tokenCreatedDate": "Token Created Date",
+                "issueDid": "Issue DID"
             },
             "tokenInformation": "Token Information",
             "supplyDifferenceTooltip": "The Supply Amount and Minted Amount for this issuance are currently different.",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -591,11 +591,19 @@
             "overview": "Resumen",
             "tokenId": "ID de token",
             "connectedProject": "Proyecto",
-            "firstMintDate": "Primera fecha de emisión",
+            "lastMintDate": "Última fecha de emisión",
             "tabs": {
                 "details": "Detalles",
                 "mintEvents": "Transacciones",
-                "linkage": "Vinculación"
+                "linkage": "Vinculación",
+                "advanced": "Avanzado"
+            },
+            "advanced": {
+                "title": "Avanzado",
+                "tokenPolicy": "ID de política del token",
+                "mintTokenId": "Token acuñado",
+                "tokenCreatedDate": "Fecha de creación del token",
+                "issueDid": "DID de emisión"
             },
             "tokenInformation": "Información del token",
             "supplyDifferenceTooltip": "El monto de suministro y el monto acuñado de esta emisión son actualmente diferentes.",

--- a/sustainable-explorer/frontend/pages/credits/[id].vue
+++ b/sustainable-explorer/frontend/pages/credits/[id].vue
@@ -7,6 +7,7 @@ import {
     FolderKanban,
     Link,
     Receipt,
+    Shield,
 } from 'lucide-vue-next';
 import { formatCredits, formatDate } from '~/lib/format';
 import type { CreditDto, CreditsResponse } from '~/composables/api/useCreditsApi';
@@ -45,6 +46,9 @@ interface CreditRawDetail {
     credit: CreditRaw | null;
     projects: CreditProjectLink[];
     tokenMessage: Record<string, any> | null;
+    policyId: string | null;
+    policyName: string | null;
+    policyTopicId: string | null;
     mintEvents: MintEvent[];
 }
 
@@ -92,8 +96,8 @@ const connectedProject = computed<CreditProjectLink | null>(() => {
 
 // ─── Tabs ─────────────────────────────────────────────────────────────────────
 
-type TabKey = 'details' | 'provenance' | 'mint-events';
-const VALID_TABS = new Set<TabKey>(['details', 'provenance', 'mint-events']);
+type TabKey = 'details' | 'provenance' | 'mint-events' | 'advanced';
+const VALID_TABS = new Set<TabKey>(['details', 'provenance', 'mint-events', 'advanced']);
 
 const activeTab = ref<TabKey>('details');
 const tabReady = ref(false);
@@ -113,6 +117,7 @@ const tabs = computed(() => [
     { key: 'details'     as TabKey, label: t('credits.detail.tabs.details'),    icon: Coins },
     { key: 'mint-events' as TabKey, label: t('credits.detail.tabs.mintEvents'), icon: Receipt },
     { key: 'provenance'  as TabKey, label: t('credits.detail.tabs.linkage'),    icon: Link },
+    { key: 'advanced'    as TabKey, label: t('credits.detail.tabs.advanced'),   icon: Shield },
 ]);
 
 // ─── Computed ─────────────────────────────────────────────────────────────────
@@ -124,7 +129,7 @@ const totalMintedAll = computed(() =>
 );
 
 const totalMintedProject = computed<number | null>(() => {
-    const pid = connectedProjectId.value;
+    const pid = connectedProjectId.value ?? credit.value?.projectId ?? null;
     if (!pid) return null;
     return mintEvents.value
         .filter(e => e.projectKey === pid)
@@ -156,18 +161,28 @@ const paginatedMintEvents = computed(() => {
 // Reset to page 1 when the project filter changes.
 watch(connectedProjectId, () => { mintEventsPage.value = 1; });
 
-const firstMintDate = computed(
-    () =>
-        credit.value?.mintDate ??
-        mintEvents.value
-            .map(e => e.date)
-            .filter(Boolean)
-            .sort()[0] ??
-        null,
-);
+const lastMintDate = computed(() => {
+    const dates = mintEvents.value.map(e => e.date).filter((d): d is string => !!d).sort();
+    return dates.at(-1) ?? credit.value?.mintDate ?? null;
+});
 
 const hashscanTokenUrl = computed(
     () => `https://hashscan.io/${network.value}/token/${tokenId.value}`,
+);
+
+// ─── Advanced tab ─────────────────────────────────────────────────────────────
+
+const tokenMessage = computed(() => data.value?.tokenMessage ?? null);
+const policyTopicId = computed(() => data.value?.policyTopicId ?? null);
+const mintTokenId = computed<string | null>(() => (tokenMessage.value?.options?.tokenId as string) ?? null);
+const tokenCreatedDate = computed<string | null>(() => (tokenMessage.value?.consensusTimestamp as string) ?? null);
+const issueDid = computed<string | null>(() => (tokenMessage.value?.owner as string) ?? null);
+
+const policyHashscanUrl = computed(() =>
+    policyTopicId.value ? `https://hashscan.io/${network.value}/topic/${policyTopicId.value}` : null,
+);
+const mintTokenHashscanUrl = computed(() =>
+    mintTokenId.value ? `https://hashscan.io/${network.value}/token/${mintTokenId.value}` : null,
 );
 
 const typeColor: Record<string, string> = {
@@ -370,10 +385,10 @@ function viewRawVc(title: string, doc: Record<string, any> | null) {
                 </div>
                 <div class="bg-card px-5 py-4">
                     <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
-                        {{ $t('credits.detail.firstMintDate') }}
+                        {{ $t('credits.detail.lastMintDate') }}
                     </div>
                     <div class="text-sm font-medium text-foreground">
-                        {{ firstMintDate ? formatDate(firstMintDate) : '—' }}
+                        {{ lastMintDate ? formatDate(lastMintDate) : '—' }}
                     </div>
                 </div>
             </div>
@@ -659,6 +674,70 @@ function viewRawVc(title: string, doc: Record<string, any> | null) {
                             {{ credit.registry }}
                         </NuxtLink>
                         <span v-else class="text-sm text-muted-foreground">{{ $t('credits.detail.noRegistry') }}</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Advanced tab: raw Token-message-derived blockchain details -->
+            <div v-else-if="activeTab === 'advanced'" class="p-6 space-y-6">
+                <div class="rounded-xl border bg-card overflow-hidden">
+                    <div class="px-5 py-3.5 border-b bg-muted/30">
+                        <h2 class="text-sm font-semibold text-foreground flex items-center gap-2">
+                            <Shield class="h-4 w-4 text-primary" />
+                            {{ $t('credits.detail.advanced.title') }}
+                        </h2>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-px bg-border">
+                        <div class="bg-card px-5 py-4">
+                            <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
+                                {{ $t('credits.detail.advanced.tokenPolicy') }}
+                            </div>
+                            <div class="flex items-center gap-2 flex-wrap">
+                                <code class="text-sm font-mono text-foreground break-all">{{ policyTopicId ?? '—' }}</code>
+                                <a
+                                    v-if="policyHashscanUrl"
+                                    :href="policyHashscanUrl"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                                >
+                                    <ExternalLink class="h-3 w-3" />
+                                    {{ $t('common.viewOnHashScan') }}
+                                </a>
+                            </div>
+                        </div>
+                        <div class="bg-card px-5 py-4">
+                            <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
+                                {{ $t('credits.detail.advanced.mintTokenId') }}
+                            </div>
+                            <a
+                                v-if="mintTokenHashscanUrl"
+                                :href="mintTokenHashscanUrl"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline transition-colors"
+                            >
+                                <ExternalLink class="h-3.5 w-3.5" />
+                                {{ $t('common.viewOnHashScan') }}
+                            </a>
+                            <span v-else class="text-sm font-medium text-foreground">—</span>
+                        </div>
+                        <div class="bg-card px-5 py-4">
+                            <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
+                                {{ $t('credits.detail.advanced.tokenCreatedDate') }}
+                            </div>
+                            <div class="text-sm font-medium text-foreground">
+                                {{ tokenCreatedDate ? formatDate(tokenCreatedDate) : '—' }}
+                            </div>
+                        </div>
+                        <div class="bg-card px-5 py-4">
+                            <div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
+                                {{ $t('credits.detail.advanced.issueDid') }}
+                            </div>
+                            <div class="text-sm font-medium text-foreground font-mono break-all">
+                                {{ issueDid ?? '—' }}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -292,7 +292,7 @@ async function downloadCredits() {
 
                         <!-- Data rows -->
                         <template v-else>
-                            <tr v-for="c in paginated" :key="`${c.tokenId}|${c.projectId ?? ''}`" class="hover:bg-muted/30 transition-colors cursor-pointer" @click="navigateTo(`/credits/${encodeURIComponent(c.tokenId)}`)">
+                            <tr v-for="c in paginated" :key="`${c.tokenId}|${c.projectId ?? ''}`" class="hover:bg-muted/30 transition-colors cursor-pointer" @click="navigateTo(c.projectId ? `/credits/${encodeURIComponent(c.tokenId)}?projectId=${encodeURIComponent(c.projectId)}` : `/credits/${encodeURIComponent(c.tokenId)}`)">
                                 <td class="py-3 px-4 whitespace-nowrap">
                                     <div class="font-medium text-foreground">{{ c.name ?? '-' }}</div>
                                     <div class="text-[11px] text-muted-foreground/60 font-mono">{{ c.tokenId ?? '-' }}</div>

--- a/sustainable-explorer/src/api/repositories/credit.repository.ts
+++ b/sustainable-explorer/src/api/repositories/credit.repository.ts
@@ -60,6 +60,12 @@ export interface CreditRawDetail {
     projects: CreditProjectLink[];
     /** Raw Token-issue message from HCS (one row from `message` table). */
     tokenMessage: Record<string, unknown> | null;
+    /** Policy ID governing this token, resolved via the linked project's originating VC message. Null when no project is attributed or its VC has no policyId. */
+    policyId: string | null;
+    /** Resolved policy display name (Instance-Policy options.name), joined via policyId -> policy. Null when unresolved. */
+    policyName: string | null;
+    /** Hedera topic id of the governing policy (policy.policyTopicId), for the HashScan link. Null when the policy is unresolved. */
+    policyTopicId: string | null;
     /** MintToken VC documents that issued tokens against this tokenId. */
     mintEvents: Array<{
         consensusTimestamp: string;

--- a/sustainable-explorer/src/api/repositories/pg-credit.repository.ts
+++ b/sustainable-explorer/src/api/repositories/pg-credit.repository.ts
@@ -402,6 +402,50 @@ export class PgCreditRepository extends CreditRepository {
         );
         const tokenMessage = tokenMessageRows[0] ?? null;
 
+        // 2b. Resolve the policy governing this token via its linked
+        //     project's originating VC message. The Token-creation message
+        //     and MintToken VCs never carry a policyId at the Guardian
+        //     source — only "project-shaped" VCs (registration, monitoring,
+        //     etc.) do, per ipfs-fetch.processor.ts's stamping logic.
+        //     business_view.sourceTimestamp is the consensusTimestamp of
+        //     that originating VC, so joining back to `message` on it
+        //     recovers the policyId. Both queries are conditional (skipped
+        //     entirely when there's no attributed project / no policyId),
+        //     and both join columns are indexed (business_view.projectKey
+        //     has a unique partial index, message.consensusTimestamp is
+        //     unique, policy.policyId has a unique index).
+        let policyId: string | null = null;
+        let policyName: string | null = null;
+        let policyTopicId: string | null = null;
+        if (credit?.projectId) {
+            const projectPolicyRows: Array<{ policyId: string | null }> = await this.dataSource.query(
+                `SELECT m."policyId"
+                 FROM business_view bv
+                 JOIN message m ON m."consensusTimestamp" = bv."sourceTimestamp"
+                 WHERE bv."viewType" = 'PROJECT' AND bv."projectKey" = $1
+                 LIMIT 1`,
+                [credit.projectId],
+            );
+            policyId = projectPolicyRows[0]?.policyId ?? null;
+        }
+        if (policyId) {
+            const policyNameRows: Array<{ policyName: string | null; policyTopicId: string | null }> = await this.dataSource.query(
+                `SELECT ip.options->>'name' AS "policyName",
+                        p."policyTopicId"   AS "policyTopicId"
+                 FROM policy p
+                 JOIN message ip
+                     ON ip.type = 'Instance-Policy'
+                    AND ip.action = 'publish-policy'
+                    AND ip."topicId" = p."policyTopicId"
+                 WHERE p."policyId" = $1
+                 ORDER BY ip."consensusTimestamp" DESC
+                 LIMIT 1`,
+                [policyId],
+            );
+            policyName = policyNameRows[0]?.policyName ?? null;
+            policyTopicId = policyNameRows[0]?.policyTopicId ?? null;
+        }
+
         // 3. MintToken VC documents that minted credits for this tokenId.
         const mintRows: Array<{
             consensusTimestamp: string;
@@ -459,6 +503,9 @@ export class PgCreditRepository extends CreditRepository {
             credit,
             projects,
             tokenMessage,
+            policyId,
+            policyName,
+            policyTopicId,
             mintEvents: mintRows,
         };
     }


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-129

<img width="1602" height="596" alt="image" src="https://github.com/user-attachments/assets/a7b01cc9-3dcd-455c-b4a2-4d93f0b0d389" />


Added a new Advanced tab to the credit/token Issuance Details page (/credits/[id]), exposing blockchain-level details that weren't previously surfaced in the UI:

- Token Policy ID — the Hedera topic ID the governing Guardian policy was published to (not the internal Guardian policy UUID, which isn't a valid HashScan resource), with a "View on HashScan" button linking to hashscan.io/{network}/topic/{policyTopicId}.
- Mint Token — a "View on HashScan" link to the minted token on hashscan.io/{network}/token/{mintTokenId}.
- Token Created Date and Issue DID — plain display fields, sourced from the token's HCS creation message.
- Tab icon (Shield) matches the equivalent "Hedera Policy" tab on the Methodology Details page for visual consistency.