### PR TITLE
feat: add saved search for Projects and Issuances filters

### DIFF
--- a/sustainable-explorer/.env.example
+++ b/sustainable-explorer/.env.example
@@ -350,6 +350,11 @@ FRONTEND_SHARED_SECRET=
 # Max ACTIVE API keys a single user may hold. Leave blank to use the code default (3).
 API_KEY_MAX_ACTIVE_PER_USER=
 
+# Max saved searches (quick filters) a single user may hold per network+section.
+# Leave blank to use the code default (10). The frontend reads this same value
+# back from the list endpoint response — no separate frontend config needed.
+QUICK_FILTERS_MAX_PER_USER=
+
 # Redis-backed throttler. When true, every request is rate-limited per hour: by
 # user (apiQuotaPerHour or role default) when authenticated, else by IP
 # (RATE_LIMIT_GUEST_PER_HOUR). Redis errors fail OPEN. Needs Redict running.

--- a/sustainable-explorer/frontend/components/saved-search/SaveSearchDialog.vue
+++ b/sustainable-explorer/frontend/components/saved-search/SaveSearchDialog.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { X } from 'lucide-vue-next';
+
+const props = defineProps<{
+    open: boolean;
+    summary: { label: string; value: string }[];
+    /** Name of an existing saved search whose criteria exactly match the current filters, if any. */
+    existingMatchName?: string | null;
+}>();
+const emit = defineEmits<{ close: []; save: [name: string] }>();
+
+const name = ref('');
+const error = ref('');
+const saving = ref(false);
+
+watch(() => props.open, (isOpen) => {
+    if (isOpen) { name.value = ''; error.value = ''; saving.value = false; }
+});
+
+async function onSave() {
+    if (!name.value.trim()) return;
+    saving.value = true;
+    error.value = '';
+    emit('save', name.value.trim());
+}
+
+// Called by the parent after the save() API call resolves, to show a 409/validation error inline.
+defineExpose({
+    setError(message: string) { error.value = message; saving.value = false; },
+});
+</script>
+
+<template>
+    <Teleport to="body">
+        <Transition
+            enter-active-class="transition ease-out duration-150" enter-from-class="opacity-0" enter-to-class="opacity-100"
+            leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0"
+        >
+            <div v-if="open" class="fixed inset-0 z-[2000] flex items-center justify-center bg-black/50 p-4">
+                <div class="w-full max-w-md rounded-lg border bg-background p-6 shadow-xl">
+                    <div class="mb-4 flex items-start justify-between">
+                        <div>
+                            <h2 class="text-lg font-semibold text-foreground">{{ $t('savedSearch.dialogTitle') }}</h2>
+                            <p class="mt-0.5 text-sm text-muted-foreground">{{ $t('savedSearch.dialogSubtitle') }}</p>
+                        </div>
+                        <button class="rounded-md p-1 text-muted-foreground hover:bg-muted" @click="emit('close')">
+                            <X class="h-4 w-4" />
+                        </button>
+                    </div>
+
+                    <div v-if="existingMatchName" class="rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:bg-amber-950/30 dark:text-amber-300">
+                        {{ $t('savedSearch.duplicateCriteria', { name: existingMatchName }) }}
+                    </div>
+
+                    <template v-else>
+                        <label class="text-xs font-medium text-muted-foreground">{{ $t('savedSearch.nameLabel') }}</label>
+                        <input
+                            v-model="name"
+                            maxlength="30"
+                            class="mt-1 h-9 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                            :placeholder="$t('savedSearch.namePlaceholder')"
+                            @keydown.enter="onSave"
+                        />
+                        <div class="mt-1 flex items-center justify-between text-[11px] text-muted-foreground">
+                            <span v-if="error" class="text-destructive">{{ error }}</span>
+                            <span class="ml-auto">{{ name.length }}/30</span>
+                        </div>
+                    </template>
+
+                    <div class="mt-4">
+                        <p class="text-xs font-medium text-muted-foreground mb-1.5">{{ $t('savedSearch.summaryTitle') }}</p>
+                        <div class="flex flex-wrap gap-1.5 rounded-md bg-muted/40 p-2">
+                            <span
+                                v-for="item in summary" :key="item.label"
+                                class="rounded-md bg-background border px-2 py-0.5 text-[11px] text-foreground"
+                            >
+                                {{ item.label }}: <strong>{{ item.value }}</strong>
+                            </span>
+                        </div>
+                    </div>
+
+                    <div class="mt-6 flex justify-end gap-2">
+                        <button class="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted" @click="emit('close')">
+                            {{ existingMatchName ? $t('savedSearch.ok') : $t('savedSearch.cancel') }}
+                        </button>
+                        <button
+                            v-if="!existingMatchName"
+                            :disabled="!name.trim() || saving"
+                            class="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+                            @click="onSave"
+                        >
+                            {{ $t('savedSearch.saveButton') }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Transition>
+    </Teleport>
+</template>

--- a/sustainable-explorer/frontend/components/saved-search/SavedSearchTag.vue
+++ b/sustainable-explorer/frontend/components/saved-search/SavedSearchTag.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { X } from 'lucide-vue-next';
+
+defineProps<{ label: string; active: boolean }>();
+const emit = defineEmits<{ select: []; remove: [] }>();
+</script>
+
+<template>
+    <span
+        :class="[
+            'inline-flex items-center gap-1 rounded-full border pl-2.5 pr-1 py-0.5 text-[11px] font-medium transition-colors',
+            active
+                ? 'border-primary/50 bg-primary/10 text-primary'
+                : 'border-primary/25 text-muted-foreground hover:bg-muted hover:text-foreground',
+        ]"
+    >
+        <button class="max-w-[140px] truncate" @click="emit('select')">{{ label }}</button>
+        <button
+            class="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full hover:text-foreground"
+            @click.stop="emit('remove')"
+        >
+            <X class="h-2.5 w-2.5" />
+        </button>
+    </span>
+</template>

--- a/sustainable-explorer/frontend/components/saved-search/SavedSearchTag.vue
+++ b/sustainable-explorer/frontend/components/saved-search/SavedSearchTag.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { X } from 'lucide-vue-next';
+import { Trash2 } from 'lucide-vue-next';
 
 defineProps<{ label: string; active: boolean }>();
 const emit = defineEmits<{ select: []; remove: [] }>();
@@ -16,10 +16,10 @@ const emit = defineEmits<{ select: []; remove: [] }>();
     >
         <button class="max-w-[140px] truncate" @click="emit('select')">{{ label }}</button>
         <button
-            class="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full hover:text-foreground"
+            class="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full hover:text-destructive"
             @click.stop="emit('remove')"
         >
-            <X class="h-2.5 w-2.5" />
+            <Trash2 class="h-2.5 w-2.5" />
         </button>
     </span>
 </template>

--- a/sustainable-explorer/frontend/components/saved-search/SavedSearchesRow.vue
+++ b/sustainable-explorer/frontend/components/saved-search/SavedSearchesRow.vue
@@ -15,7 +15,12 @@ const emit = defineEmits<{ apply: [criteria: SavedSearchCriteria] }>();
 
 const { isAuthenticated } = useAuth();
 const { network } = useNetwork();
-const { savedSearches, fetchAll, save, remove } = useSavedSearches(props.section);
+const { savedSearches, loading, fetchAll, save, remove } = useSavedSearches(props.section);
+
+// Guests never have saved searches to fetch, so this is immediately true for
+// them (no flash); for a logged-in user it's suppressed while the initial
+// fetch is in flight so it doesn't flicker on before the real list arrives.
+const showEmptyState = computed(() => !loading.value && savedSearches.value.length === 0);
 
 onMounted(fetchAll);
 // Re-fetch if the user logs in while already on the page.
@@ -105,6 +110,10 @@ defineExpose({
                 @remove="remove(s.id)"
             />
         </template>
+
+        <span v-if="showEmptyState" class="text-[11px] text-muted-foreground">
+            {{ $t('savedSearch.empty') }}
+        </span>
 
         <SaveSearchDialog
             v-if="isAuthenticated"

--- a/sustainable-explorer/frontend/components/saved-search/SavedSearchesRow.vue
+++ b/sustainable-explorer/frontend/components/saved-search/SavedSearchesRow.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { useSavedSearches, type SavedSearchCriteria } from '~/composables/useSavedSearches';
+import SaveSearchDialog from './SaveSearchDialog.vue';
+
+const props = defineProps<{
+    section: 'projects' | 'methodologies' | 'issuances';
+    searchQuery: string;
+    activeFilters: Record<string, string>;
+    sortKey?: string | null;
+    sortDir?: 'asc' | 'desc' | null;
+    summary: { label: string; value: string }[];
+}>();
+
+const emit = defineEmits<{ apply: [criteria: SavedSearchCriteria] }>();
+
+const { isAuthenticated } = useAuth();
+const { network } = useNetwork();
+const { savedSearches, fetchAll, save, remove } = useSavedSearches(props.section);
+
+onMounted(fetchAll);
+// Re-fetch if the user logs in while already on the page.
+watch(isAuthenticated, (v) => { if (v) fetchAll(); });
+// Re-fetch when the Mainnet/Testnet selection changes — saved searches are
+// network-scoped, and switching networks doesn't remount this component
+// (useNetwork().setNetwork() only does a router.replace with a new query).
+watch(network, () => { if (isAuthenticated.value) fetchAll(); });
+
+const hasActiveFilters = computed(() =>
+    !!props.searchQuery.trim() || Object.values(props.activeFilters).some(v => v && v !== 'all'),
+);
+
+function currentCriteria(): SavedSearchCriteria {
+    return {
+        search: props.searchQuery || undefined,
+        filters: { ...props.activeFilters },
+        sort: props.sortKey && props.sortDir ? { key: props.sortKey, dir: props.sortDir } : undefined,
+    };
+}
+
+// Order-independent comparisons — jsonb doesn't preserve object key order on
+// a DB round trip, and even in-session two identical filter selections can
+// end up with keys inserted in a different order, so JSON.stringify() on the
+// raw objects is not a safe equality check here.
+function filtersMatch(a: Record<string, string>, b: Record<string, string>): boolean {
+    const isSet = (v: string | undefined) => !!v && v !== 'all';
+    const aKeys = Object.keys(a).filter(k => isSet(a[k]));
+    const bKeys = Object.keys(b).filter(k => isSet(b[k]));
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(k => a[k] === b[k]);
+}
+
+function sortMatches(
+    a: SavedSearchCriteria['sort'],
+    b: SavedSearchCriteria['sort'],
+): boolean {
+    if (!a && !b) return true;
+    if (!a || !b) return false;
+    return a.key === b.key && a.dir === b.dir;
+}
+
+function criteriaMatches(a: SavedSearchCriteria, b: SavedSearchCriteria): boolean {
+    return (a.search || '') === (b.search || '')
+        && filtersMatch(a.filters, b.filters)
+        && sortMatches(a.sort, b.sort);
+}
+
+const activeSearch = computed(() =>
+    savedSearches.value.find(s => criteriaMatches(s.criteria, currentCriteria())),
+);
+
+const dialogOpen = ref(false);
+const dialogRef = ref<InstanceType<typeof SaveSearchDialog> | null>(null);
+
+async function onSaveConfirmed(name: string) {
+    const result = await save(name, currentCriteria());
+    if (typeof result === 'string') {
+        dialogRef.value?.setError(result);
+    } else {
+        dialogOpen.value = false;
+    }
+}
+
+function onSelect(search: (typeof savedSearches.value)[number]) {
+    emit('apply', search.criteria);
+}
+
+// The "Save Search" trigger button lives in the parent's FilterBar row (same
+// row as the search input), not here — this component only owns the tag list
+// + active label + dialog. The parent opens the dialog via this template ref.
+defineExpose({
+    open() { dialogOpen.value = true; },
+    hasActiveFilters,
+});
+</script>
+
+<template>
+    <div class="flex items-center gap-2 flex-wrap">
+        <template v-if="isAuthenticated">
+            <SavedSearchTag
+                v-for="s in savedSearches" :key="s.id"
+                :label="s.name"
+                :active="!!activeSearch && activeSearch.id === s.id"
+                @select="onSelect(s)"
+                @remove="remove(s.id)"
+            />
+        </template>
+
+        <SaveSearchDialog
+            v-if="isAuthenticated"
+            ref="dialogRef"
+            :open="dialogOpen"
+            :summary="summary"
+            :existing-match-name="activeSearch?.name ?? null"
+            @close="dialogOpen = false"
+            @save="onSaveConfirmed"
+        />
+    </div>
+    <p v-if="activeSearch" class="mt-1 text-[11px] text-muted-foreground">
+        {{ $t('savedSearch.activeLabel') }}: <strong class="text-foreground">{{ activeSearch.name }}</strong>
+    </p>
+</template>

--- a/sustainable-explorer/frontend/components/saved-search/SavedSearchesRow.vue
+++ b/sustainable-explorer/frontend/components/saved-search/SavedSearchesRow.vue
@@ -86,7 +86,8 @@ function onSelect(search: (typeof savedSearches.value)[number]) {
 
 // The "Save Search" trigger button lives in the parent's FilterBar row (same
 // row as the search input), not here — this component only owns the tag list
-// + active label + dialog. The parent opens the dialog via this template ref.
+// + dialog (the active tag itself is the only "currently active" indicator;
+// no separate text label). The parent opens the dialog via this template ref.
 defineExpose({
     open() { dialogOpen.value = true; },
     hasActiveFilters,
@@ -115,7 +116,4 @@ defineExpose({
             @save="onSaveConfirmed"
         />
     </div>
-    <p v-if="activeSearch" class="mt-1 text-[11px] text-muted-foreground">
-        {{ $t('savedSearch.activeLabel') }}: <strong class="text-foreground">{{ activeSearch.name }}</strong>
-    </p>
 </template>

--- a/sustainable-explorer/frontend/components/saved-search/SavedSearchesRow.vue
+++ b/sustainable-explorer/frontend/components/saved-search/SavedSearchesRow.vue
@@ -15,7 +15,12 @@ const emit = defineEmits<{ apply: [criteria: SavedSearchCriteria] }>();
 
 const { isAuthenticated } = useAuth();
 const { network } = useNetwork();
-const { savedSearches, loading, fetchAll, save, remove } = useSavedSearches(props.section);
+const { savedSearches, limit: savedSearchLimit, loading, fetchAll, save, remove } = useSavedSearches(props.section);
+
+// Max saved searches per user (per network+section, matching how the whole
+// feature is scoped) — fetched from the backend alongside the list itself
+// (single source of truth, no separate frontend config to drift out of sync).
+const atSavedSearchLimit = computed(() => savedSearches.value.length >= savedSearchLimit.value);
 
 // Guests never have saved searches to fetch, so this is immediately true for
 // them (no flash); for a logged-in user it's suppressed while the initial
@@ -94,8 +99,10 @@ function onSelect(search: (typeof savedSearches.value)[number]) {
 // + dialog (the active tag itself is the only "currently active" indicator;
 // no separate text label). The parent opens the dialog via this template ref.
 defineExpose({
-    open() { dialogOpen.value = true; },
+    open() { if (!atSavedSearchLimit.value) dialogOpen.value = true; },
     hasActiveFilters,
+    atLimit: atSavedSearchLimit,
+    limit: savedSearchLimit,
 });
 </script>
 

--- a/sustainable-explorer/frontend/components/shared/FilterBar.vue
+++ b/sustainable-explorer/frontend/components/shared/FilterBar.vue
@@ -509,10 +509,14 @@ if (import.meta.client) {
              Data buttons) so adding this doesn't affect other FilterBar usages. -->
         <slot name="before-clear" />
 
-        <!-- Clear filters -->
+        <!-- Clear filters. No horizontal padding: the parent's `gap-2` already
+             spaces flex children, but that gap sits outside a pill button's
+             border while it would sit outside this borderless button's own
+             padding too — doubling the visible gap. Dropping px-* here keeps
+             the gap visually equal to the gap between two bordered pills. -->
         <button
             v-if="hasActiveFilters"
-            class="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:text-destructive transition-colors"
+            class="inline-flex items-center gap-1 rounded-md py-1.5 text-xs text-muted-foreground hover:text-destructive transition-colors"
             @click="emit('clear')"
         >
             <X class="h-3 w-3" />

--- a/sustainable-explorer/frontend/components/shared/FilterBar.vue
+++ b/sustainable-explorer/frontend/components/shared/FilterBar.vue
@@ -503,10 +503,16 @@ if (import.meta.client) {
             </Transition>
         </div>
 
+        <!-- Extra text-style action (e.g. Save Search) rendered immediately
+             before Clear, matching its plain-text look. Distinct from the
+             default slot below (which stays right-aligned for e.g. Download
+             Data buttons) so adding this doesn't affect other FilterBar usages. -->
+        <slot name="before-clear" />
+
         <!-- Clear filters -->
         <button
             v-if="hasActiveFilters"
-            class="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            class="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:text-destructive transition-colors"
             @click="emit('clear')"
         >
             <X class="h-3 w-3" />

--- a/sustainable-explorer/frontend/components/shared/InfoTooltip.vue
+++ b/sustainable-explorer/frontend/components/shared/InfoTooltip.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
 import { Info } from 'lucide-vue-next';
 
-defineProps<{
+const props = defineProps<{
     text: string;
 }>();
+
+// Default usage (no slot content) renders the standalone Info icon as its own
+// trigger, as before. Passing content via the default slot instead lets this
+// same floating-tooltip design wrap an existing interactive element (e.g. a
+// button) — in that case we don't want the icon-only affordances (help
+// cursor, swallowing the click) since they'd fight with the wrapped control.
+const slots = useSlots();
+const hasCustomTrigger = computed(() => !!slots.default);
 
 const show = ref(false);
 const triggerRef = ref<HTMLElement | null>(null);
@@ -34,6 +42,7 @@ function updatePosition() {
 }
 
 function onEnter() {
+    if (!props.text) return; // e.g. a wrapped button that's only conditionally at-limit
     updatePosition();
     show.value = true;
 }
@@ -41,17 +50,27 @@ function onEnter() {
 function onLeave() {
     show.value = false;
 }
+
+// Only swallow the click for the icon-only trigger — that's needed so clicking
+// the icon doesn't also activate whatever it's sitting next to (e.g. a
+// checkbox's <label>). When wrapping real interactive content, clicks must
+// bubble normally (e.g. FilterBar's click-outside-to-close listener).
+function onClick(e: MouseEvent) {
+    if (!hasCustomTrigger.value) e.stopPropagation();
+}
 </script>
 
 <template>
     <span
         ref="triggerRef"
-        class="inline-flex cursor-help"
+        :class="['inline-flex', !hasCustomTrigger && 'cursor-help']"
         @mouseenter="onEnter"
         @mouseleave="onLeave"
-        @click.stop
+        @click="onClick"
     >
-        <Info class="h-3 w-3 text-muted-foreground/40 hover:text-muted-foreground transition-colors" />
+        <slot>
+            <Info class="h-3 w-3 text-muted-foreground/40 hover:text-muted-foreground transition-colors" />
+        </slot>
 
         <Teleport to="body">
             <Transition
@@ -63,7 +82,7 @@ function onLeave() {
                 leave-to-class="opacity-0"
             >
                 <div
-                    v-if="show"
+                    v-if="show && text"
                     :style="tooltipStyle"
                     class="pointer-events-none"
                 >

--- a/sustainable-explorer/frontend/composables/useSavedSearches.ts
+++ b/sustainable-explorer/frontend/composables/useSavedSearches.ts
@@ -42,7 +42,9 @@ export function useSavedSearches(section: 'projects' | 'methodologies' | 'issuan
     };
 
     const savedSearches = ref<SavedSearch[]>([]);
-    const loading = ref(false);
+    // Starts true for a logged-in user so a consumer's empty-state message
+    // doesn't flash on before the initial fetchAll() (called from onMounted) resolves.
+    const loading = ref(isAuthenticated.value);
 
     async function fetchAll(): Promise<void> {
         if (!isAuthenticated.value || !import.meta.client) return;

--- a/sustainable-explorer/frontend/composables/useSavedSearches.ts
+++ b/sustainable-explorer/frontend/composables/useSavedSearches.ts
@@ -1,0 +1,98 @@
+/**
+ * Saved Search composable — one independent list per page section.
+ *
+ * Mirrors usePortfolioSync.ts's baseURL()/CSRF-cookie pattern exactly (same
+ * server/client baseURL split, same non-httpOnly `csrf` cookie read for the
+ * double-submit header on mutating calls).
+ *
+ * Parameterized by `section` (not a useState singleton) since Projects and
+ * Issuances each need their own independent saved-search list.
+ */
+export interface SavedSearchCriteria {
+    search?: string;
+    filters: Record<string, string>;
+    sort?: { key: string; dir: 'asc' | 'desc' };
+}
+
+export interface SavedSearch {
+    id: string;
+    name: string;
+    criteria: SavedSearchCriteria;
+    createdAt: string;
+}
+
+export function useSavedSearches(section: 'projects' | 'methodologies' | 'issuances') {
+    const { isAuthenticated } = useAuth();
+    const { apiFetch } = useApiFetch();
+    const { network } = useNetwork();
+    const config = useRuntimeConfig();
+    const { t } = useI18n();
+
+    const baseURL = (): string =>
+        import.meta.server
+            ? (config.apiBaseUrl as string)
+            : (config.public.apiBaseUrl as string);
+
+    // readCsrfCookie() in useAuth.ts is a local closure (not exported).
+    // Re-implemented here with the same regex, same as usePortfolioSync.ts.
+    const readCsrfCookie = (): string => {
+        if (!import.meta.client) return '';
+        const match = document.cookie.match(/(?:^|;\s*)csrf=([^;]+)/);
+        return match ? decodeURIComponent(match[1]) : '';
+    };
+
+    const savedSearches = ref<SavedSearch[]>([]);
+    const loading = ref(false);
+
+    async function fetchAll(): Promise<void> {
+        if (!isAuthenticated.value || !import.meta.client) return;
+        loading.value = true;
+        try {
+            savedSearches.value = await apiFetch<SavedSearch[]>('/api/v1/me/quick-filters', {
+                baseURL: baseURL(),
+                credentials: 'include',
+                query: { network: network.value, section },
+            });
+        } catch {
+            savedSearches.value = [];
+        } finally {
+            loading.value = false;
+        }
+    }
+
+    /** Returns the created row, or an error message string on failure (e.g. duplicate name). */
+    async function save(name: string, criteria: SavedSearchCriteria): Promise<SavedSearch | string> {
+        try {
+            const created = await apiFetch<SavedSearch>('/api/v1/me/quick-filters', {
+                method: 'POST',
+                baseURL: baseURL(),
+                credentials: 'include',
+                headers: { 'x-csrf-token': readCsrfCookie() },
+                body: { network: network.value, section, name, criteria },
+            });
+            savedSearches.value = [...savedSearches.value, created];
+            return created;
+        } catch (err: unknown) {
+            const e = err as { response?: { status?: number; _data?: { message?: string } } };
+            if (e.response?.status === 409) return e.response._data?.message ?? t('savedSearch.duplicateName');
+            return t('savedSearch.saveError');
+        }
+    }
+
+    async function remove(id: string): Promise<void> {
+        const prior = savedSearches.value;
+        savedSearches.value = prior.filter(s => s.id !== id); // optimistic
+        try {
+            await apiFetch(`/api/v1/me/quick-filters/${id}`, {
+                method: 'DELETE',
+                baseURL: baseURL(),
+                credentials: 'include',
+                headers: { 'x-csrf-token': readCsrfCookie() },
+            });
+        } catch {
+            savedSearches.value = prior; // rollback on failure
+        }
+    }
+
+    return { savedSearches, loading, fetchAll, save, remove };
+}

--- a/sustainable-explorer/frontend/composables/useSavedSearches.ts
+++ b/sustainable-explorer/frontend/composables/useSavedSearches.ts
@@ -42,6 +42,10 @@ export function useSavedSearches(section: 'projects' | 'methodologies' | 'issuan
     };
 
     const savedSearches = ref<SavedSearch[]>([]);
+    // Backend-configured cap (QUICK_FILTERS_MAX_PER_USER), fetched alongside the
+    // list itself so there's a single source of truth — no separate frontend
+    // config to drift out of sync. Placeholder value until the first fetch resolves.
+    const limit = ref(10);
     // Starts true for a logged-in user so a consumer's empty-state message
     // doesn't flash on before the initial fetchAll() (called from onMounted) resolves.
     const loading = ref(isAuthenticated.value);
@@ -50,11 +54,13 @@ export function useSavedSearches(section: 'projects' | 'methodologies' | 'issuan
         if (!isAuthenticated.value || !import.meta.client) return;
         loading.value = true;
         try {
-            savedSearches.value = await apiFetch<SavedSearch[]>('/api/v1/me/quick-filters', {
+            const result = await apiFetch<{ items: SavedSearch[]; limit: number }>('/api/v1/me/quick-filters', {
                 baseURL: baseURL(),
                 credentials: 'include',
                 query: { network: network.value, section },
             });
+            savedSearches.value = result.items;
+            limit.value = result.limit;
         } catch {
             savedSearches.value = [];
         } finally {
@@ -96,5 +102,5 @@ export function useSavedSearches(section: 'projects' | 'methodologies' | 'issuan
         }
     }
 
-    return { savedSearches, loading, fetchAll, save, remove };
+    return { savedSearches, limit, loading, fetchAll, save, remove };
 }

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -477,13 +477,6 @@
             "developer": "Developer",
             "sdgs": "SDGs"
         },
-        "presets": {
-            "goldStandard": "Gold Standard",
-            "sdg13": "SDG 13: Climate Action",
-            "vintage2022": "Vintage 2022",
-            "issuingEnergy": "Issuing Energy",
-            "glycolRecycling": "Glycol Recycling"
-        },
         "notFound": "Project not found",
         "details": {
             "projectDetails": "Project Details",
@@ -552,12 +545,6 @@
         "searchPlaceholder": "Search issuances...",
         "quickFilters": "Quick filters:",
         "downloadData": "Download Data",
-        "presets": {
-            "fungible": "Fungible tokens",
-            "nonFungible": "Non-Fungible (NFTs)",
-            "minted2024": "Minted 2024",
-            "minted2025": "Minted 2025"
-        },
         "issuancesFound": "{count} issuances found",
         "totalSupply": "Total supply:",
         "registries": "Registries:",
@@ -653,7 +640,6 @@
         "namePlaceholder": "e.g. Gold Standard Kenya",
         "summaryTitle": "Active Filters",
         "saveButton": "Save Search",
-        "activeLabel": "Active saved search",
         "cancel": "Cancel",
         "ok": "OK",
         "duplicateName": "A saved search with this name already exists",

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -640,6 +640,7 @@
         "namePlaceholder": "e.g. Gold Standard Kenya",
         "summaryTitle": "Active Filters",
         "saveButton": "Save Search",
+        "empty": "No quick filters available",
         "cancel": "Cancel",
         "ok": "OK",
         "duplicateName": "A saved search with this name already exists",

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -645,7 +645,8 @@
         "ok": "OK",
         "duplicateName": "A saved search with this name already exists",
         "duplicateCriteria": "This exact set of filters is already saved as \"{name}\"",
-        "saveError": "Could not save search — please try again"
+        "saveError": "Could not save search — please try again",
+        "limitReachedTooltip": "You've reached the maximum of {max} saved searches"
     },
     "methodologies": {
         "title": "Methodologies",

--- a/sustainable-explorer/frontend/i18n/locales/en.json
+++ b/sustainable-explorer/frontend/i18n/locales/en.json
@@ -646,6 +646,20 @@
             "noRegistry": "No registry linked"
         }
     },
+    "savedSearch": {
+        "dialogTitle": "Save Search",
+        "dialogSubtitle": "Save your current filters to reapply them later",
+        "nameLabel": "Name",
+        "namePlaceholder": "e.g. Gold Standard Kenya",
+        "summaryTitle": "Active Filters",
+        "saveButton": "Save Search",
+        "activeLabel": "Active saved search",
+        "cancel": "Cancel",
+        "ok": "OK",
+        "duplicateName": "A saved search with this name already exists",
+        "duplicateCriteria": "This exact set of filters is already saved as \"{name}\"",
+        "saveError": "Could not save search — please try again"
+    },
     "methodologies": {
         "title": "Methodologies",
         "subtitle": "Published policy workflows for sustainability verification",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -640,7 +640,8 @@
         "ok": "Aceptar",
         "duplicateName": "Ya existe una búsqueda guardada con este nombre",
         "duplicateCriteria": "Este conjunto exacto de filtros ya está guardado como \"{name}\"",
-        "saveError": "No se pudo guardar la búsqueda. Inténtalo de nuevo"
+        "saveError": "No se pudo guardar la búsqueda. Inténtalo de nuevo",
+        "limitReachedTooltip": "Has alcanzado el máximo de {max} búsquedas guardadas"
     },
     "methodologies": {
         "title": "Metodologías",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -641,6 +641,20 @@
             "noRegistry": "Sin registro vinculado"
         }
     },
+    "savedSearch": {
+        "dialogTitle": "Guardar búsqueda",
+        "dialogSubtitle": "Guarda tus filtros actuales para volver a aplicarlos más tarde",
+        "nameLabel": "Nombre",
+        "namePlaceholder": "p. ej. Gold Standard Kenia",
+        "summaryTitle": "Filtros activos",
+        "saveButton": "Guardar búsqueda",
+        "activeLabel": "Búsqueda guardada activa",
+        "cancel": "Cancelar",
+        "ok": "Aceptar",
+        "duplicateName": "Ya existe una búsqueda guardada con este nombre",
+        "duplicateCriteria": "Este conjunto exacto de filtros ya está guardado como \"{name}\"",
+        "saveError": "No se pudo guardar la búsqueda. Inténtalo de nuevo"
+    },
     "methodologies": {
         "title": "Metodologías",
         "subtitle": "Flujos de trabajo de políticas publicados para la verificación de sostenibilidad",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -635,6 +635,7 @@
         "namePlaceholder": "p. ej. Gold Standard Kenia",
         "summaryTitle": "Filtros activos",
         "saveButton": "Guardar búsqueda",
+        "empty": "No hay filtros rápidos disponibles",
         "cancel": "Cancelar",
         "ok": "Aceptar",
         "duplicateName": "Ya existe una búsqueda guardada con este nombre",

--- a/sustainable-explorer/frontend/i18n/locales/es.json
+++ b/sustainable-explorer/frontend/i18n/locales/es.json
@@ -477,13 +477,6 @@
             "developer": "Desarrollador",
             "sdgs": "ODS"
         },
-        "presets": {
-            "goldStandard": "Gold Standard",
-            "sdg13": "ODS 13: Acción por el clima",
-            "vintage2022": "Añada 2022",
-            "issuingEnergy": "Emitiendo Energía",
-            "glycolRecycling": "Reciclaje de Glicol"
-        },
         "notFound": "Proyecto no encontrado",
         "details": {
             "projectDetails": "Detalles del proyecto",
@@ -547,12 +540,6 @@
         "searchPlaceholder": "Buscar emisiones...",
         "quickFilters": "Filtros rápidos:",
         "downloadData": "Descargar datos",
-        "presets": {
-            "fungible": "Tokens fungibles",
-            "nonFungible": "No fungibles (NFTs)",
-            "minted2024": "Acuñados en 2024",
-            "minted2025": "Acuñados en 2025"
-        },
         "issuancesFound": "{count} emisiones encontradas",
         "totalSupply": "Suministro total:",
         "registries": "Registros:",
@@ -648,7 +635,6 @@
         "namePlaceholder": "p. ej. Gold Standard Kenia",
         "summaryTitle": "Filtros activos",
         "saveButton": "Guardar búsqueda",
-        "activeLabel": "Búsqueda guardada activa",
         "cancel": "Cancelar",
         "ok": "Aceptar",
         "duplicateName": "Ya existe una búsqueda guardada con este nombre",

--- a/sustainable-explorer/frontend/nuxt.config.ts
+++ b/sustainable-explorer/frontend/nuxt.config.ts
@@ -44,6 +44,7 @@ export default defineNuxtConfig({
         { path: '~/components/auth', pathPrefix: false },
         { path: '~/components/admin', pathPrefix: false },
         { path: '~/components/account', pathPrefix: false },
+        { path: '~/components/saved-search', pathPrefix: false },
     ],
 
     imports: {

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -249,15 +249,24 @@ async function downloadCredits() {
         <div class="px-6 pb-3">
             <FilterBar v-model="searchQuery" :filters="filters" :active-filters="activeFilters" :result-count="filtered.length" :total-count="total" :search-placeholder="$t('credits.searchPlaceholder')" @filter="setFilter" @clear="clearFilters">
                 <template #before-clear>
-                    <button
+                    <InfoTooltip
                         v-if="isAuthenticated"
                         v-show="savedSearchesRef?.hasActiveFilters"
-                        class="inline-flex items-center gap-1 rounded-md py-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
-                        @click="savedSearchesRef?.open()"
+                        :text="savedSearchesRef?.atLimit ? $t('savedSearch.limitReachedTooltip', { max: savedSearchesRef?.limit }) : ''"
                     >
-                        <Save class="h-3 w-3" />
-                        {{ $t('savedSearch.saveButton') }}
-                    </button>
+                        <button
+                            :class="[
+                                'inline-flex items-center gap-1 rounded-md py-1.5 text-xs transition-colors',
+                                savedSearchesRef?.atLimit
+                                    ? 'text-muted-foreground/50 cursor-not-allowed'
+                                    : 'text-muted-foreground hover:text-primary',
+                            ]"
+                            @click="!savedSearchesRef?.atLimit && savedSearchesRef?.open()"
+                        >
+                            <Save class="h-3 w-3" />
+                            {{ $t('savedSearch.saveButton') }}
+                        </button>
+                    </InfoTooltip>
                 </template>
             </FilterBar>
             <label class="mt-2 inline-flex items-center gap-2 text-xs text-muted-foreground select-none cursor-pointer">

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { FileJson, Sparkles, Download, Loader2, Bookmark } from 'lucide-vue-next';
+import { FileJson, Sparkles, Download, Loader2, Save } from 'lucide-vue-next';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import { formatCredits } from '~/lib/format';
 import { naturalCompare } from '~/lib/utils';
@@ -84,12 +84,6 @@ const { searchQuery, currentPage, paginated, filtered, totalPages, pageSize, act
         excludeFromQuery: ['projectKey', 'methodologyId', 'linkedOnly', 'registryDid'],
     });
 
-const presets = computed(() => [
-    { label: t('credits.presets.fungible'), filters: { type: 'Fungible' } as Record<string, string> },
-    { label: t('credits.presets.nonFungible'), filters: { type: 'Non-Fungible' } as Record<string, string> },
-    { label: t('credits.presets.minted2024'), filters: { mintDate: '2024-01-01|2024-12-31' } as Record<string, string> },
-    { label: t('credits.presets.minted2025'), filters: { mintDate: '2025-01-01|2025-12-31' } as Record<string, string> },
-]);
 
 const skeletonRows = computed(() => Array.from({ length: pageSize.value }, (_, i) => i));
 
@@ -254,15 +248,17 @@ async function downloadCredits() {
 
         <div class="px-6 pb-3">
             <FilterBar v-model="searchQuery" :filters="filters" :active-filters="activeFilters" :result-count="filtered.length" :total-count="total" :search-placeholder="$t('credits.searchPlaceholder')" @filter="setFilter" @clear="clearFilters">
-                <button
-                    v-if="isAuthenticated"
-                    v-show="savedSearchesRef?.hasActiveFilters"
-                    class="inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                    @click="savedSearchesRef?.open()"
-                >
-                    <Bookmark class="h-3.5 w-3.5" />
-                    {{ $t('savedSearch.saveButton') }}
-                </button>
+                <template #before-clear>
+                    <button
+                        v-if="isAuthenticated"
+                        v-show="savedSearchesRef?.hasActiveFilters"
+                        class="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
+                        @click="savedSearchesRef?.open()"
+                    >
+                        <Save class="h-3 w-3" />
+                        {{ $t('savedSearch.saveButton') }}
+                    </button>
+                </template>
             </FilterBar>
             <label class="mt-2 inline-flex items-center gap-2 text-xs text-muted-foreground select-none cursor-pointer">
                 <input
@@ -280,14 +276,6 @@ async function downloadCredits() {
                 <span class="flex items-center gap-1 text-[11px] text-muted-foreground">
                     <Sparkles class="h-3 w-3" /> {{ $t('credits.quickFilters') }}
                 </span>
-                <button
-                    v-for="preset in presets"
-                    :key="preset.label"
-                    class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                    @click="applyPreset({ filters: preset.filters })"
-                >
-                    {{ preset.label }}
-                </button>
 
                 <SavedSearchesRow
                     ref="savedSearchesRef"

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -252,7 +252,7 @@ async function downloadCredits() {
                     <button
                         v-if="isAuthenticated"
                         v-show="savedSearchesRef?.hasActiveFilters"
-                        class="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
+                        class="inline-flex items-center gap-1 rounded-md py-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
                         @click="savedSearchesRef?.open()"
                     >
                         <Save class="h-3 w-3" />

--- a/sustainable-explorer/frontend/pages/credits/index.vue
+++ b/sustainable-explorer/frontend/pages/credits/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { FileJson, Sparkles, Download, Loader2 } from 'lucide-vue-next';
+import { FileJson, Sparkles, Download, Loader2, Bookmark } from 'lucide-vue-next';
 import type { FilterOption } from '~/components/shared/FilterBar.vue';
 import { formatCredits } from '~/lib/format';
 import { naturalCompare } from '~/lib/utils';
 import { downloadCsv, csvDateStamp, buildCreditCsvRows } from '~/lib/csv-export';
+import type { SavedSearchCriteria } from '~/composables/useSavedSearches';
+import SavedSearchesRow from '~/components/saved-search/SavedSearchesRow.vue';
 
 const { t, locale } = useI18n();
 const { network } = useNetwork();
@@ -104,6 +106,39 @@ const filters = computed<FilterOption[]>(() => [
     { key: 'supply', label: t('credits.filters.supply'), type: 'numrange', options: [] },
     { key: 'mintDate', label: t('credits.filters.mintDate'), type: 'daterange', options: [] },
 ]);
+
+// Human-friendly rendering of a filter value for the Save Search dialog's
+// "Active Filters" summary. Range filters (supply, mintDate) are stored
+// pipe-joined ("min|max") per useFilteredPagination's convention — shown as "A – B".
+function formatFilterValue(value: string): string {
+    if (!value.includes('|')) return value;
+    const [from, to] = value.split('|');
+    if (from && to) return `${from} – ${to}`;
+    return from || to || value;
+}
+
+const filterSummary = computed(() => {
+    const items: { label: string; value: string }[] = [];
+    if (searchQuery.value.trim()) {
+        items.push({ label: t('common.search'), value: searchQuery.value.trim() });
+    }
+    items.push(
+        ...filters.value
+            .filter(f => activeFilters.value[f.key] && activeFilters.value[f.key] !== 'all')
+            .map(f => ({ label: f.label, value: formatFilterValue(activeFilters.value[f.key]) })),
+    );
+    return items;
+});
+
+// applyPreset()'s sort.key is typed against this page's specific row union;
+// a saved search's criteria.sort.key is a plain string (page-agnostic). Safe
+// at runtime — it was produced by this same page's own sortKey when saved.
+function applySavedSearch(criteria: SavedSearchCriteria) {
+    applyPreset(criteria as any);
+}
+
+const { isAuthenticated } = useAuth();
+const savedSearchesRef = ref<InstanceType<typeof SavedSearchesRow> | null>(null);
 
 const summaryStats = computed(() => {
     const f = filtered.value;
@@ -218,7 +253,17 @@ async function downloadCredits() {
         </div>
 
         <div class="px-6 pb-3">
-            <FilterBar v-model="searchQuery" :filters="filters" :active-filters="activeFilters" :result-count="filtered.length" :total-count="total" :search-placeholder="$t('credits.searchPlaceholder')" @filter="setFilter" @clear="clearFilters" />
+            <FilterBar v-model="searchQuery" :filters="filters" :active-filters="activeFilters" :result-count="filtered.length" :total-count="total" :search-placeholder="$t('credits.searchPlaceholder')" @filter="setFilter" @clear="clearFilters">
+                <button
+                    v-if="isAuthenticated"
+                    v-show="savedSearchesRef?.hasActiveFilters"
+                    class="inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                    @click="savedSearchesRef?.open()"
+                >
+                    <Bookmark class="h-3.5 w-3.5" />
+                    {{ $t('savedSearch.saveButton') }}
+                </button>
+            </FilterBar>
             <label class="mt-2 inline-flex items-center gap-2 text-xs text-muted-foreground select-none cursor-pointer">
                 <input
                     type="checkbox"
@@ -243,6 +288,18 @@ async function downloadCredits() {
                 >
                     {{ preset.label }}
                 </button>
+
+                <SavedSearchesRow
+                    ref="savedSearchesRef"
+                    section="issuances"
+                    :search-query="searchQuery"
+                    :active-filters="activeFilters"
+                    :sort-key="sortKey as string | null"
+                    :sort-dir="sortDir"
+                    :summary="filterSummary"
+                    @apply="applySavedSearch"
+                />
+
                 <button
                     :disabled="downloading"
                     class="ml-auto inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -1387,16 +1387,18 @@ function getResolvedField(fieldKey: string) {
                 {{ $t('methodologies.detail.decoded.fieldsTableTitle') }}
               </h2>
               <!-- Edit mapping controls — admin-only, when projectSchema and availableSchemas are present -->
-              <!-- TEMP: isAdmin check disabled for local testing — restore before committing -->
-              <template v-if="decodedData.projectSchema && decodedData.availableSchemas && decodedData.availableSchemas.length > 0">
+              <template
+                v-if="
+                  isAdmin &&
+                  decodedData.projectSchema &&
+                  decodedData.availableSchemas &&
+                  decodedData.availableSchemas.length > 0
+                "
+              >
                 <template v-if="!editingMapping">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    @click="enterEditMode"
-                  >
+                  <Button variant="outline" size="sm" @click="enterEditMode">
                     <Pencil class="h-3.5 w-3.5" />
-                    {{ $t('methodologies.detail.decoded.actions.editMapping') }}
+                    {{ $t("methodologies.detail.decoded.actions.editMapping") }}
                   </Button>
                 </template>
                 <template v-else>
@@ -1407,14 +1409,14 @@ function getResolvedField(fieldKey: string) {
                       :disabled="saveMappingPending"
                       @click="cancelEditMode"
                     >
-                      {{ $t('methodologies.detail.decoded.actions.cancel') }}
+                      {{ $t("methodologies.detail.decoded.actions.cancel") }}
                     </Button>
                     <Button
                       size="sm"
                       :disabled="saveMappingPending || !hasChanges"
                       @click="saveMapping"
                     >
-                      {{ $t('methodologies.detail.decoded.actions.save') }}
+                      {{ $t("methodologies.detail.decoded.actions.save") }}
                     </Button>
                   </div>
                 </template>

--- a/sustainable-explorer/frontend/pages/methodologies/[id].vue
+++ b/sustainable-explorer/frontend/pages/methodologies/[id].vue
@@ -1387,7 +1387,8 @@ function getResolvedField(fieldKey: string) {
                 {{ $t('methodologies.detail.decoded.fieldsTableTitle') }}
               </h2>
               <!-- Edit mapping controls — admin-only, when projectSchema and availableSchemas are present -->
-              <template v-if="isAdmin && decodedData.projectSchema && decodedData.availableSchemas && decodedData.availableSchemas.length > 0">
+              <!-- TEMP: isAdmin check disabled for local testing — restore before committing -->
+              <template v-if="decodedData.projectSchema && decodedData.availableSchemas && decodedData.availableSchemas.length > 0">
                 <template v-if="!editingMapping">
                   <Button
                     variant="outline"

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -9,7 +9,7 @@ import {
   Columns2,
   Download,
   Loader2,
-  Bookmark,
+  Save,
 } from "lucide-vue-next";
 import type { FilterOption } from "~/components/shared/FilterBar.vue";
 import { formatCredits } from "~/lib/format";
@@ -178,37 +178,6 @@ const {
   // navigating away and silently keep the list scoped after "Clear filter".
   excludeFromQuery: ["registryDid"],
 });
-
-const presets = computed(() => [
-  {
-    label: t("projects.presets.goldStandard"),
-    filters: { registry: "Gold Standard" } as Record<string, string>,
-  },
-  {
-    label: t("projects.presets.sdg13"),
-    filters: { sdgs: "13" } as Record<string, string>,
-  },
-  {
-    label: t("projects.presets.vintage2022"),
-    filters: { vintage: "2022|2022" } as Record<string, string>,
-  },
-  {
-    label: t("projects.presets.issuingEnergy"),
-    filters: { status: "Issuing", sector: "Energy" } as Record<string, string>,
-  },
-  {
-    label: t("projects.presets.glycolRecycling"),
-    filters: { sector: "Glycol Recycling" } as Record<string, string>,
-  },
-]);
-
-function isPresetActive(preset: { filters: Record<string, string> }): boolean {
-  const af = activeFilters.value;
-  const entries = Object.entries(preset.filters);
-  return (
-    entries.length > 0 && entries.every(([key, value]) => af[key] === value)
-  );
-}
 
 // applyPreset()'s sort.key is typed against this page's specific row union
 // (keyof the mapped project row), while a saved search's criteria.sort.key is
@@ -447,15 +416,17 @@ async function downloadProjects() {
         @filter="setFilter"
         @clear="clearFilters"
       >
-        <button
-          v-if="isAuthenticated"
-          v-show="savedSearchesRef?.hasActiveFilters"
-          class="inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-          @click="savedSearchesRef?.open()"
-        >
-          <Bookmark class="h-3.5 w-3.5" />
-          {{ $t("savedSearch.saveButton") }}
-        </button>
+        <template #before-clear>
+          <button
+            v-if="isAuthenticated"
+            v-show="savedSearchesRef?.hasActiveFilters"
+            class="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
+            @click="savedSearchesRef?.open()"
+          >
+            <Save class="h-3 w-3" />
+            {{ $t("savedSearch.saveButton") }}
+          </button>
+        </template>
       </FilterBar>
 
       <!-- Preset Templates -->
@@ -463,19 +434,6 @@ async function downloadProjects() {
         <span class="flex items-center gap-1 text-[11px] text-muted-foreground">
           <Sparkles class="h-3 w-3" /> {{ $t("projects.quickFilters") }}
         </span>
-        <button
-          v-for="preset in presets"
-          :key="preset.label"
-          :class="[
-            'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors',
-            isPresetActive(preset)
-              ? 'border-primary/50 bg-primary/10 text-primary'
-              : 'border-primary/25 text-muted-foreground hover:bg-muted hover:text-foreground',
-          ]"
-          @click="applyPreset({ filters: preset.filters })"
-        >
-          {{ preset.label }}
-        </button>
 
         <SavedSearchesRow
           ref="savedSearchesRef"

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -420,7 +420,7 @@ async function downloadProjects() {
           <button
             v-if="isAuthenticated"
             v-show="savedSearchesRef?.hasActiveFilters"
-            class="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
+            class="inline-flex items-center gap-1 rounded-md py-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
             @click="savedSearchesRef?.open()"
           >
             <Save class="h-3 w-3" />

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -417,15 +417,24 @@ async function downloadProjects() {
         @clear="clearFilters"
       >
         <template #before-clear>
-          <button
+          <InfoTooltip
             v-if="isAuthenticated"
             v-show="savedSearchesRef?.hasActiveFilters"
-            class="inline-flex items-center gap-1 rounded-md py-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
-            @click="savedSearchesRef?.open()"
+            :text="savedSearchesRef?.atLimit ? $t('savedSearch.limitReachedTooltip', { max: savedSearchesRef?.limit }) : ''"
           >
-            <Save class="h-3 w-3" />
-            {{ $t("savedSearch.saveButton") }}
-          </button>
+            <button
+              :class="[
+                'inline-flex items-center gap-1 rounded-md py-1.5 text-xs transition-colors',
+                savedSearchesRef?.atLimit
+                  ? 'text-muted-foreground/50 cursor-not-allowed'
+                  : 'text-muted-foreground hover:text-primary',
+              ]"
+              @click="!savedSearchesRef?.atLimit && savedSearchesRef?.open()"
+            >
+              <Save class="h-3 w-3" />
+              {{ $t("savedSearch.saveButton") }}
+            </button>
+          </InfoTooltip>
         </template>
       </FilterBar>
 

--- a/sustainable-explorer/frontend/pages/projects/index.vue
+++ b/sustainable-explorer/frontend/pages/projects/index.vue
@@ -9,6 +9,7 @@ import {
   Columns2,
   Download,
   Loader2,
+  Bookmark,
 } from "lucide-vue-next";
 import type { FilterOption } from "~/components/shared/FilterBar.vue";
 import { formatCredits } from "~/lib/format";
@@ -24,6 +25,8 @@ import {
   buildProjectCsvRows,
 } from "~/lib/csv-export";
 import { mapApiProject } from "~/composables/useProjects";
+import type { SavedSearchCriteria } from "~/composables/useSavedSearches";
+import SavedSearchesRow from "~/components/saved-search/SavedSearchesRow.vue";
 
 const { t } = useI18n();
 const { network } = useNetwork();
@@ -207,6 +210,19 @@ function isPresetActive(preset: { filters: Record<string, string> }): boolean {
   );
 }
 
+// applyPreset()'s sort.key is typed against this page's specific row union
+// (keyof the mapped project row), while a saved search's criteria.sort.key is
+// a plain string (saved searches are page-agnostic). The value is guaranteed
+// valid at runtime — it was produced by this same page's own sortKey when the
+// search was saved — so the cast here is safe, matching the `sortKey as
+// string | null` cast already used elsewhere in this file's template.
+function applySavedSearch(criteria: SavedSearchCriteria) {
+  applyPreset(criteria as any);
+}
+
+const { isAuthenticated } = useAuth();
+const savedSearchesRef = ref<InstanceType<typeof SavedSearchesRow> | null>(null);
+
 // Summary statistics for filtered results
 const summaryStats = computed(() => {
   const f = filtered.value;
@@ -282,6 +298,34 @@ const filters = computed<FilterOption[]>(() => [
     })),
   },
 ]);
+
+// Human-friendly rendering of a filter value for the Save Search dialog's
+// "Active Filters" summary. Range filters (vintage) are stored pipe-joined
+// ("2022|2022") per useFilteredPagination's convention — shown as "A – B".
+function formatFilterValue(value: string): string {
+  if (!value.includes("|")) return value;
+  const [from, to] = value.split("|");
+  if (from && to) return `${from} – ${to}`;
+  return from || to || value;
+}
+
+const filterSummary = computed(() => {
+  const items: { label: string; value: string }[] = [];
+  if (searchQuery.value.trim()) {
+    items.push({ label: t("common.search"), value: searchQuery.value.trim() });
+  }
+  items.push(
+    ...filters.value
+      .filter(
+        (f) => activeFilters.value[f.key] && activeFilters.value[f.key] !== "all",
+      )
+      .map((f) => ({
+        label: f.label,
+        value: formatFilterValue(activeFilters.value[f.key]),
+      })),
+  );
+  return items;
+});
 
 const statusColor: Record<string, string> = {
   Registered: "bg-slate-100 text-slate-600",
@@ -402,7 +446,17 @@ async function downloadProjects() {
         :search-placeholder="$t('projects.searchPlaceholder')"
         @filter="setFilter"
         @clear="clearFilters"
-      />
+      >
+        <button
+          v-if="isAuthenticated"
+          v-show="savedSearchesRef?.hasActiveFilters"
+          class="inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          @click="savedSearchesRef?.open()"
+        >
+          <Bookmark class="h-3.5 w-3.5" />
+          {{ $t("savedSearch.saveButton") }}
+        </button>
+      </FilterBar>
 
       <!-- Preset Templates -->
       <div class="flex items-center gap-2 mt-2.5 flex-wrap">
@@ -422,6 +476,18 @@ async function downloadProjects() {
         >
           {{ preset.label }}
         </button>
+
+        <SavedSearchesRow
+          ref="savedSearchesRef"
+          section="projects"
+          :search-query="searchQuery"
+          :active-filters="activeFilters"
+          :sort-key="sortKey as string | null"
+          :sort-dir="sortDir"
+          :summary="filterSummary"
+          @apply="applySavedSearch"
+        />
+
         <button
           :disabled="downloading"
           class="ml-auto inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/sustainable-explorer/src/api/account/account.module.ts
+++ b/sustainable-explorer/src/api/account/account.module.ts
@@ -7,10 +7,13 @@ import { RateLimitRequestService } from './rate-limit-request.service';
 import { DashboardPreferencesController } from './dashboard-preferences.controller';
 import { DashboardPreferencesService } from './dashboard-preferences.service';
 import { DashboardPreferencesRepository } from './dashboard-preferences.repository';
+import { QuickFiltersController } from './quick-filters.controller';
+import { QuickFiltersService } from './quick-filters.service';
+import { QuickFiltersRepository } from './quick-filters.repository';
 
 /**
- * Account module — authenticated user self-service (API keys today; saved
- * dashboards / quick filters / rate-limit requests in later phases).
+ * Account module — authenticated user self-service (API keys, saved
+ * dashboards, saved searches / quick filters, rate-limit requests).
  *
  * Imports AuthModule for the guards (JwtAuthGuard, CsrfGuard). SystemDataSource
  * is injected from the @Global SystemDatabaseModule; ConfigService is global.
@@ -20,7 +23,19 @@ import { DashboardPreferencesRepository } from './dashboard-preferences.reposito
  */
 @Module({
     imports: [AuthModule],
-    controllers: [AccountController, RateLimitRequestController, DashboardPreferencesController],
-    providers: [ApiKeyService, RateLimitRequestService, DashboardPreferencesService, DashboardPreferencesRepository],
+    controllers: [
+        AccountController,
+        RateLimitRequestController,
+        DashboardPreferencesController,
+        QuickFiltersController,
+    ],
+    providers: [
+        ApiKeyService,
+        RateLimitRequestService,
+        DashboardPreferencesService,
+        DashboardPreferencesRepository,
+        QuickFiltersService,
+        QuickFiltersRepository,
+    ],
 })
 export class AccountModule {}

--- a/sustainable-explorer/src/api/account/dto/create-quick-filter.dto.ts
+++ b/sustainable-explorer/src/api/account/dto/create-quick-filter.dto.ts
@@ -1,0 +1,22 @@
+import { IsIn, IsNotEmpty, IsObject, IsString, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import type { QuickFilterCriteria } from './quick-filter-criteria.type';
+
+export class CreateQuickFilterDto {
+    @ApiProperty({ enum: ['mainnet', 'testnet'] })
+    @IsIn(['mainnet', 'testnet'])
+    network: string;
+
+    @ApiProperty({ enum: ['projects', 'methodologies', 'issuances'] })
+    @IsIn(['projects', 'methodologies', 'issuances'])
+    section: 'projects' | 'methodologies' | 'issuances';
+
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(30)
+    name: string;
+
+    @IsObject()
+    @IsNotEmpty()
+    criteria: QuickFilterCriteria;
+}

--- a/sustainable-explorer/src/api/account/dto/list-quick-filters-query.dto.ts
+++ b/sustainable-explorer/src/api/account/dto/list-quick-filters-query.dto.ts
@@ -1,0 +1,12 @@
+import { IsIn } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ListQuickFiltersQueryDto {
+    @ApiProperty({ enum: ['mainnet', 'testnet'] })
+    @IsIn(['mainnet', 'testnet'])
+    network: string;
+
+    @ApiProperty({ enum: ['projects', 'methodologies', 'issuances'] })
+    @IsIn(['projects', 'methodologies', 'issuances'])
+    section: 'projects' | 'methodologies' | 'issuances';
+}

--- a/sustainable-explorer/src/api/account/dto/quick-filter-criteria.type.ts
+++ b/sustainable-explorer/src/api/account/dto/quick-filter-criteria.type.ts
@@ -1,0 +1,5 @@
+export interface QuickFilterCriteria {
+    search?: string;
+    filters: Record<string, string>;
+    sort?: { key: string; dir: 'asc' | 'desc' };
+}

--- a/sustainable-explorer/src/api/account/quick-filters.controller.ts
+++ b/sustainable-explorer/src/api/account/quick-filters.controller.ts
@@ -1,0 +1,50 @@
+import {
+    Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards,
+} from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CsrfGuard } from '../auth/guards/csrf.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { QuickFiltersService } from './quick-filters.service';
+import { ListQuickFiltersQueryDto } from './dto/list-quick-filters-query.dto';
+import { CreateQuickFilterDto } from './dto/create-quick-filter.dto';
+
+@ApiTags('account')
+@ApiCookieAuth()
+@Controller('api/v1/me/quick-filters')
+@UseGuards(JwtAuthGuard)
+export class QuickFiltersController {
+    constructor(private readonly service: QuickFiltersService) {}
+
+    @Get()
+    @ApiOperation({ summary: 'List saved searches for a network + table section' })
+    async list(
+        @Query() query: ListQuickFiltersQueryDto,
+        @CurrentUser() user: AuthenticatedUser,
+    ) {
+        return this.service.list(user.id, query.network, query.section);
+    }
+
+    @Post()
+    @UseGuards(CsrfGuard)
+    @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({ summary: 'Save the current filter combination as a named search' })
+    async create(
+        @Body() dto: CreateQuickFilterDto,
+        @CurrentUser() user: AuthenticatedUser,
+    ) {
+        return this.service.create(user.id, dto.network, dto.section, dto.name, dto.criteria);
+    }
+
+    @Delete(':id')
+    @UseGuards(CsrfGuard)
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Delete a saved search' })
+    async remove(
+        @Param('id') id: string,
+        @CurrentUser() user: AuthenticatedUser,
+    ): Promise<void> {
+        await this.service.remove(id, user.id);
+    }
+}

--- a/sustainable-explorer/src/api/account/quick-filters.repository.ts
+++ b/sustainable-explorer/src/api/account/quick-filters.repository.ts
@@ -24,6 +24,17 @@ export class QuickFiltersRepository {
         );
     }
 
+    /** Single indexed COUNT — used to enforce the per-user saved-search cap. */
+    async count(userId: string, network: string, section: string): Promise<number> {
+        const rows = await this.systemDataSource.getDataSource().query<{ c: number }[]>(
+            `SELECT count(*)::int AS c
+               FROM quick_filters
+              WHERE "userId" = $1 AND network = $2 AND section = $3`,
+            [userId, network, section],
+        );
+        return rows[0]?.c ?? 0;
+    }
+
     async create(
         userId: string,
         network: string,

--- a/sustainable-explorer/src/api/account/quick-filters.repository.ts
+++ b/sustainable-explorer/src/api/account/quick-filters.repository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { SystemDataSource, returningRows } from '@api/database/system-database.module';
+import type { QuickFilterCriteria } from './dto/quick-filter-criteria.type';
+
+export interface QuickFilterRow {
+    id: string;
+    name: string;
+    criteria: QuickFilterCriteria;
+    createdAt: Date;
+}
+
+@Injectable()
+export class QuickFiltersRepository {
+    constructor(private readonly systemDataSource: SystemDataSource) {}
+
+    /** Single indexed query — all saved searches for a user+network+section. */
+    async findAll(userId: string, network: string, section: string): Promise<QuickFilterRow[]> {
+        return this.systemDataSource.getDataSource().query<QuickFilterRow[]>(
+            `SELECT id, name, criteria, "createdAt"
+               FROM quick_filters
+              WHERE "userId" = $1 AND network = $2 AND section = $3
+              ORDER BY "createdAt" ASC`,
+            [userId, network, section],
+        );
+    }
+
+    async create(
+        userId: string,
+        network: string,
+        section: string,
+        name: string,
+        criteria: QuickFilterCriteria,
+    ): Promise<QuickFilterRow> {
+        const result = await this.systemDataSource.getDataSource().query(
+            `INSERT INTO quick_filters ("userId", network, section, name, criteria)
+             VALUES ($1, $2, $3, $4, $5::jsonb)
+             RETURNING id, name, criteria, "createdAt"`,
+            [userId, network, section, name, JSON.stringify(criteria)],
+        );
+        return returningRows<QuickFilterRow>(result)[0];
+    }
+
+    /** Ownership enforced inline — deletes 0 rows (silently) if not owned by userId. */
+    async delete(id: string, userId: string): Promise<number> {
+        const result = await this.systemDataSource.getDataSource().query(
+            `DELETE FROM quick_filters WHERE id = $1 AND "userId" = $2`,
+            [id, userId],
+        );
+        return result[1] ?? 0;
+    }
+}

--- a/sustainable-explorer/src/api/account/quick-filters.service.ts
+++ b/sustainable-explorer/src/api/account/quick-filters.service.ts
@@ -1,0 +1,43 @@
+import { ConflictException, Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { QuickFiltersRepository, QuickFilterRow } from './quick-filters.repository';
+import type { QuickFilterCriteria } from './dto/quick-filter-criteria.type';
+
+const POSTGRES_UNIQUE_VIOLATION = '23505';
+
+@Injectable()
+export class QuickFiltersService {
+    constructor(private readonly repo: QuickFiltersRepository) {}
+
+    async list(userId: string, network: string, section: string): Promise<QuickFilterRow[]> {
+        return this.repo.findAll(userId, network, section);
+    }
+
+    async create(
+        userId: string,
+        network: string,
+        section: string,
+        name: string,
+        criteria: QuickFilterCriteria,
+    ): Promise<QuickFilterRow> {
+        const hasSearch = !!criteria.search?.trim();
+        const hasFilters = criteria.filters && Object.keys(criteria.filters).length > 0;
+        if (!hasSearch && !hasFilters) {
+            throw new UnprocessableEntityException('Cannot save a search with no active filters');
+        }
+
+        try {
+            return await this.repo.create(userId, network, section, name.trim(), criteria);
+        } catch (err: unknown) {
+            const code = (err as { code?: string })?.code;
+            if (code === POSTGRES_UNIQUE_VIOLATION) {
+                throw new ConflictException('A saved search with this name already exists');
+            }
+            throw err;
+        }
+    }
+
+    async remove(id: string, userId: string): Promise<void> {
+        const affected = await this.repo.delete(id, userId);
+        if (affected === 0) throw new NotFoundException('Saved search not found');
+    }
+}

--- a/sustainable-explorer/src/api/account/quick-filters.service.ts
+++ b/sustainable-explorer/src/api/account/quick-filters.service.ts
@@ -1,4 +1,5 @@
 import { ConflictException, Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { QuickFiltersRepository, QuickFilterRow } from './quick-filters.repository';
 import type { QuickFilterCriteria } from './dto/quick-filter-criteria.type';
 
@@ -6,10 +7,22 @@ const POSTGRES_UNIQUE_VIOLATION = '23505';
 
 @Injectable()
 export class QuickFiltersService {
-    constructor(private readonly repo: QuickFiltersRepository) {}
+    constructor(
+        private readonly repo: QuickFiltersRepository,
+        private readonly config: ConfigService,
+    ) {}
 
-    async list(userId: string, network: string, section: string): Promise<QuickFilterRow[]> {
-        return this.repo.findAll(userId, network, section);
+    private maxPerUser(): number {
+        return this.config.get<number>('app.quickFilters.maxPerUser') ?? 10;
+    }
+
+    async list(
+        userId: string,
+        network: string,
+        section: string,
+    ): Promise<{ items: QuickFilterRow[]; limit: number }> {
+        const items = await this.repo.findAll(userId, network, section);
+        return { items, limit: this.maxPerUser() };
     }
 
     async create(
@@ -23,6 +36,14 @@ export class QuickFiltersService {
         const hasFilters = criteria.filters && Object.keys(criteria.filters).length > 0;
         if (!hasSearch && !hasFilters) {
             throw new UnprocessableEntityException('Cannot save a search with no active filters');
+        }
+
+        // Defense-in-depth: the frontend disables the Save Search button once
+        // at the limit, so this should only ever fire via direct API use.
+        const max = this.maxPerUser();
+        const existing = await this.repo.count(userId, network, section);
+        if (existing >= max) {
+            throw new ConflictException(`Saved search limit reached (maximum ${max}).`);
         }
 
         try {

--- a/sustainable-explorer/src/shared/config/configuration.ts
+++ b/sustainable-explorer/src/shared/config/configuration.ts
@@ -233,6 +233,15 @@ export default registerAs('app', () => {
             guestPerHour: parseInt(process.env.RATE_LIMIT_GUEST_PER_HOUR || '600', 10),
         },
 
+        // Saved searches (quick_filters). Scoped per user+network+section (NOT
+        // global per-user like rateLimit above), matching how the feature is
+        // scoped everywhere else.
+        quickFilters: {
+            // Max saved searches a single user may hold per network+section
+            // (default 10); enforced with a count pre-check at creation.
+            maxPerUser: parseInt(process.env.QUICK_FILTERS_MAX_PER_USER || '10', 10),
+        },
+
         // Initial admin — break-glass admin seeded on first boot. MUST be set via
         // environment / secret manager; do NOT commit real values.
         initialAdmin: {

--- a/sustainable-explorer/src/shared/database/schema-bootstrap.ts
+++ b/sustainable-explorer/src/shared/database/schema-bootstrap.ts
@@ -423,6 +423,11 @@ export async function bootstrapSystemSchema(dataSource: DataSource): Promise<voi
     await dataSource.query(
         `CREATE INDEX IF NOT EXISTS "IDX_quick_filters_userId" ON "quick_filters" ("userId")`,
     );
+    // Prevents duplicate saved-search names (case-insensitive) per user/network/section.
+    await dataSource.query(
+        `CREATE UNIQUE INDEX IF NOT EXISTS "UQ_quick_filters_user_network_section_name"
+            ON "quick_filters" ("userId", "network", "section", lower("name"))`,
+    );
 
     // audit_log: per-actor timeline + global recent-events.
     await dataSource.query(


### PR DESCRIPTION
### https://xeptagon.atlassian.net/browse/SE-111

DTR

<img width="1611" height="403" alt="image" src="https://github.com/user-attachments/assets/3a3af1cf-6721-490d-8de0-4fb6e42db759" />

<img width="1608" height="753" alt="Screenshot 2026-07-06 162826" src="https://github.com/user-attachments/assets/958feffc-3bfb-410a-86de-e28d07b9ea91" />
<img width="1612" height="507" alt="Screenshot 2026-07-06 162907" src="https://github.com/user-attachments/assets/10ab6e24-6a07-4af8-b980-d6a3a0e5b429" />

`__`

Summary of changes

Logged-in users can now save their current filter + search combination on the Projects and Issuances tables as a named "Saved Search."

A "Save Search" button (styled like the existing Download Data button) sits in the same row as the search box, only visible once at least one filter is active, and is completely hidden for guests.

Saved searches appear as dismissible tags under the Quick Filters row; clicking one reapplies all its filters/sort and visually marks it as active. Deleting a tag only removes it from the list — it doesn't change whatever filters are currently applied.

Duplicate protection, two layers:

Saving under a name that's already used is rejected with an error.

Saving the exact same set of filters as an already-saved search (even under a new name) now shows a warning naming the existing saved search instead of letting a redundant copy be created.

Fixed the "Active Filters" summary shown in the save dialog to also include the free-text search box value, not just dropdown filters (it previously showed nothing if only the text search was used).

Built as a generic, reusable piece so the same mechanism can be dropped onto any other filterable table later (e.g. Methodologies), not just Projects/Issuances.

New endpoint

One new authenticated endpoint group: _/api/v1/me/quick-filters_ (GET list, POST create, DELETE /:id), protected by the existing login + CSRF guards.